### PR TITLE
Custom oracle tokenizer

### DIFF
--- a/src/databricks/labs/remorph/config.py
+++ b/src/databricks/labs/remorph/config.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from sqlglot.dialects.dialect import Dialect, Dialects
 
 from databricks.labs.remorph.reconcile.recon_config import Table
-from databricks.labs.remorph.snow import databricks, experimental, snowflake
+from databricks.labs.remorph.snow import databricks, experimental, oracle, snowflake
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ SQLGLOT_DIALECTS = {
     "drill": Dialects.DRILL,
     "mssql": Dialects.TSQL,
     "netezza": Dialects.POSTGRES,
-    "oracle": Dialects.ORACLE,
+    "oracle": oracle.Oracle,
     "postgresql": Dialects.POSTGRES,
     "presto": Dialects.PRESTO,
     "redshift": Dialects.REDSHIFT,

--- a/src/databricks/labs/remorph/snow/oracle.py
+++ b/src/databricks/labs/remorph/snow/oracle.py
@@ -1,0 +1,12 @@
+from typing import ClassVar
+
+from sqlglot.dialects.oracle import Oracle as Orc
+from sqlglot.tokens import TokenType
+
+
+class Oracle(Orc):
+    # Instantiate Snowflake Dialect
+    oracle = Orc()
+
+    class Tokenizer(oracle.Tokenizer):
+        KEYWORDS: ClassVar[dict] = {**Orc.Tokenizer.KEYWORDS, 'LONG': TokenType.TEXT}

--- a/src/databricks/labs/remorph/snow/oracle.py
+++ b/src/databricks/labs/remorph/snow/oracle.py
@@ -5,7 +5,7 @@ from sqlglot.tokens import TokenType
 
 
 class Oracle(Orc):
-    # Instantiate Snowflake Dialect
+    # Instantiate Oracle Dialect
     oracle = Orc()
 
     class Tokenizer(oracle.Tokenizer):

--- a/tests/resources/functional/oracle/test_long_datatype/test_long_datatype_1.sql
+++ b/tests/resources/functional/oracle/test_long_datatype/test_long_datatype_1.sql
@@ -1,0 +1,6 @@
+
+-- oracle sql:
+SELECT cast(col1 as long) AS col1 FROM dual;
+
+-- databricks sql:
+SELECT CAST(COL1 AS STRING) AS COL1 FROM DUAL;

--- a/tests/unit/snow/test_oracle.py
+++ b/tests/unit/snow/test_oracle.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+import pytest
+
+from ..conftest import FunctionalTestFile, get_functional_test_files_from_directory
+
+path = Path(__file__).parent / Path('../../resources/functional/oracle/')
+functional_tests = get_functional_test_files_from_directory(path, "oracle", "databricks", False)
+test_names = [f.test_name for f in functional_tests]
+
+
+@pytest.mark.parametrize("sample", functional_tests, ids=test_names)
+def test_databricks(dialect_context, sample: FunctionalTestFile):
+    validate_source_transpile, _ = dialect_context
+    validate_source_transpile(databricks_sql=sample.databricks_sql, source={"oracle": sample.source})


### PR DESCRIPTION
* In the Oracle database, the long datatype can be used for character data as well. Therefore, we are mapping the long datatype to text (string) in the tokenizer. 
* We have only overridden the tokenizer because it is sufficient for handling the long datatype at present.