### PR TITLE
TSQL - Implement unary and binary expressions with correct precedence

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.1.0</version>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -87,6 +87,12 @@
       <version>3.3.0.0-alpha.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>4.1.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -1212,8 +1212,6 @@ IPV4_ADDR: DEC_DIGIT+ '.' DEC_DIGIT+ '.' DEC_DIGIT+ '.' DEC_DIGIT+;
 SPACE: [ \t\r\n]+ -> skip;
 // https://docs.microsoft.com/en-us/sql/t-sql/language-elements/slash-star-comment-transact-sql
 COMMENT      : '/*' (COMMENT | .)*? '*/' -> channel(HIDDEN);
-//TODO: In ANTLR v4 we cannot distinguish between 7 + ---42 amd  -- A comment. Needs custom char stream
-// ANTLR will match the longest sequence in the lexer rules and will always pick comment over uminus uminus
 LINE_COMMENT : '--' ~[\r\n]*             -> channel(HIDDEN);
 
 // TODO: ID can be not only Latin.

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -1212,6 +1212,8 @@ IPV4_ADDR: DEC_DIGIT+ '.' DEC_DIGIT+ '.' DEC_DIGIT+ '.' DEC_DIGIT+;
 SPACE: [ \t\r\n]+ -> skip;
 // https://docs.microsoft.com/en-us/sql/t-sql/language-elements/slash-star-comment-transact-sql
 COMMENT      : '/*' (COMMENT | .)*? '*/' -> channel(HIDDEN);
+//TODO: In ANTLR v4 we cannot distinguish between 7 + ---42 amd  -- A comment. Needs custom char stream
+// ANTLR will match the longest sequence in the lexer rules and will always pick comment over uminus uminus
 LINE_COMMENT : '--' ~[\r\n]*             -> channel(HIDDEN);
 
 // TODO: ID can be not only Latin.

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -5280,7 +5280,9 @@ constant
 primitive_constant
     : STRING // string, datetime or uniqueidentifier
     | HEX
-    | (INT | REAL | FLOAT)                    // float or decimal
+    | INT
+    | REAL
+    | FLOAT
     | DOLLAR (MINUS | PLUS)? (INT | FLOAT) // money
     | parameter
     ;

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -3892,17 +3892,20 @@ constant_LOCAL_ID
 // https://docs.microsoft.com/en-us/sql/t-sql/language-elements/expressions-transact-sql
 // Operator precendence: https://docs.microsoft.com/en-us/sql/t-sql/language-elements/operator-precedence-transact-sql
 expression
-    : primitive_expression #expr_primitive
+    : bracket_expression #expr_precedence
+    | <assoc=right> op=BIT_NOT expression #expr_bit_not
+    | <assoc=right> op=(PLUS | MINUS) expression #expr_unary
+    | expression op=(STAR | DIV | MOD) expression #expr_op_prec_1
+    | expression op=(PLUS | MINUS) expression #expr_op_prec_2
+    | expression op=(BIT_AND | BIT_XOR | BIT_OR) expression #expr_op_prec_3
+    | expression op=DOUBLE_BAR expression #expr_op_prec_4
+    | primitive_expression #expr_primitive
     | function_call #expr_func
     | expression DOT (value_call | query_call | exist_call | modify_call) #expr_dot
     | expression DOT hierarchyid_call #expr_hierarchyid
     | expression COLLATE id_ #expr_collate
     | case_expression #expr_case
     | full_column_name #expr_full_column
-    | bracket_expression #expr_precedence
-    | unary_operator_expression #expr_unary
-    | expression op = (STAR | DIV | MOD) expression #expr_op_prec_1
-    | expression op = (PLUS | MINUS | BIT_AND | BIT_XOR | BIT_OR | DOUBLE_BAR) expression #expr_op_prec_2
     | expression time_zone #expr_tz
     | over_clause #expr_over
     | DOLLAR_ACTION #expr_dollar
@@ -3927,11 +3930,6 @@ primitive_expression
 case_expression
     : CASE caseExpr = expression switch_section+ (ELSE elseExpr = expression)? END
     | CASE switch_search_condition_section+ (ELSE elseExpr = expression)? END
-    ;
-
-unary_operator_expression
-    : BIT_NOT expression
-    | op = (PLUS | MINUS) expression
     ;
 
 // TODO: This is likely incorrect! Precedence can probably be expressed directly in expression rule

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -54,14 +54,24 @@ case class UnresolvedOperator(unparsed_target: String) extends Expression {}
 
 // TODO: TSQL grammar has a number of operators not yet supported - add them here, if not already supported
 
