### PR TITLE
Prevent adding `# pylint: disable` comments without explicit approval

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -64,6 +64,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Verify no lint disabled in the new code
         run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,3 +58,9 @@ jobs:
 
       - name: Verify linting
         run: hatch run verify
+
+  no-disable-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -72,7 +72,8 @@ jobs:
           NEW_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^+')
           CHEAT=$(echo "${NEW_CODE}" | grep '# pylint: disable')
           echo "CHEAT: ${CHEAT}\n"
-          if ["${CHEAT}" -neq ""]; then
-            echo "Do not cheat the linter:\n${CHEAT}"
+          # check if $CHEAT is not empty
+          if [ -n "${CHEAT}" ]; then
+            echo "Do not cheat the linter:\n ${CHEAT}"
             exit 1
           fi

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           NEW_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^+')
           echo "NEW_CODE: ${NEW_CODE}\n"
-          CHEAT=$(echo $NEW_CODE | grep '# pylint: disable')
+          CHEAT=$(echo "${NEW_CODE}" | grep '# pylint: disable')
           echo "CHEAT: ${CHEAT}\n"
           if "${CHEAT}"; then
             echo "Do not cheat the linter:\n${CHEAT}"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -59,8 +59,17 @@ jobs:
       - name: Verify linting
         run: hatch run verify
 
-  no-disable-lint:
+  no-lint-disabled:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Verify no lint disabled in the new code
+        run: |
+          NEW_CODE=$(git diff main..HEAD | grep -e '^+')
+          CHEAT=$(echo $NEW_CODE | grep '# pylint: disable')
+          if $CHEAT; then
+            echo "Do not cheat the linter:\n${CHEAT}"
+            exit 1
+          fi

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -71,9 +71,7 @@ jobs:
         run: |
           NEW_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^+')
           CHEAT=$(echo "${NEW_CODE}" | grep '# pylint: disable')
-          echo "CHEAT: ${CHEAT}\n"
-          # check if $CHEAT is not empty
           if [ -n "${CHEAT}" ]; then
-            echo "Do not cheat the linter:\n ${CHEAT}"
+            echo "Do not cheat the linter: ${CHEAT}"
             exit 1
           fi

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -70,10 +70,9 @@ jobs:
       - name: Verify no lint disabled in the new code
         run: |
           NEW_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^+')
-          echo "NEW_CODE: ${NEW_CODE}\n"
           CHEAT=$(echo "${NEW_CODE}" | grep '# pylint: disable')
           echo "CHEAT: ${CHEAT}\n"
-          if "${CHEAT}"; then
+          if ["${CHEAT}" -neq ""]; then
             echo "Do not cheat the linter:\n${CHEAT}"
             exit 1
           fi

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -71,7 +71,8 @@ jobs:
         run: |
           NEW_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^+')
           CHEAT=$(echo $NEW_CODE | grep '# pylint: disable')
-          if $CHEAT; then
+          echo $CHEAT
+          if "${CHEAT}"; then
             echo "Do not cheat the linter:\n${CHEAT}"
             exit 1
           fi

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -70,8 +70,9 @@ jobs:
       - name: Verify no lint disabled in the new code
         run: |
           NEW_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^+')
+          echo "NEW_CODE: ${NEW_CODE}\n"
           CHEAT=$(echo $NEW_CODE | grep '# pylint: disable')
-          echo $CHEAT
+          echo "CHEAT: ${CHEAT}\n"
           if "${CHEAT}"; then
             echo "Do not cheat the linter:\n${CHEAT}"
             exit 1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -67,7 +67,8 @@ jobs:
 
       - name: Verify no lint disabled in the new code
         run: |
-          NEW_CODE=$(git diff main..HEAD | grep -e '^+')
+          GIT_COMMIT=$(git log -1 --format='%H')
+          NEW_CODE=$(git diff main..${GIT_COMMIT} | grep -e '^+')
           CHEAT=$(echo $NEW_CODE | grep '# pylint: disable')
           if $CHEAT; then
             echo "Do not cheat the linter:\n${CHEAT}"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -67,8 +67,7 @@ jobs:
 
       - name: Verify no lint disabled in the new code
         run: |
-          GIT_COMMIT=$(git log -1 --format='%H')
-          NEW_CODE=$(git diff main..${GIT_COMMIT} | grep -e '^+')
+          NEW_CODE=$(git diff ${GITHUB_BASE_REF}..${GITHUB_REF} | grep -e '^+')
           CHEAT=$(echo $NEW_CODE | grep '# pylint: disable')
           if $CHEAT; then
             echo "Do not cheat the linter:\n${CHEAT}"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Verify no lint disabled in the new code
         run: |
-          NEW_CODE=$(git diff ${GITHUB_BASE_REF}..${GITHUB_REF} | grep -e '^+')
+          NEW_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^+')
           CHEAT=$(echo $NEW_CODE | grep '# pylint: disable')
           if $CHEAT; then
             echo "Do not cheat the linter:\n${CHEAT}"

--- a/src/databricks/labs/remorph/config.py
+++ b/src/databricks/labs/remorph/config.py
@@ -5,7 +5,6 @@ from databricks.sdk.core import Config
 
 logger = logging.getLogger(__name__)
 
-# pylint: disable=too-few-public-methods
 
 @dataclass
 class MorphConfig:

--- a/src/databricks/labs/remorph/config.py
+++ b/src/databricks/labs/remorph/config.py
@@ -5,6 +5,7 @@ from databricks.sdk.core import Config
 
 logger = logging.getLogger(__name__)
 
+# pylint: disable=too-few-public-methods
 
 @dataclass
 class MorphConfig:


### PR DESCRIPTION
This PR will make it impossible to cheat the linter without explicit approval