### PR TITLE
Support for Null safe equality join for databricks generator

### DIFF
--- a/src/databricks/labs/remorph/snow/databricks.py
+++ b/src/databricks/labs/remorph/snow/databricks.py
@@ -370,6 +370,7 @@ class Databricks(Databricks):  #
             exp.ApproxQuantile: rename_func("APPROX_PERCENTILE"),
             exp.TimestampTrunc: timestamptrunc_sql,
             exp.Mod: rename_func("MOD"),
+            exp.NullSafeEQ: lambda self, e: self.binary(e, "<=>"),
         }
 
         def preprocess(self, expression: exp.Expression) -> exp.Expression:

--- a/tests/resources/functional/snowflake/test_nullsafe_eq/test_nullsafe_eq_1.sql
+++ b/tests/resources/functional/snowflake/test_nullsafe_eq/test_nullsafe_eq_1.sql
@@ -1,0 +1,6 @@
+
+-- snowflake sql:
+SELECT A.COL1, B.COL2 FROM TABL1 A JOIN TABL2 B ON A.COL1 <=> B.COL1;
+
+-- databricks sql:
+SELECT A.COL1, B.COL2 FROM TABL1 as A JOIN TABL2 as B ON A.COL1 <=> B.COL1;


### PR DESCRIPTION
Null safe equality join for Databricks generator will generate " <=> " instead of "is not distinct from" 