### PR TITLE
Implement translation of Snowflake HAVING clauses

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -42,8 +42,12 @@ class SnowflakeExpressionBuilder extends SnowflakeParserBaseVisitor[ir.Expressio
   }
 
   override def visitPrimitive_expression(ctx: Primitive_expressionContext): ir.Expression = {
-    val columnName = ctx.id_(0).getText
-    ir.Column(columnName)
+    if (ctx.id_(0) != null) {
+      val columnName = ctx.id_(0).getText
+      ir.Column(columnName)
+    } else {
+      super.visitPrimitive_expression(ctx)
+    }
   }
 
   override def visitOrder_item(ctx: Order_itemContext): ir.Expression = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
@@ -1,6 +1,5 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
-import com.databricks.labs.remorph.parsers.intermediate.Relation
 import com.databricks.labs.remorph.parsers.{intermediate => ir}
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser._
 
@@ -10,10 +9,10 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] {
 
   override def visitSelect_optional_clauses(ctx: Select_optional_clausesContext): ir.Relation = {
     val from = ctx.from_clause().accept(this)
-    buildOrderBy(ctx, buildGroupBy(ctx, buildWhere(ctx, from)))
+    buildOrderBy(ctx, buildHaving(ctx.having_clause(), buildGroupBy(ctx, buildWhere(ctx, from))))
   }
 
-  private def buildWhere(ctx: Select_optional_clausesContext, from: Relation): Relation =
+  private def buildWhere(ctx: Select_optional_clausesContext, from: ir.Relation): ir.Relation =
     if (ctx.where_clause() != null) {
       val predicate = ctx.where_clause().search_condition().accept(new SnowflakePredicateBuilder)
       ir.Filter(from, predicate)
@@ -21,16 +20,18 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] {
       from
     }
 
-  private def buildGroupBy(ctx: Select_optional_clausesContext, input: Relation): Relation =
+  private def buildGroupBy(ctx: Select_optional_clausesContext, input: ir.Relation): ir.Relation =
     if (ctx.group_by_clause() != null) {
       val groupingExpressions =
         ctx.group_by_clause().group_by_list().group_by_elem().asScala.map(_.accept(new SnowflakeExpressionBuilder))
-      ir.Aggregate(input = input, group_type = ir.GroupBy, grouping_expressions = groupingExpressions, pivot = None)
+      val aggregate =
+        ir.Aggregate(input = input, group_type = ir.GroupBy, grouping_expressions = groupingExpressions, pivot = None)
+      buildHaving(ctx.group_by_clause().having_clause(), aggregate)
     } else {
       input
     }
 
-  private def buildOrderBy(ctx: Select_optional_clausesContext, input: Relation): Relation =
+  private def buildOrderBy(ctx: Select_optional_clausesContext, input: ir.Relation): ir.Relation =
     if (ctx.order_by_clause() != null) {
       val sortOrders = ctx.order_by_clause().order_item().asScala.map { orderItem =>
         val expression = orderItem.accept(new SnowflakeExpressionBuilder)
@@ -54,6 +55,14 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] {
       input
     }
 
+  def buildHaving(ctx: Having_clauseContext, input: ir.Relation): ir.Relation = {
+    if (ctx != null) {
+      val condition = ctx.search_condition().accept(new SnowflakePredicateBuilder)
+      ir.Filter(input, condition)
+    } else {
+      input
+    }
+  }
   override def visitObject_ref(ctx: Object_refContext): ir.Relation = {
     val tableName = ctx.object_name().id_(0).getText
     val table = ir.NamedTable(tableName, Map.empty, is_streaming = false)

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
@@ -174,6 +174,20 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with Matchers {
           Seq(Column("a"), Count(Column("b")))))
     }
 
+    "translate a query with GROUP BY HAVING clause" in {
+      example(
+        query = "SELECT a, COUNT(b) FROM c GROUP BY a HAVING COUNT(b) > 1",
+        expectedAst = Project(
+          Filter(
+            Aggregate(
+              input = NamedTable("c", Map.empty, is_streaming = false),
+              group_type = GroupBy,
+              grouping_expressions = Seq(Column("a")),
+              pivot = None),
+            GreaterThan(Count(Column("b")), Literal(integer = Some(1)))),
+          Seq(Column("a"), Count(Column("b")))))
+    }
+
     "translate a query with ORDER BY" in {
       example(
         query = "SELECT a FROM b ORDER BY a",


### PR DESCRIPTION
The grammar states that `having_clause` can occur within a `group_by_clause` or straight into a `select_optional_list` (in which case, the `group_by_clause` is absent. 

That's the reason why I had to sorta duplicate the call to `buildHaving` here.

However, the Snowflake docs seems to mandate the `HAVING` clause to appear after a `GROUP BY`, so I am not sure how the latter case described above may actually occur...