### PR TITLE
Fixed default value for sdk config - Uninstall Errors

### DIFF
--- a/src/databricks/labs/remorph/config.py
+++ b/src/databricks/labs/remorph/config.py
@@ -10,7 +10,7 @@ class MorphConfig:
     __version__ = 1
 
     source: str
-    sdk_config: dict[str, str] | None
+    sdk_config: dict[str, str] | None = None
     input_sql: str | None = None
     output_folder: str | None = None
     skip_validation: bool = False


### PR DESCRIPTION
Fixes 

```
AttributeError: 'types.UnionType' object has no attribute '__name__'. Did you mean: '__ne__'?