### PR TITLE
Fixed orcale missing datatypes

### DIFF
--- a/src/databricks/labs/remorph/snow/oracle.py
+++ b/src/databricks/labs/remorph/snow/oracle.py
@@ -9,4 +9,17 @@ class Oracle(Orc):
     oracle = Orc()
 
     class Tokenizer(oracle.Tokenizer):
-        KEYWORDS: ClassVar[dict] = {**Orc.Tokenizer.KEYWORDS, 'LONG': TokenType.TEXT}
+        KEYWORDS: ClassVar[dict] = {
+            **Orc.Tokenizer.KEYWORDS,
+            'LONG': TokenType.TEXT,
+            'NCLOB': TokenType.TEXT,
+            'ROWID': TokenType.TEXT,
+            'UROWID': TokenType.TEXT,
+            'ANYTYPE': TokenType.TEXT,
+            'ANYDATA': TokenType.TEXT,
+            'ANYDATASET': TokenType.TEXT,
+            'XMLTYPE': TokenType.TEXT,
+            'SDO_GEOMETRY': TokenType.TEXT,
+            'SDO_TOPO_GEOMETRY': TokenType.TEXT,
+            'SDO_GEORASTER': TokenType.TEXT,
+        }

--- a/tests/unit/reconcile/test_schema_compare.py
+++ b/tests/unit/reconcile/test_schema_compare.py
@@ -246,10 +246,10 @@ def test_oracle_schema_compare(schemas, mock_spark_session):
     )
     df = schema_compare_output.compare_df
 
-    assert not schema_compare_output.is_valid
+    assert schema_compare_output.is_valid
     assert df.count() == 26
-    assert df.filter("is_valid = 'true'").count() == 19
-    assert df.filter("is_valid = 'false'").count() == 7
+    assert df.filter("is_valid = 'true'").count() == 26
+    assert df.filter("is_valid = 'false'").count() == 0
 
 
 def test_schema_compare(mock_spark_session):


### PR DESCRIPTION
* After analysis, it is identified that for creating Tokenizer KEYWORDS mapping, we don't need Tokens for keys, So we made appropriate changes, and now we support all Oracle datatypes.