### PR TITLE
Patch Logger function call during wheel file

### DIFF
--- a/src/databricks/labs/remorph/__about__.py
+++ b/src/databricks/labs/remorph/__about__.py
@@ -1,1 +1,2 @@
+# DO NOT MODIFY THIS FILE
 __version__ = "0.1.2"

--- a/src/databricks/labs/remorph/__init__.py
+++ b/src/databricks/labs/remorph/__init__.py
@@ -1,4 +1,3 @@
 from databricks.labs.blueprint.logger import install_logger
 
 install_logger()
-

--- a/src/databricks/labs/remorph/__init__.py
+++ b/src/databricks/labs/remorph/__init__.py
@@ -1,1 +1,4 @@
+from databricks.labs.blueprint.logger import install_logger
+
+install_logger()
 

--- a/src/databricks/labs/remorph/helpers/execution_time.py
+++ b/src/databricks/labs/remorph/helpers/execution_time.py
@@ -1,8 +1,7 @@
 import inspect
+import logging
 import time
 from functools import wraps
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/src/databricks/labs/remorph/helpers/execution_time.py
+++ b/src/databricks/labs/remorph/helpers/execution_time.py
@@ -2,9 +2,9 @@ import inspect
 import time
 from functools import wraps
 
-from databricks.labs.blueprint.entrypoint import get_logger
+import logging
 
-logger = get_logger(__file__)
+logger = logging.getLogger(__name__)
 
 
 def timeit(func):

--- a/src/databricks/labs/remorph/helpers/validate.py
+++ b/src/databricks/labs/remorph/helpers/validate.py
@@ -1,3 +1,4 @@
+import logging
 from io import StringIO
 
 from databricks.connect import DatabricksSession
@@ -5,8 +6,6 @@ from databricks.sdk.core import Config
 from pyspark.sql.utils import AnalysisException, ParseException
 
 from databricks.labs.remorph.config import MorphConfig
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/src/databricks/labs/remorph/helpers/validate.py
+++ b/src/databricks/labs/remorph/helpers/validate.py
@@ -1,13 +1,14 @@
 from io import StringIO
 
 from databricks.connect import DatabricksSession
-from databricks.labs.blueprint.entrypoint import get_logger
 from databricks.sdk.core import Config
 from pyspark.sql.utils import AnalysisException, ParseException
 
 from databricks.labs.remorph.config import MorphConfig
 
-logger = get_logger(__file__)
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Validate:

--- a/src/databricks/labs/remorph/reconcile/execute.py
+++ b/src/databricks/labs/remorph/reconcile/execute.py
@@ -1,8 +1,10 @@
-from databricks.labs.blueprint.entrypoint import get_logger
+
 
 from databricks.labs.remorph.helpers.execution_time import timeit
 
-logger = get_logger(__file__)
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @timeit

--- a/src/databricks/labs/remorph/reconcile/execute.py
+++ b/src/databricks/labs/remorph/reconcile/execute.py
@@ -1,8 +1,6 @@
-
+import logging
 
 from databricks.labs.remorph.helpers.execution_time import timeit
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/src/databricks/labs/remorph/snow/databricks.py
+++ b/src/databricks/labs/remorph/snow/databricks.py
@@ -1,7 +1,7 @@
 import re
 from typing import ClassVar
 
-from databricks.labs.blueprint.entrypoint import get_logger
+
 from sqlglot import expressions as exp
 from sqlglot.dialects import hive
 from sqlglot.dialects.databricks import Databricks
@@ -11,7 +11,9 @@ from sqlglot.helper import apply_index_offset, csv
 
 from databricks.labs.remorph.snow import local_expression
 
-logger = get_logger(__file__)
+import logging
+
+logger = logging.getLogger(__name__)
 
 VALID_DATABRICKS_TYPES = {
     "BIGINT",

--- a/src/databricks/labs/remorph/snow/databricks.py
+++ b/src/databricks/labs/remorph/snow/databricks.py
@@ -1,6 +1,6 @@
+import logging
 import re
 from typing import ClassVar
-
 
 from sqlglot import expressions as exp
 from sqlglot.dialects import hive
@@ -10,8 +10,6 @@ from sqlglot.errors import UnsupportedError
 from sqlglot.helper import apply_index_offset, csv
 
 from databricks.labs.remorph.snow import local_expression
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/src/databricks/labs/remorph/snow/dialect_utils.py
+++ b/src/databricks/labs/remorph/snow/dialect_utils.py
@@ -1,10 +1,10 @@
+import logging
+
 from sqlglot import ErrorLevel, exp, parse
 from sqlglot.expressions import Expression, Select
 
 from databricks.labs.remorph.helpers.morph_status import ValidationError
 from databricks.labs.remorph.snow.snowflake import Snow
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/src/databricks/labs/remorph/snow/dialect_utils.py
+++ b/src/databricks/labs/remorph/snow/dialect_utils.py
@@ -1,11 +1,12 @@
-from databricks.labs.blueprint.entrypoint import get_logger
 from sqlglot import ErrorLevel, exp, parse
 from sqlglot.expressions import Expression, Select
 
 from databricks.labs.remorph.helpers.morph_status import ValidationError
 from databricks.labs.remorph.snow.snowflake import Snow
 
-logger = get_logger(__file__)
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def find_windows_in_select(select: Select) -> list[exp.Window]:

--- a/src/databricks/labs/remorph/snow/snowflake.py
+++ b/src/databricks/labs/remorph/snow/snowflake.py
@@ -3,7 +3,6 @@ import re
 import typing as t
 from typing import ClassVar
 
-from databricks.labs.blueprint.entrypoint import get_logger
 from sqlglot import exp, parser
 from sqlglot.dialects.dialect import parse_date_delta
 from sqlglot.dialects.snowflake import Snowflake
@@ -15,7 +14,9 @@ from sqlglot.trie import new_trie
 
 from databricks.labs.remorph.snow import local_expression
 
-logger = get_logger(__file__)
+import logging
+
+logger = logging.getLogger(__name__)
 
 """ SF Supported Date and Time Parts:
     https://docs.snowflake.com/en/sql-reference/functions-date-time#label-supported-date-time-parts

--- a/src/databricks/labs/remorph/snow/snowflake.py
+++ b/src/databricks/labs/remorph/snow/snowflake.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import re
 import typing as t
 from typing import ClassVar
@@ -13,8 +14,6 @@ from sqlglot.tokens import Token, TokenType
 from sqlglot.trie import new_trie
 
 from databricks.labs.remorph.snow import local_expression
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -13,8 +14,6 @@ from databricks.labs.remorph.helpers.morph_status import MorphStatus, Validation
 from databricks.labs.remorph.helpers.validate import Validate
 from databricks.labs.remorph.snow import dialect_utils
 from databricks.labs.remorph.snow.sql_transpiler import SQLTranspiler
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -1,8 +1,6 @@
 import os
 from pathlib import Path
 
-from databricks.labs.blueprint.entrypoint import get_logger
-
 from databricks.labs.remorph.config import MorphConfig
 from databricks.labs.remorph.helpers.execution_time import timeit
 from databricks.labs.remorph.helpers.file_utils import (
@@ -16,7 +14,9 @@ from databricks.labs.remorph.helpers.validate import Validate
 from databricks.labs.remorph.snow import dialect_utils
 from databricks.labs.remorph.snow.sql_transpiler import SQLTranspiler
 
-logger = get_logger(__file__)
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def process_file(config: MorphConfig, input_file: str | Path, output_file: str | Path):


### PR DESCRIPTION
refactor logger to make only cli use `get_logger` from blueprint

closes #127 