### PR TITLE
Isort import issues and ruff warnings fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,11 +59,11 @@ coverage    = "pytest --cov src tests/unit --cov-report=html"
 integration = "pytest --cov src tests/integration --durations 20"
 fmt         = ["isort .",
                "black .",
-               "ruff  . --fix",
+               "ruff  check . --fix",
                "pylint --output-format=colorized -j 0 src tests"]
 verify      = ["black --check .",
                "isort . --check-only",
-               "ruff .",
+               "ruff check .",
                "pylint --output-format=colorized -j 0 src tests"]
 
 [tool.hatch.envs.sqlglot-latest]
@@ -76,6 +76,7 @@ dependencies = [
 [tool.isort]
 skip_glob = ["notebooks/*.py"]
 profile = "black"
+known_first_party = ["databricks"]
 
 [tool.pytest.ini_options]
 addopts = "-s -p no:warnings -vv --cache-clear"

--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -4,11 +4,10 @@ import os
 from databricks.labs.blueprint.cli import App
 from databricks.labs.blueprint.entrypoint import get_logger
 from databricks.labs.blueprint.installation import Installation
-from databricks.sdk import WorkspaceClient
-
 from databricks.labs.remorph.config import MorphConfig
 from databricks.labs.remorph.reconcile.execute import recon
 from databricks.labs.remorph.transpiler.execute import morph
+from databricks.sdk import WorkspaceClient
 
 remorph = App(__file__)
 logger = get_logger(__file__)

--- a/src/databricks/labs/remorph/coverage/commons.py
+++ b/src/databricks/labs/remorph/coverage/commons.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-instance-attributes,broad-exception-caught
+# pylint: disable=all
 import dataclasses
 import json
 import logging
@@ -36,7 +36,7 @@ class ReportEntry:
 
 
 def get_supported_sql_files(input_dir: Path) -> Generator[Path, None, None]:
-    yield from filter(lambda item: item.is_file() and item.suffix.lower() in {".sql", ".ddl"}, input_dir.rglob("*"))
+    yield from filter(lambda item: item.is_file() and item.suffix.lower() in [".sql", ".ddl"], input_dir.rglob("*"))
 
 
 def write_json_line(file: TextIO, content: ReportEntry):
@@ -134,16 +134,16 @@ def _prepare_report_entry(
         expressions = parse_sql(sql, source_dialect)
         report_entry.parsed = 1
         report_entry.statements = len(expressions)
-    except Exception as parse_error:
-        report_entry.parsing_error = str(parse_error)
+    except Exception as pe:
+        report_entry.parsing_error = str(pe)
         return report_entry
 
     try:
         generated_sqls = generate_sql(expressions, target_dialect)
         report_entry.transpiled = 1
         report_entry.transpiled_statements = len([sql for sql in generated_sqls if sql.strip()])
-    except Exception as transpile_error:
-        report_entry.transpilation_error = str(transpile_error)
+    except Exception as te:
+        report_entry.transpilation_error = str(te)
 
     return report_entry
 

--- a/src/databricks/labs/remorph/coverage/commons.py
+++ b/src/databricks/labs/remorph/coverage/commons.py
@@ -1,4 +1,4 @@
-# pylint: disable=all
+# pylint: disable=too-many-instance-attributes,broad-exception-caught
 import dataclasses
 import json
 import logging
@@ -36,7 +36,7 @@ class ReportEntry:
 
 
 def get_supported_sql_files(input_dir: Path) -> Generator[Path, None, None]:
-    yield from filter(lambda item: item.is_file() and item.suffix.lower() in [".sql", ".ddl"], input_dir.rglob("*"))
+    yield from filter(lambda item: item.is_file() and item.suffix.lower() in {".sql", ".ddl"}, input_dir.rglob("*"))
 
 
 def write_json_line(file: TextIO, content: ReportEntry):
@@ -134,16 +134,16 @@ def _prepare_report_entry(
         expressions = parse_sql(sql, source_dialect)
         report_entry.parsed = 1
         report_entry.statements = len(expressions)
-    except Exception as pe:
-        report_entry.parsing_error = str(pe)
+    except Exception as parse_error:
+        report_entry.parsing_error = str(parse_error)
         return report_entry
 
     try:
         generated_sqls = generate_sql(expressions, target_dialect)
         report_entry.transpiled = 1
         report_entry.transpiled_statements = len([sql for sql in generated_sqls if sql.strip()])
-    except Exception as te:
-        report_entry.transpilation_error = str(te)
+    except Exception as transpile_error:
+        report_entry.transpilation_error = str(transpile_error)
 
     return report_entry
 

--- a/src/databricks/labs/remorph/coverage/remorph_snow_transpilation_coverage.py
+++ b/src/databricks/labs/remorph/coverage/remorph_snow_transpilation_coverage.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 from databricks.labs.blueprint.wheels import ProductInfo
-
 from databricks.labs.remorph.coverage import commons
 from databricks.labs.remorph.snow.databricks import Databricks
 from databricks.labs.remorph.snow.snowflake import Snow

--- a/src/databricks/labs/remorph/helpers/db_sql.py
+++ b/src/databricks/labs/remorph/helpers/db_sql.py
@@ -7,10 +7,9 @@ from databricks.labs.lsql.backends import (
     SqlBackend,
     StatementExecutionBackend,
 )
+from databricks.labs.remorph.config import MorphConfig
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors.base import DatabricksError
-
-from databricks.labs.remorph.config import MorphConfig
 
 logger = logging.getLogger(__name__)
 

--- a/src/databricks/labs/remorph/helpers/validation.py
+++ b/src/databricks/labs/remorph/helpers/validation.py
@@ -2,9 +2,8 @@ import logging
 from io import StringIO
 
 from databricks.labs.lsql.backends import SqlBackend
-from databricks.sdk.errors.base import DatabricksError
-
 from databricks.labs.remorph.config import MorphConfig
+from databricks.sdk.errors.base import DatabricksError
 
 logger = logging.getLogger(__name__)
 

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -10,6 +10,8 @@ from databricks.labs.blueprint.installation import Installation
 from databricks.labs.blueprint.installer import InstallState
 from databricks.labs.blueprint.tui import Prompts
 from databricks.labs.blueprint.wheels import ProductInfo
+from databricks.labs.remorph.__about__ import __version__
+from databricks.labs.remorph.config import MorphConfig
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import NotFound
 from databricks.sdk.retries import retried
@@ -18,9 +20,6 @@ from databricks.sdk.service.sql import (
     EndpointInfoWarehouseType,
     SpotInstancePolicy,
 )
-
-from databricks.labs.remorph.__about__ import __version__
-from databricks.labs.remorph.config import MorphConfig
 
 logger = logging.getLogger(__name__)
 

--- a/src/databricks/labs/remorph/reconcile/connectors/data_source.py
+++ b/src/databricks/labs/remorph/reconcile/connectors/data_source.py
@@ -1,13 +1,10 @@
 import re
 from abc import ABC, abstractmethod
 
-from databricks.sdk import WorkspaceClient  # pylint: disable-next=wrong-import-order
 from pyspark.sql import DataFrame, SparkSession
 
-from databricks.labs.remorph.reconcile.recon_config import (  # pylint: disable=ungrouped-imports
-    JdbcReaderOptions,
-    Schema,
-)
+from databricks.labs.remorph.reconcile.recon_config import JdbcReaderOptions, Schema
+from databricks.sdk import WorkspaceClient
 
 
 class DataSource(ABC):

--- a/src/databricks/labs/remorph/reconcile/execute.py
+++ b/src/databricks/labs/remorph/reconcile/execute.py
@@ -2,7 +2,6 @@ import logging
 from pathlib import Path
 
 from databricks.labs.blueprint.installation import Installation
-
 from databricks.labs.remorph.reconcile.connectors.data_source import DataSource
 from databricks.labs.remorph.reconcile.recon_config import Table, TableRecon
 

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -2,8 +2,6 @@ import logging
 import os
 from pathlib import Path
 
-from databricks.sdk import WorkspaceClient
-
 from databricks.labs.remorph.config import MorphConfig
 from databricks.labs.remorph.helpers import db_sql
 from databricks.labs.remorph.helpers.execution_time import timeit
@@ -17,6 +15,7 @@ from databricks.labs.remorph.helpers.morph_status import MorphStatus, Validation
 from databricks.labs.remorph.helpers.validation import Validator
 from databricks.labs.remorph.snow import lca_utils
 from databricks.labs.remorph.snow.sql_transpiler import SqlglotEngine
+from databricks.sdk import WorkspaceClient
 
 # pylint: disable=unspecified-encoding
 

--- a/src/databricks/labs/remorph/uninstall.py
+++ b/src/databricks/labs/remorph/uninstall.py
@@ -4,11 +4,10 @@ from datetime import timedelta
 from databricks.labs.blueprint.installation import Installation
 from databricks.labs.blueprint.tui import Prompts
 from databricks.labs.blueprint.wheels import ProductInfo
-from databricks.sdk import WorkspaceClient
-from databricks.sdk.errors import NotFound
-
 from databricks.labs.remorph.__about__ import __version__
 from databricks.labs.remorph.config import MorphConfig
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors import NotFound
 
 logger = logging.getLogger("databricks.labs.remorph.install")
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,20 +1,19 @@
-# pylint: disable=wrong-import-order,ungrouped-imports, useless-suppression)
 import re
 from pathlib import Path
 from unittest.mock import create_autospec
 
 import pytest
-from databricks.connect import DatabricksSession
-from databricks.sdk import WorkspaceClient
-from databricks.sdk.core import Config
-from databricks.sdk.service import iam
 from sqlglot import ErrorLevel, UnsupportedError
 from sqlglot import parse_one as sqlglot_parse_one
 from sqlglot import transpile
 
+from databricks.connect import DatabricksSession
 from databricks.labs.remorph.config import SQLGLOT_DIALECTS, MorphConfig
 from databricks.labs.remorph.snow.databricks import Databricks
 from databricks.labs.remorph.snow.snowflake import Snow
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.core import Config
+from databricks.sdk.service import iam
 
 from .snow.helpers.functional_test_cases import (
     FunctionalTestFile,

--- a/tests/unit/helpers/test_db_sql.py
+++ b/tests/unit/helpers/test_db_sql.py
@@ -1,9 +1,9 @@
 from unittest.mock import patch
 
 import pytest
-from databricks.sdk.errors.base import DatabricksError
 
 from databricks.labs.remorph.helpers.db_sql import get_sql_backend
+from databricks.sdk.errors.base import DatabricksError
 
 
 @pytest.fixture()

--- a/tests/unit/helpers/test_validation.py
+++ b/tests/unit/helpers/test_validation.py
@@ -1,6 +1,5 @@
 from databricks.labs.lsql.backends import MockBackend
 from databricks.labs.lsql.core import Row
-
 from databricks.labs.remorph.helpers.validation import Validator
 
 

--- a/tests/unit/reconcile/connectors/test_databricks.py
+++ b/tests/unit/reconcile/connectors/test_databricks.py
@@ -2,10 +2,10 @@ import re
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
-from databricks.sdk import WorkspaceClient
 from pyspark.errors import PySparkException
 
 from databricks.labs.remorph.reconcile.connectors.databricks import DatabricksDataSource
+from databricks.sdk import WorkspaceClient
 
 
 def initial_setup():

--- a/tests/unit/reconcile/connectors/test_snowflake.py
+++ b/tests/unit/reconcile/connectors/test_snowflake.py
@@ -2,12 +2,12 @@ import re
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
-from databricks.sdk import WorkspaceClient
 from pyspark.errors import PySparkException
 
 from databricks.labs.remorph.reconcile.connectors.snowflake import SnowflakeDataSource
 from databricks.labs.remorph.reconcile.constants import SourceDriver
 from databricks.labs.remorph.reconcile.recon_config import JdbcReaderOptions, Table
+from databricks.sdk import WorkspaceClient
 
 
 def initial_setup():

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3,11 +3,11 @@ from unittest.mock import create_autospec, patch
 
 import pytest
 import yaml
-from databricks.sdk import WorkspaceClient
-from databricks.sdk.errors import NotFound
 
 from databricks.labs.remorph import cli
 from databricks.labs.remorph.config import MorphConfig
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors import NotFound
 
 
 @pytest.fixture

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -3,18 +3,18 @@ from datetime import timedelta
 from unittest.mock import create_autospec
 
 import pytest
+
 from databricks.labs.blueprint.installation import Installation, MockInstallation
 from databricks.labs.blueprint.tui import MockPrompts, Prompts
-from databricks.sdk import WorkspaceClient
-from databricks.sdk.errors import NotFound
-from databricks.sdk.service.catalog import CatalogInfo
-
 from databricks.labs.remorph.config import MorphConfig
 from databricks.labs.remorph.install import (
     CatalogSetup,
     WorkspaceInstallation,
     WorkspaceInstaller,
 )
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors import NotFound
+from databricks.sdk.service.catalog import CatalogInfo
 
 
 @pytest.fixture

--- a/tests/unit/test_uninstall.py
+++ b/tests/unit/test_uninstall.py
@@ -2,13 +2,13 @@ from datetime import timedelta
 from unittest.mock import create_autospec
 
 import pytest
+
 from databricks.labs.blueprint.installation import Installation
 from databricks.labs.blueprint.tui import MockPrompts
-from databricks.sdk import WorkspaceClient
-from databricks.sdk.errors import NotFound
-
 from databricks.labs.remorph.config import MorphConfig
 from databricks.labs.remorph.uninstall import WorkspaceUnInstallation
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors import NotFound
 
 
 @pytest.fixture

--- a/tests/unit/transpiler/test_execute.py
+++ b/tests/unit/transpiler/test_execute.py
@@ -4,14 +4,14 @@ from pathlib import Path
 from unittest.mock import create_autospec, patch
 
 import pytest
+
 from databricks.connect import DatabricksSession
 from databricks.labs.lsql.backends import MockBackend
-from databricks.sdk.core import Config
-
 from databricks.labs.remorph.config import MorphConfig
 from databricks.labs.remorph.helpers.file_utils import make_dir
 from databricks.labs.remorph.helpers.validation import Validator
 from databricks.labs.remorph.transpiler.execute import morph
+from databricks.sdk.core import Config
 
 # pylint: disable=unspecified-encoding
 


### PR DESCRIPTION
This PR aims to solve the following `isort` issues and `ruff` warnings:

### isort

* wrong-import-order : 

      *  C0411: third party import "pyspark.sql.SparkSession" should be placed before first party import "databricks.sdk.WorkspaceClient"  (wrong-import-order)
      *  C0411: third party import "sqlglot.dialects.dialect.Dialect" should be placed before first party import "databricks.sdk.WorkspaceClient"  (wrong-import-order)
      *  C0411: third party import "pyspark.sql.DataFrame" should be placed before first party import "databricks.sdk.WorkspaceClient"  (wrong-import-order)


* ungrouped-imports : 
      *  `C0412: Imports from package databricks are not grouped (ungrouped-imports)`

-------

### ruff
*  `ruff  . --fix` : 
    *  ```warning: `ruff <path>` is deprecated. Use `ruff check <path>` instead.```