-// Arithmetic expressions
+// Operators, in order of precedence
+
+// Bitwise NOT is highest precedence after parens '(' ')'
+case class BitwiseNot(expression: Expression) extends Unary(expression) {}
+
+// Unary arithmetic expressions
+case class UMinus(expression: Expression) extends Unary(expression) {}
+case class UPlus(expression: Expression) extends Unary(expression) {}
+
+// Binary Arithmetic expressions
 case class Multiply(left: Expression, right: Expression) extends Binary(left, right) {}
 case class Divide(left: Expression, right: Expression) extends Binary(left, right) {}
 case class Mod(left: Expression, right: Expression) extends Binary(left, right) {}
+
 case class Add(left: Expression, right: Expression) extends Binary(left, right) {}
 case class Subtract(left: Expression, right: Expression) extends Binary(left, right) {}
 
-// Binary bitwise expressions
+// Binary bitwise expressions and con
 case class BitwiseAnd(left: Expression, right: Expression) extends Binary(left, right) {}
 case class BitwiseOr(left: Expression, right: Expression) extends Binary(left, right) {}
 case class BitwiseXor(left: Expression, right: Expression) extends Binary(left, right) {}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -71,7 +71,7 @@ case class Mod(left: Expression, right: Expression) extends Binary(left, right) 
 case class Add(left: Expression, right: Expression) extends Binary(left, right) {}
 case class Subtract(left: Expression, right: Expression) extends Binary(left, right) {}
 
-// Binary bitwise expressions and con
+// Binary bitwise expressions
 case class BitwiseAnd(left: Expression, right: Expression) extends Binary(left, right) {}
 case class BitwiseOr(left: Expression, right: Expression) extends Binary(left, right) {}
 case class BitwiseXor(left: Expression, right: Expression) extends Binary(left, right) {}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -86,7 +86,6 @@ class TSqlExpressionBuilder
       case PLUS => ir.Add(left, right)
       case MINUS => ir.Subtract(left, right)
       case BIT_AND => ir.BitwiseAnd(left, right)
-      case BIT_NOT => ir.BitwiseAnd(left, right)
       case BIT_XOR => ir.BitwiseXor(left, right)
       case BIT_OR => ir.BitwiseOr(left, right)
       case DOUBLE_BAR => ir.Concat(left, right)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -27,11 +27,28 @@ class TSqlExpressionBuilder
     ctx.expression().accept(this)
   }
 
+  override def visitExpr_bit_not(ctx: Expr_bit_notContext): ir.Expression = {
+    ir.BitwiseNot(ctx.expression().accept(this))
+  }
+
+  override def visitExpr_unary(ctx: Expr_unaryContext): ir.Expression = ctx.op.getType() match {
+    case MINUS => ir.UMinus(ctx.expression().accept(this))
+    case PLUS => ir.UPlus(ctx.expression().accept(this))
+  }
+
   override def visitExpr_op_prec_1(ctx: Expr_op_prec_1Context): ir.Expression = {
     buildBinaryExpression(ctx.expression(0).accept(this), ctx.expression(1).accept(this), ctx.op)
   }
 
   override def visitExpr_op_prec_2(ctx: Expr_op_prec_2Context): ir.Expression = {
+    buildBinaryExpression(ctx.expression(0).accept(this), ctx.expression(1).accept(this), ctx.op)
+  }
+
+  override def visitExpr_op_prec_3(ctx: Expr_op_prec_3Context): ir.Expression = {
+    buildBinaryExpression(ctx.expression(0).accept(this), ctx.expression(1).accept(this), ctx.op)
+  }
+
+  override def visitExpr_op_prec_4(ctx: Expr_op_prec_4Context): ir.Expression = {
     buildBinaryExpression(ctx.expression(0).accept(this), ctx.expression(1).accept(this), ctx.op)
   }
 
@@ -66,6 +83,7 @@ class TSqlExpressionBuilder
       case PLUS => ir.Add(left, right)
       case MINUS => ir.Subtract(left, right)
       case BIT_AND => ir.BitwiseAnd(left, right)
+      case BIT_NOT => ir.BitwiseAnd(left, right)
       case BIT_XOR => ir.BitwiseXor(left, right)
       case BIT_OR => ir.BitwiseOr(left, right)
       case DOUBLE_BAR => ir.Concat(left, right)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -31,7 +31,10 @@ class TSqlExpressionBuilder
     ir.BitwiseNot(ctx.expression().accept(this))
   }
 
