### PR TITLE
Created verify_workspace_client func to handle product info

### DIFF
--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -2,6 +2,7 @@ import logging
 import os
 from pathlib import Path
 
+from databricks.labs.remorph.__about__ import __version__
 from databricks.labs.remorph.config import MorphConfig
 from databricks.labs.remorph.helpers import db_sql
 from databricks.labs.remorph.helpers.execution_time import timeit
@@ -198,3 +199,12 @@ def morph(workspace_client: WorkspaceClient, config: MorphConfig):
         }
     )
     return status
+
+
+def verify_workspace_client(workspace_client: WorkspaceClient) -> WorkspaceClient:
+    # pylint: disable=protected-access
+    if workspace_client.config._product != "remorph":
+        workspace_client.config._product = "remorph"
+    if workspace_client.config._product_version != __version__:
+        workspace_client.config._product_version = __version__
+    return workspace_client

--- a/tests/unit/transpiler/test_execute.py
+++ b/tests/unit/transpiler/test_execute.py
@@ -7,10 +7,11 @@ import pytest
 
 from databricks.connect import DatabricksSession
 from databricks.labs.lsql.backends import MockBackend
+from databricks.labs.remorph.__about__ import __version__
 from databricks.labs.remorph.config import MorphConfig
 from databricks.labs.remorph.helpers.file_utils import make_dir
 from databricks.labs.remorph.helpers.validation import Validator
-from databricks.labs.remorph.transpiler.execute import morph
+from databricks.labs.remorph.transpiler.execute import morph, verify_workspace_client
 from databricks.sdk.core import Config
 
 # pylint: disable=unspecified-encoding
@@ -380,3 +381,19 @@ def test_with_not_existing_file_skip_validation(initial_setup, mock_workspace_cl
 
     # cleanup
     safe_remove_dir(input_dir)
+
+
+def test_verify_workspace_client(mock_workspace_client):
+    # pylint: disable=protected-access
+    # True condition
+    workspace_client = verify_workspace_client(mock_workspace_client)
+    assert workspace_client.config._product == "remorph"
+    assert workspace_client.config._product_version == __version__
+
+    # False condition
+    workspace_client = mock_workspace_client
+    workspace_client.config._product = "remorph"
+    workspace_client.config._product_version = __version__
+    workspace_client = verify_workspace_client(workspace_client)
+    assert workspace_client.config._product == "remorph"
+    assert workspace_client.config._product_version == __version__


### PR DESCRIPTION
* For incoming workspace_client for the future user functions. We are checking and setting up proper product and product_version for telemetric data. 
* We had to use ` # pylint: disable=protected-access` since we are accessing _product and _product_version params in WorkspaceClient.