### PR TITLE
Update HexaDecimal codes in the Errors file

### DIFF
--- a/src/databricks/labs/remorph/helpers/file_utils.py
+++ b/src/databricks/labs/remorph/helpers/file_utils.py
@@ -1,5 +1,4 @@
 import codecs
-import re
 from pathlib import Path
 
 
@@ -91,10 +90,14 @@ def read_file(filename: str | Path) -> str:
         return file.read()
 
 
-def remove_hexadecimal_chars(input_string: str) -> str:
+def refactor_hexadecimal_chars(input_string: str) -> str:
     """
-    Removes the HexaDecimal characters ( \x1b[\\d+m ) from the given string if it exists.
-    :param input_string: String with HexaDecimal characters ex: ( \x1b[4mWHERE\x1b[0m )
-    :return: String without HexaDecimal characters ex: ( WHERE )
+    Updates the HexaDecimal characters ( \x1b[\\d+m ) in the given string as below.
+    :param input_string: String with HexaDecimal characters. ex: ( \x1b[4mWHERE\x1b[0m )
+    :return: String with HexaDecimal characters refactored to arrows. ex: ( --> WHERE <--)
     """
-    return re.sub(r'\x1b\[\d+m', '', input_string)
+    output_string = input_string
+    highlight = {"\x1b[4m": "--> ", "\x1b[0m": " <--"}
+    for key, value in highlight.items():
+        output_string = output_string.replace(key, value)
+    return output_string

--- a/src/databricks/labs/remorph/snow/sql_transpiler.py
+++ b/src/databricks/labs/remorph/snow/sql_transpiler.py
@@ -2,7 +2,7 @@ from sqlglot import ErrorLevel, Expression, exp, parse, transpile
 from sqlglot.dialects.dialect import Dialect
 from sqlglot.errors import ParseError, TokenError, UnsupportedError
 
-from databricks.labs.remorph.helpers.file_utils import remove_hexadecimal_chars
+from databricks.labs.remorph.helpers.file_utils import refactor_hexadecimal_chars
 from databricks.labs.remorph.helpers.morph_status import ParserError
 
 
@@ -17,7 +17,7 @@ class SqlglotEngine:
             transpiled_sql = transpile(sql, read=self.read_dialect, write=write_dialect, pretty=True, error_level=None)
         except (ParseError, TokenError, UnsupportedError) as e:
             transpiled_sql = [""]
-            error_list.append(ParserError(file_name, remove_hexadecimal_chars(str(e))))
+            error_list.append(ParserError(file_name, refactor_hexadecimal_chars(str(e))))
 
         return transpiled_sql, error_list
 

--- a/tests/unit/helpers/test_file_utils.py
+++ b/tests/unit/helpers/test_file_utils.py
@@ -9,6 +9,7 @@ from databricks.labs.remorph.helpers.file_utils import (
     dir_walk,
     is_sql_file,
     make_dir,
+    refactor_hexadecimal_chars,
     remove_bom,
 )
 
@@ -136,3 +137,13 @@ def test_dir_walk_empty_dir():
     assert len(result[0][1]) == 0
     assert len(result[0][2]) == 0
     safe_remove_dir(path)
+
+
+def test_refactor_hexadecimal_chars():
+    input_string = "SELECT * FROM test \x1b[4mWHERE\x1b[0m"
+    output_string = "SELECT * FROM test --> WHERE <--"
+    assert refactor_hexadecimal_chars(input_string) == output_string
+
+    input_string2 = "SELECT \x1b[4marray_agg(\x1b[0mafter_state order by timestamp asc) FROM dual"
+    output_string2 = "SELECT --> array_agg( <--after_state order by timestamp asc) FROM dual"
+    assert refactor_hexadecimal_chars(input_string2) == output_string2


### PR DESCRIPTION
 Updates the HexaDecimal characters in the string  as below:
 `( \x1b[4mWHERE\x1b[0m )` to  `( --> WHERE <-- )`
    