### PR TITLE
Wrap unparsable inputs in UnresolvedExpression/UnresolvedRelation

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/IncompleteParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/IncompleteParser.scala
@@ -1,0 +1,16 @@
+package com.databricks.labs.remorph.parsers
+
+import org.antlr.v4.runtime.tree.{ParseTreeVisitor, RuleNode}
+
+trait IncompleteParser[T] extends ParseTreeVisitor[T] {
+
+  protected def wrapUnresolvedInput(unparsedInput: String): T
+  abstract override def visitChildren(node: RuleNode): T = {
+    super.visitChildren(node) match {
+      case null =>
+        // TODO: getText doesn't return the original text, this reporting will have to be improved
+        wrapUnresolvedInput(node.getText)
+      case x => x
+    }
+  }
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/unresolved.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/unresolved.scala
@@ -1,5 +1,6 @@
 package com.databricks.labs.remorph.parsers.intermediate
 
-case class UnresolvedRelation() extends RelationCommon
+case class UnresolvedRelation(inputText: String) extends RelationCommon
 
+case class UnresolvedExpression(inputText: String) extends Expression {}
 case object UnknownRelation extends RelationCommon

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
@@ -1,13 +1,14 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.parsers.{IncompleteParser, intermediate => ir}
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser._
 import org.antlr.v4.runtime.ParserRuleContext
 
 import scala.collection.JavaConverters._
 
-class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] {
+class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] with IncompleteParser[ir.Relation] {
 
+  protected override def wrapUnresolvedInput(unparsedInput: String): ir.Relation = ir.UnresolvedRelation(unparsedInput)
   override def visitSelect_statement(ctx: Select_statementContext): ir.Relation = {
     val select = ctx.select_optional_clauses().accept(this)
     val relation =

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
@@ -146,4 +146,9 @@ class SnowflakeExpressionBuilderSpec extends AnyWordSpec with ParserTestCommon w
     }
   }
 
+  "Unparsed input" should {
+    "be reported as UnresolvedExpression" in {
+      example("{'name':'Homer Simpson'}", _.json_literal(), UnresolvedExpression("{'name':'Homer Simpson'}"))
+    }
+  }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
@@ -131,4 +131,10 @@ class SnowflakeRelationBuilderSpec extends AnyWordSpec with ParserTestCommon wit
             Literal(integer = Some(1)))))
     }
   }
+
+  "Unparsed input" should {
+    "be reported as UnresolvedRelation" in {
+      example("MATCH_RECOGNIZE()", _.match_recognize(), UnresolvedRelation("MATCH_RECOGNIZE()"))
+    }
+  }
 }


### PR DESCRIPTION
With this change in place, every grammar rule for which the corresponding `visit*` method is unimplemented or delegates (part of its implementation) to `visitChildren` will be translated to `UnresolvedExpression`/`UnresolvedRelation` automatically. 

Best effort is made to return the original unparsed bits, although doing so properly and/or returning position of the unparsed text in the original input would require some more work.