-  override def visitExpr_unary(ctx: Expr_unaryContext): ir.Expression = ctx.op.getType() match {
+  override def visitExpr_unary(ctx: Expr_unaryContext): ir.Expression = ctx.op.getType match {
+    // Note that while we could evaluate the unary expression if it is a numeric
+    // constant, it is usually better to be explicit about the unary operation as
+    // if people use -+-42 then maybe they have a reason.
     case MINUS => ir.UMinus(ctx.expression().accept(this))
     case PLUS => ir.UPlus(ctx.expression().accept(this))
   }
@@ -108,7 +111,6 @@ class TSqlExpressionBuilder
         ctx.predicate().accept(this)
       }
     }
-
   }
 
   override def visitPredicate(ctx: PredicateContext): ir.Expression = {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -100,6 +100,14 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
             Literal(integer = Some(7))),
           Literal(integer = Some(66))))
       example(
+        "1 + -2 * 3 + 7 + ~66",
+        _.expression(),
+        Add(
+          Add(
+            Add(Literal(integer = Some(1)), Multiply(UMinus(Literal(integer = Some(2))), Literal(integer = Some(3)))),
+            Literal(integer = Some(7))),
+          BitwiseNot(Literal(integer = Some(66)))))
+      example(
         "1 + -2 * 3 + 7 | 1980 || 'leeds1' || 'leeds2' || 'leeds3'",
         _.expression(),
         Concat(

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -62,5 +62,59 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
           Divide(Column("c"), Literal(integer = Some(5)))))
       example(query = "a || b || c", _.expression(), Concat(Concat(Column("a"), Column("b")), Column("c")))
     }
+    "correctly apply operator precedence and associativity" in {
+      example(
+        "1 + -++-2",
+        _.expression(),
+        Add(Literal(integer = Some(1)), UMinus(UPlus(UPlus(UMinus(Literal(integer = Some(2))))))))
+      example(
+        "1 + ~ 2 * 3",
+        _.expression(),
+        Add(Literal(integer = Some(1)), Multiply(BitwiseNot(Literal(integer = Some(2))), Literal(integer = Some(3)))))
+      example(
+        "1 + -2 * 3",
+        _.expression(),
+        Add(Literal(integer = Some(1)), Multiply(UMinus(Literal(integer = Some(2))), Literal(integer = Some(3)))))
+      example(
+        "1 + -2 * 3 + 7 & 66",
+        _.expression(),
+        BitwiseAnd(
+          Add(
+            Add(Literal(integer = Some(1)), Multiply(UMinus(Literal(integer = Some(2))), Literal(integer = Some(3)))),
+            Literal(integer = Some(7))),
+          Literal(integer = Some(66))))
+      example(
+        "1 + -2 * 3 + 7 ^ 66",
+        _.expression(),
+        BitwiseXor(
+          Add(
+            Add(Literal(integer = Some(1)), Multiply(UMinus(Literal(integer = Some(2))), Literal(integer = Some(3)))),
+            Literal(integer = Some(7))),
+          Literal(integer = Some(66))))
+      example(
+        "1 + -2 * 3 + 7 | 66",
+        _.expression(),
+        BitwiseOr(
+          Add(
+            Add(Literal(integer = Some(1)), Multiply(UMinus(Literal(integer = Some(2))), Literal(integer = Some(3)))),
+            Literal(integer = Some(7))),
+          Literal(integer = Some(66))))
+      example(
+        "1 + -2 * 3 + 7 | 1980 || 'leeds1' || 'leeds2' || 'leeds3'",
+        _.expression(),
+        Concat(
+          Concat(
+            Concat(
+              BitwiseOr(
+                Add(
+                  Add(
+                    Literal(integer = Some(1)),
+                    Multiply(UMinus(Literal(integer = Some(2))), Literal(integer = Some(3)))),
+                  Literal(integer = Some(7))),
+                Literal(integer = Some(1980))),
+              Literal(string = Some("leeds1"))),
+            Literal(string = Some("leeds2"))),
+          Literal(string = Some("leeds3"))))
+    }
   }
 }


### PR DESCRIPTION
Unary operators were not correctly implemented in the ANTLR grammar file, and this is now corrected. In addition, unary operators are right associative, which affects order of operations in certain case. Precedence has also been corrected to follow the TSQL normative specification. 

Progresses: #275 