### PR TITLE
Improve testing of Snowflake to IR translation

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -55,16 +55,23 @@ class SnowflakeExpressionBuilder extends SnowflakeParserBaseVisitor[ir.Expressio
     ir.Column(columnName)
   }
 
-  override def visitLiteral(ctx: LiteralContext): ir.Literal = if (ctx.STRING() != null) {
-    ir.Literal(string = Some(removeQuotes(ctx.STRING().getText)))
-  } else if (ctx.DECIMAL != null) {
-    visitDecimal(ctx.DECIMAL.getText)
-  } else if (ctx.true_false() != null) {
-    visitTrue_false(ctx.true_false())
-  } else if (ctx.NULL_() != null) {
-    ir.Literal(nullType = Some(ir.NullType()))
-  } else {
-    ir.Literal(nullType = Some(ir.NullType()))
+  override def visitLiteral(ctx: LiteralContext): ir.Literal = {
+    val sign = Option(ctx.sign()).map(_ => "-").getOrElse("")
+    if (ctx.STRING() != null) {
+      ir.Literal(string = Some(removeQuotes(ctx.STRING().getText)))
+    } else if (ctx.DECIMAL() != null) {
+      visitDecimal(sign + ctx.DECIMAL().getText)
+    } else if (ctx.FLOAT() != null) {
+      visitDecimal(sign + ctx.FLOAT().getText)
+    } else if (ctx.REAL() != null) {
+      visitDecimal(sign + ctx.REAL().getText)
+    } else if (ctx.true_false() != null) {
+      visitTrue_false(ctx.true_false())
+    } else if (ctx.NULL_() != null) {
+      ir.Literal(nullType = Some(ir.NullType()))
+    } else {
+      ir.Literal(nullType = Some(ir.NullType()))
+    }
   }
 
   private def removeQuotes(str: String): String = {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/ParserTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/ParserTestCommon.scala
@@ -1,0 +1,32 @@
+package com.databricks.labs.remorph.parsers.snowflake
+
+import com.databricks.labs.remorph.parsers.intermediate.TreeNode
+import org.antlr.v4.runtime.{CharStreams, CommonTokenStream, RuleContext}
+import org.scalatest.{Assertion, Assertions}
+
+trait ParserTestCommon { self: Assertions =>
+
+  def astBuilder: SnowflakeParserBaseVisitor[_]
+  protected def parseString[R <: RuleContext](input: String, rule: SnowflakeParser => R): R = {
+    val inputString = CharStreams.fromString(input)
+    val lexer = new SnowflakeLexer(inputString)
+    val tokenStream = new CommonTokenStream(lexer)
+    val parser = new SnowflakeParser(tokenStream)
+    val tree = rule(parser)
+    // uncomment the following line if you need a peek in the Snowflake AST
+    // println(tree.toStringTree(parser))
+    tree
+  }
+
+  protected def example[R <: RuleContext](
+      query: String,
+      rule: SnowflakeParser => R,
+      expectedAst: TreeNode): Assertion = {
+    val sfTree = parseString(query, rule)
+
+    val result = astBuilder.visit(sfTree)
+
+    assert(result == expectedAst, s"\nFor input string\n$query\nactual result:\n$result\nexpected\n$expectedAst")
+  }
+
+}

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
@@ -1,31 +1,15 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
 import com.databricks.labs.remorph.parsers.intermediate._
-import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class SnowflakeAstBuilderSpec extends AnyWordSpec with Matchers {
+class SnowflakeAstBuilderSpec extends AnyWordSpec with ParserTestCommon with Matchers {
 
-  private def parseString(input: String): SnowflakeParser.Snowflake_fileContext = {
-    val inputString = CharStreams.fromString(input)
-    val lexer = new SnowflakeLexer(inputString)
-    val tokenStream = new CommonTokenStream(lexer)
-    val parser = new SnowflakeParser(tokenStream)
-    val tree = parser.snowflake_file()
-    // uncomment the following line if you need a peek in the Snowflake AST
-    // println(tree.toStringTree(parser))
-    tree
-  }
-
-  private def example(query: String, expectedAst: TreeNode): Assertion = {
-    val sfTree = parseString(query)
-
-    val result = new SnowflakeAstBuilder().visit(sfTree)
-
-    result shouldBe expectedAst
-  }
+  override def astBuilder: SnowflakeParserBaseVisitor[_] = new SnowflakeAstBuilder
+  private def example(query: String, expectedAst: TreeNode): Assertion =
+    example(query, _.snowflake_file(), expectedAst)
 
   "SnowflakeVisitor" should {
     "translate a simple SELECT query" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
@@ -1,0 +1,26 @@
+package com.databricks.labs.remorph.parsers.snowflake
+
+import com.databricks.labs.remorph.parsers.intermediate.{Literal, NullType, Decimal}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class SnowflakeExpressionBuilderSpec extends AnyWordSpec with ParserTestCommon with Matchers {
+
+  override def astBuilder: SnowflakeParserBaseVisitor[_] = new SnowflakeExpressionBuilder
+
+  "SnowflakeExpressionBuilder" should {
+    "translate literals" in {
+      example("null", _.literal(), Literal(nullType = Some(NullType())))
+      example("true", _.literal(), Literal(boolean = Some(true)))
+      example("false", _.literal(), Literal(boolean = Some(false)))
+      example("1", _.literal(), Literal(integer = Some(1)))
+      example("-1", _.literal(), Literal(integer = Some(-1)))
+      example("1.1", _.literal(), Literal(float = Some(1.1f)))
+      example("1.1e2", _.literal(), Literal(integer = Some(110)))
+      example("1.1e-2", _.literal(), Literal(float = Some(0.011f)))
+      example("0.123456789", _.literal(), Literal(double = Some(0.123456789)))
+      example("0.123456789e-1234", _.literal(), Literal(decimal = Some(Decimal("0.123456789e-1234", None, None))))
+      example("'foo'", _.literal(), Literal(string = Some("foo")))
+    }
+  }
+}

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
-import com.databricks.labs.remorph.parsers.intermediate.{Literal, NullType, Decimal}
+import com.databricks.labs.remorph.parsers.intermediate._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -21,6 +21,14 @@ class SnowflakeExpressionBuilderSpec extends AnyWordSpec with ParserTestCommon w
       example("0.123456789", _.literal(), Literal(double = Some(0.123456789)))
       example("0.123456789e-1234", _.literal(), Literal(decimal = Some(Decimal("0.123456789e-1234", None, None))))
       example("'foo'", _.literal(), Literal(string = Some("foo")))
+    }
+
+    "translate column names" in {
+      example("x", _.column_name(), Column("x"))
+    }
+
+    "translate aggregation functions" in {
+      example("COUNT(x)", _.aggregate_function(), Count(Column("x")))
     }
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
@@ -1,0 +1,114 @@
+package com.databricks.labs.remorph.parsers.snowflake
+
+import com.databricks.labs.remorph.parsers.intermediate._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class SnowflakeRelationBuilderSpec extends AnyWordSpec with ParserTestCommon with Matchers {
+
+  override def astBuilder: SnowflakeParserBaseVisitor[_] = new SnowflakeRelationBuilder
+
+  private def namedTable(name: String): Relation = NamedTable(name, Map.empty, is_streaming = false)
+
+  "SnowflakeRelationBuilder" should {
+
+    "translate FROM clauses" in {
+      example("FROM some_table", _.from_clause(), namedTable("some_table"))
+    }
+
+    "translate WHERE clauses" in {
+      example(
+        "FROM some_table WHERE 1=1",
+        _.select_optional_clauses(),
+        Filter(namedTable("some_table"), Equals(Literal(integer = Some(1)), Literal(integer = Some(1)))))
+    }
+
+    "translate GROUP BY clauses" in {
+      example(
+        "FROM some_table GROUP BY some_column",
+        _.select_optional_clauses(),
+        Aggregate(
+          input = namedTable("some_table"),
+          group_type = GroupBy,
+          grouping_expressions = Seq(Column("some_column")),
+          pivot = None))
+    }
+
+    "translate ORDER BY clauses" in {
+      example(
+        "FROM some_table ORDER BY some_column",
+        _.select_optional_clauses(),
+        Sort(
+          namedTable("some_table"),
+          Seq(SortOrder(Column("some_column"), AscendingSortDirection, SortNullsLast)),
+          is_global = false))
+      example(
+        "FROM some_table ORDER BY some_column ASC",
+        _.select_optional_clauses(),
+        Sort(
+          namedTable("some_table"),
+          Seq(SortOrder(Column("some_column"), AscendingSortDirection, SortNullsLast)),
+          is_global = false))
+      example(
+        "FROM some_table ORDER BY some_column ASC NULLS LAST",
+        _.select_optional_clauses(),
+        Sort(
+          namedTable("some_table"),
+          Seq(SortOrder(Column("some_column"), AscendingSortDirection, SortNullsLast)),
+          is_global = false))
+      example(
+        "FROM some_table ORDER BY some_column DESC",
+        _.select_optional_clauses(),
+        Sort(
+          namedTable("some_table"),
+          Seq(SortOrder(Column("some_column"), DescendingSortDirection, SortNullsLast)),
+          is_global = false))
+      example(
+        "FROM some_table ORDER BY some_column DESC NULLS LAST",
+        _.select_optional_clauses(),
+        Sort(
+          namedTable("some_table"),
+          Seq(SortOrder(Column("some_column"), DescendingSortDirection, SortNullsLast)),
+          is_global = false))
+      example(
+        "FROM some_table ORDER BY some_column DESC NULLS FIRST",
+        _.select_optional_clauses(),
+        Sort(
+          namedTable("some_table"),
+          Seq(SortOrder(Column("some_column"), DescendingSortDirection, SortNullsFirst)),
+          is_global = false))
+
+    }
+
+    "translate combinations of the above" in {
+      example(
+        "FROM some_table WHERE 1=1 GROUP BY some_column",
+        _.select_optional_clauses(),
+        Aggregate(
+          input = Filter(namedTable("some_table"), Equals(Literal(integer = Some(1)), Literal(integer = Some(1)))),
+          group_type = GroupBy,
+          grouping_expressions = Seq(Column("some_column")),
+          pivot = None))
+
+      example(
+        "FROM some_table WHERE 1=1 GROUP BY some_column ORDER BY some_column NULLS FIRST",
+        _.select_optional_clauses(),
+        Sort(
+          Aggregate(
+            input = Filter(namedTable("some_table"), Equals(Literal(integer = Some(1)), Literal(integer = Some(1)))),
+            group_type = GroupBy,
+            grouping_expressions = Seq(Column("some_column")),
+            pivot = None),
+          Seq(SortOrder(Column("some_column"), AscendingSortDirection, SortNullsFirst)),
+          is_global = false))
+
+      example(
+        "FROM some_table WHERE 1=1 ORDER BY some_column NULLS FIRST",
+        _.select_optional_clauses(),
+        Sort(
+          Filter(namedTable("some_table"), Equals(Literal(integer = Some(1)), Literal(integer = Some(1)))),
+          Seq(SortOrder(Column("some_column"), AscendingSortDirection, SortNullsFirst)),
+          is_global = false))
+    }
+  }
+}


### PR DESCRIPTION
Introduces a specific Spec for `SnowflakeExpressionBuilder` and `SnowflakeRelationBuilder`.

While adding tests in `SnowflakeExpressionBuilderSpec`, I realized that `SnowflakePredicateBuilder` and the `Predicate` trait altogether will probably have to go away:

We want `TRUE` and `FALSE` to be valid predicates. However, they are literals, which get translated to `Literal` which extends `Expression` and not `Predicate` (because other kinds of literals, such as numbers or strings cannot be considered predicates). 

In a subsequent PR, I will therefore move code in `SnowflakePredicateBuilder` inside `SnowflakeExpressionBuilder`