### PR TITLE
Updated `NOTICE` to include dependent projects and their licenses 

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,38 @@
+Copyright (2024) Databricks, Inc.
+
+This software includes software developed at Databricks (https://www.databricks.com/) and its use is subject to the included LICENSE file.
+
+This software contains code from the following open source projects, licensed under the MIT license:
+
+SQL Glot - https://github.com/tobymao/sqlglot
+Copyright 2023 Toby Mao
+License - https://github.com/tobymao/sqlglot/blob/main/LICENSE
+
+This software contains code from the following open source projects, licensed under the Apache 2.0 license:
+
+DataComPy - https://github.com/capitalone/datacompy
+Copyright 2018 Capital One Services, LLC
+License - https://github.com/capitalone/datacompy/blob/develop/LICENSE
+
+Apache Spark - https://github.com/apache/spark
+Copyright 2018 The Apache Software Foundation 
+License - https://github.com/apache/spark/blob/master/LICENSE
+
+Databricks SDK for Python - https://github.com/databricks/databricks-sdk-py
+Copyright 2023 Databricks, Inc.  All rights reserved.
+License - https://github.com/databricks/databricks-sdk-py/blob/main/LICENSE
+
+This software contains code from the following open source projects, licensed under the BSD license:
+
+ANTLR v4 - https://github.com/antlr/antlr4
+Copyright (c) 2012-2022 The ANTLR Project. All rights reserved. 
+https://github.com/antlr/antlr4/blob/dev/LICENSE.txt
+
+This software contains code from the following publicly available projects, licensed under the Databricks license:
+
+Databricks Labs Blueprint - https://github.com/databrickslabs/blueprint
+Copyright (2023) Databricks, Inc. 
+https://github.com/databrickslabs/blueprint/blob/main/LICENSE
+
+Databricks Connect - https://pypi.org/project/databricks-connect/
+Coopyright (2019) Databricks Inc. 


### PR DESCRIPTION
Added a `NOTICE` file that describes all of remorph's relevant dependencies and licenses. 