### PR TITLE
Feature/upgrade sqlglot 23.0.1 to 23.13.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
   "databricks-sdk>=0.18.0",
-  "sqlglot==23.0.1",
+  "sqlglot==23.13.7",
   "databricks-labs-blueprint[yaml]>=0.2.3",
   "databricks-labs-lsql>=0.2.3",
 ]

--- a/src/databricks/labs/remorph/snow/databricks.py
+++ b/src/databricks/labs/remorph/snow/databricks.py
@@ -626,3 +626,20 @@ class Databricks(Databricks):  #
                 sql = f"UPDATE {this} SET {set_sql}{expression_sql}{order}{limit}"
 
             return self.prepend_ctes(expression, sql)
+
+        def struct_sql(self, expression: exp.Struct) -> str:
+            expression.set(
+                "expressions",
+                [
+                    (
+                        exp.alias_(
+                            e.expression, e.name if hasattr(e.this, "is_string") and e.this.is_string else e.this
+                        )
+                        if isinstance(e, exp.PropertyEQ)
+                        else e
+                    )
+                    for e in expression.expressions
+                ],
+            )
+
+            return self.function_fallback_sql(expression)

--- a/src/databricks/labs/remorph/snow/local_expression.py
+++ b/src/databricks/labs/remorph/snow/local_expression.py
@@ -130,6 +130,10 @@ class DateTrunc(Func):
     arg_types: ClassVar[dict] = {"unit": False, "this": True, "zone": False}
 
 
+class Median(Func):
+    arg_types: ClassVar[dict] = {"this": True}
+
+
 @dataclass
 class WithinGroupParams:
     agg_col: exp.Column

--- a/src/databricks/labs/remorph/snow/snowflake.py
+++ b/src/databricks/labs/remorph/snow/snowflake.py
@@ -366,6 +366,7 @@ class Snow(Snowflake):
             "TRUNC": lambda args: local_expression.DateTrunc(unit=seq_get(args, 1), this=seq_get(args, 0)),
             "APPROX_PERCENTILE": exp.ApproxQuantile.from_arg_list,
             "NTH_VALUE": local_expression.NthValue.from_arg_list,
+            "MEDIAN": local_expression.Median.from_arg_list,
         }
 
         FUNCTION_PARSERS: ClassVar[dict] = {

--- a/tests/resources/functional/snowflake/test_lateral_struct/test_lateral_struct_3.sql
+++ b/tests/resources/functional/snowflake/test_lateral_struct/test_lateral_struct_3.sql
@@ -1,19 +1,19 @@
 
 -- snowflake sql:
-SELECT d.value:display_position::NUMBER as item_card_impression_display_position,
-                                   i.value:impression_attributes::VARCHAR as item_card_impression_impression_attributes,
-                                   cast(current_timestamp() as timestamp_ntz(9)) as dwh_created_date_time_utc,
-                                   i.value:propensity::FLOAT as propensity,
+SELECT d.value:display_position::NUMBER as display_position,
+                                   i.value:attributes::VARCHAR as attributes,
+                                   cast(current_timestamp() as timestamp_ntz(9)) as created_at,
+                                   i.value:prop::FLOAT as prop,
                                    candidates
-                                 FROM dwh.vw_replacement_customer  d,
-                                 LATERAL FLATTEN (INPUT => d.item_card_impressions, OUTER => TRUE) i
-                                 WHERE event_date_pt = '{start_date}' and event_name in ('store.replacements_view');
+                                 FROM dwh.vw  d,
+                                 LATERAL FLATTEN (INPUT => d.impressions, OUTER => TRUE) i
+                                 WHERE event_date = '{start_date}' and event_name in ('store.replacements_view');
 
 -- databricks sql:
 SELECT
-                      CAST(d.value.display_position AS DECIMAL(38, 0)) AS item_card_impression_display_position,
-                      CAST(i.impression_attributes AS STRING) AS item_card_impression_impression_attributes,
-                      CAST(CURRENT_TIMESTAMP() AS TIMESTAMP_NTZ) AS dwh_created_date_time_utc,
-                      CAST(i.propensity AS DOUBLE) AS propensity, candidates
-               FROM dwh.vw_replacement_customer AS d LATERAL VIEW OUTER EXPLODE(d.item_card_impressions) AS i
-               WHERE event_date_pt = '{start_date}' AND event_name IN ('store.replacements_view');
+                      CAST(d.value.display_position AS DECIMAL(38, 0)) AS display_position,
+                      CAST(i.attributes AS STRING) AS attributes,
+                      CAST(CURRENT_TIMESTAMP() AS TIMESTAMP_NTZ) AS created_at,
+                      CAST(i.prop AS DOUBLE) AS prop, candidates
+               FROM dwh.vw AS d LATERAL VIEW OUTER EXPLODE(d.impressions) AS i
+               WHERE event_date = '{start_date}' AND event_name IN ('store.replacements_view');

--- a/tests/resources/functional/snowflake/test_lateral_struct/test_lateral_struct_3.sql
+++ b/tests/resources/functional/snowflake/test_lateral_struct/test_lateral_struct_3.sql
@@ -13,7 +13,7 @@ SELECT d.value:display_position::NUMBER as item_card_impression_display_position
 SELECT
                       CAST(d.value.display_position AS DECIMAL(38, 0)) AS item_card_impression_display_position,
                       CAST(i.impression_attributes AS STRING) AS item_card_impression_impression_attributes,
-                      CAST(CURRENT_TIMESTAMP() AS TIMESTAMP) AS dwh_created_date_time_utc,
+                      CAST(CURRENT_TIMESTAMP() AS TIMESTAMP_NTZ) AS dwh_created_date_time_utc,
                       CAST(i.propensity AS DOUBLE) AS propensity, candidates
                FROM dwh.vw_replacement_customer AS d LATERAL VIEW OUTER EXPLODE(d.item_card_impressions) AS i
                WHERE event_date_pt = '{start_date}' AND event_name IN ('store.replacements_view');


### PR DESCRIPTION
* Latest SQLGLOT supports  Snowflake TIMESTAMP_NTZ
* struct_sql is an override function from the base generator class. `hasattr(e.this, "is_string") and` snippet is only added in override function.
* Added Median class in local_expressions to support median function.