### PR TITLE
TSQL -Creates new context aware walkers for tracking column references

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -1176,6 +1176,8 @@ TZOFFSET    : 'TZOFFSET';
 ISO_WEEK    : 'ISO_WEEK';
 WEEKDAY     : 'WEEKDAY';
 
+
+// TODO: These are all broken and prevent valid identifiers from working - FIX
 YEAR_ABBR        : 'yy' | 'yyyy';
 QUARTER_ABBR     : 'qq' | 'q';
 MONTH_ABBR       : 'mm' | 'm';

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -3892,29 +3892,28 @@ constant_LOCAL_ID
 // https://docs.microsoft.com/en-us/sql/t-sql/language-elements/expressions-transact-sql
 // Operator precendence: https://docs.microsoft.com/en-us/sql/t-sql/language-elements/operator-precedence-transact-sql
 expression
-    : LPAREN expression RPAREN                                  #expr_precedence
-    | <assoc=right> op=BIT_NOT expression                       #expr_bit_not
-    | <assoc=right> op=(PLUS | MINUS) expression                #expr_unary
-    | expression op=(STAR | DIV | MOD) expression               #expr_op_prec_1
-    | expression op=(PLUS | MINUS) expression                   #expr_op_prec_2
-    | expression op=(BIT_AND | BIT_XOR | BIT_OR) expression     #expr_op_prec_3
-    | expression op=DOUBLE_BAR expression                       #expr_op_prec_4
-    | primitive_expression                                      #expr_primitive
-    | function_call                                             #expr_func
-    | expression COLLATE id_                                    #expr_collate
-    | case_expression                                           #expr_case
-    | expression time_zone                                      #expr_tz
-    | over_clause                                               #expr_over
-    | hierarchyid_call                                          #exprHierarchyId
-    | value_call                                                #exprValue
-    | query_call                                                #expryQuery
-    | exist_call                                                #exprExist
-    | modify_call                                               #exprModiy
-    | id_                                                       #expr_id
-    | DOLLAR_ACTION                                             #expr_dollar
+    : LPAREN expression RPAREN                                  #exprPrecedence
+    | <assoc=right> op=BIT_NOT expression                       #exprBitNot
+    | <assoc=right> op=(PLUS | MINUS) expression                #exprUnary
+    | expression op=(STAR | DIV | MOD) expression               #exprOpPrec1
+    | expression op=(PLUS | MINUS) expression                   #exprOpPrec2
+    | expression op=(BIT_AND | BIT_XOR | BIT_OR) expression     #exprOpPrec3
+    | expression op=DOUBLE_BAR expression                       #exprOpPrec4
+    | primitiveExpression                                       #exprPrimitive
+    | functionCall                                              #exprFunc
+    | expression COLLATE id_                                    #exprCollate
+    | caseExpression                                            #exprCase
+    | expression timeZone                                       #exprTimeZone
+    | overClause                                                #exprOver
+    | hierarchyidCall                                           #exprHierarchyId
+    | valueCall                                                 #exprValue
+    | queryCall                                                 #expryQuery
+    | existCall                                                 #exprExist
+    | modifyCall                                                #exprModiy
+    | id_                                                       #exprId
+    | DOLLAR_ACTION                                             #exprDollar
     | <assoc=right> expression DOT expression                   #exprDot
-    | LPAREN subquery RPAREN                                    #expr_subquery
-    | over_clause                                               #expr_over
+    | LPAREN subquery RPAREN                                    #exprSubquery
     ;
 
 parameter

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -5155,7 +5155,7 @@ ddlObject
 
 fullColumnName
     : ((DELETED | INSERTED | fullTableName) DOT)? (
-        columnName = id_
+          id_
         | (DOLLAR (IDENTITY | ROWGUID))
     )
     ;

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -3892,24 +3892,29 @@ constant_LOCAL_ID
 // https://docs.microsoft.com/en-us/sql/t-sql/language-elements/expressions-transact-sql
 // Operator precendence: https://docs.microsoft.com/en-us/sql/t-sql/language-elements/operator-precedence-transact-sql
 expression
-    : LPAREN expression RPAREN #exprPrecedence
-    | <assoc=right> op=BIT_NOT expression #exprBitNot
-    | <assoc=right> op=(PLUS | MINUS) expression #exprUnary
-    | expression op=(STAR | DIV | MOD) expression #exprOpPrec1
-    | expression op=(PLUS | MINUS) expression #exprOpPrec2
-    | expression op=(BIT_AND | BIT_XOR | BIT_OR) expression #exprOpPrec3
-    | expression op=DOUBLE_BAR expression #exprOpPrec4
-    | primitiveExpression #exprPrimitive
-    | functionCall #exprFunc
-    | expression DOT (valueCall | queryCall | existCall | modifyCall) #exprDot
-    | expression DOT hierarchyidCall #exprHierarchyid
-    | expression COLLATE id_ #exprCollate
-    | caseExpression #exprCase
-    | fullColumnName #exprFullColumn
-    | expression timeZone #exprTz
-    | overClause #exprOver
-    | DOLLAR_ACTION #exprDollar
-    | LPAREN subquery RPAREN #exprSubquery
+    : LPAREN expression RPAREN                                  #expr_precedence
+    | <assoc=right> op=BIT_NOT expression                       #expr_bit_not
+    | <assoc=right> op=(PLUS | MINUS) expression                #expr_unary
+    | expression op=(STAR | DIV | MOD) expression               #expr_op_prec_1
+    | expression op=(PLUS | MINUS) expression                   #expr_op_prec_2
+    | expression op=(BIT_AND | BIT_XOR | BIT_OR) expression     #expr_op_prec_3
+    | expression op=DOUBLE_BAR expression                       #expr_op_prec_4
+    | primitive_expression                                      #expr_primitive
+    | function_call                                             #expr_func
+    | expression COLLATE id_                                    #expr_collate
+    | case_expression                                           #expr_case
+    | expression time_zone                                      #expr_tz
+    | over_clause                                               #expr_over
+    | hierarchyid_call                                          #exprHierarchyId
+    | value_call                                                #exprValue
+    | query_call                                                #expryQuery
+    | exist_call                                                #exprExist
+    | modify_call                                               #exprModiy
+    | id_                                                       #expr_id
+    | DOLLAR_ACTION                                             #expr_dollar
+    | <assoc=right> expression DOT expression                   #exprDot
+    | LPAREN subquery RPAREN                                    #expr_subquery
+    | over_clause                                               #expr_over
     ;
 
 parameter
@@ -6259,7 +6264,7 @@ id_
     : ID
     | TEMP_ID
     | DOUBLE_QUOTE_ID
-    | DOUBLE_QUOTE_BLANK
+    | DOUBLE_QUOTE_BLANK // TODO: This is silly I think - remove
     | SQUARE_BRACKET_ID
     | keyword
     | RAW

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -2,14 +2,7 @@ package com.databricks.labs.remorph.parsers.intermediate
 
 trait AstExtension
 
-case class Table(
-    name: String,
-    linkedServer: Option[String] = None,
-    database: Option[String] = None,
-    schema: Option[String] = None)
-    extends Expression
-    with AstExtension {}
-case class Column(name: String, table: Option[Table] = None) extends Expression with AstExtension {}
+case class Column(name: String) extends Expression with AstExtension {}
 
 case class Identifier(name: String, isQuoted: Boolean) extends Expression with AstExtension {}
 
@@ -18,7 +11,6 @@ abstract class Binary(left: Expression, right: Expression) extends Expression {}
 
 trait Predicate extends AstExtension
 
-case class Precedence(expression: Expression) extends Expression {}
 case class And(left: Expression, right: Expression) extends Binary(left, right) with Predicate {}
 case class Or(left: Expression, right: Expression) extends Binary(left, right) with Predicate {}
 case class Not(pred: Expression) extends Unary(pred) with Predicate {}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -3,6 +3,14 @@ package com.databricks.labs.remorph.parsers.intermediate
 trait AstExtension
 
 case class Column(name: String) extends Expression with AstExtension {}
+case class TSqlColumn(
+    database: Option[String] = None,
+    schema: Option[String] = None,
+    table: Option[String] = None,
+    name: String)
+    extends Expression
+    with AstExtension {}
+case class Identifier(name: String, isQuoted: Boolean) extends Expression with AstExtension {}
 
 abstract class Unary(pred: Expression) extends Expression {}
 abstract class Binary(left: Expression, right: Expression) extends Expression {}
@@ -138,3 +146,5 @@ case class RenameConstraint(oldName: String, newName: String) extends TableAlter
 case class RenameColumn(oldName: String, newName: String) extends TableAlteration
 
 case class AlterTableCommand(tableName: String, alterations: Seq[TableAlteration]) extends Catalog {}
+
+case class Dot(left: Expression, right: Expression) extends Binary(left, right) {}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -2,14 +2,15 @@ package com.databricks.labs.remorph.parsers.intermediate
 
 trait AstExtension
 
-case class Column(name: String) extends Expression with AstExtension {}
-case class TSqlColumn(
+case class Table(
+    name: String,
+    linkedServer: Option[String] = None,
     database: Option[String] = None,
-    schema: Option[String] = None,
-    table: Option[String] = None,
-    name: String)
+    schema: Option[String] = None)
     extends Expression
     with AstExtension {}
+case class Column(name: String, table: Option[Table] = None) extends Expression with AstExtension {}
+
 case class Identifier(name: String, isQuoted: Boolean) extends Expression with AstExtension {}
 
 abstract class Unary(pred: Expression) extends Expression {}
@@ -147,4 +148,7 @@ case class RenameColumn(oldName: String, newName: String) extends TableAlteratio
 
 case class AlterTableCommand(tableName: String, alterations: Seq[TableAlteration]) extends Catalog {}
 
+// Used for raw expressions that have no context
 case class Dot(left: Expression, right: Expression) extends Binary(left, right) {}
+
+case class ExpressionList(expressions: Seq[Expression]) extends Expression {}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -33,6 +33,7 @@ class SnowflakeExpressionBuilder
       ir.Alias(input, Seq(alias), None)
     }
   override def visitColumn_name(ctx: Column_nameContext): ir.Expression = {
+    // TODO: Build table as per TSQl
     ir.Column(ctx.id_(0).getText)
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
@@ -50,7 +50,7 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] w
       projectExpressions: Seq[ir.Expression]): ir.Relation =
     if (Option(ctx).exists(_.DISTINCT() != null)) {
       val columnNames = projectExpressions.collect {
-        case ir.Column(c) => Seq(c)
+        case ir.Column(c, _) => Seq(c)
         case ir.Alias(_, a, _) => a
       }.flatten
       ir.Deduplicate(input, columnNames, all_columns_as_keys = columnNames.isEmpty, within_watermark = false)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
@@ -50,7 +50,7 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] w
       projectExpressions: Seq[ir.Expression]): ir.Relation =
     if (Option(ctx).exists(_.DISTINCT() != null)) {
       val columnNames = projectExpressions.collect {
-        case ir.Column(c, _) => Seq(c)
+        case ir.Column(c) => Seq(c)
         case ir.Alias(_, a, _) => a
       }.flatten
       ir.Deduplicate(input, columnNames, all_columns_as_keys = columnNames.isEmpty, within_watermark = false)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilder.scala
@@ -3,8 +3,6 @@ package com.databricks.labs.remorph.parsers.tsql
 import com.databricks.labs.remorph.parsers.tsql.TSqlParser.SelectStatementStandaloneContext
 import com.databricks.labs.remorph.parsers.{intermediate => ir}
 
-import scala.collection.JavaConverters._
-
 /**
  * @see
  *   org.apache.spark.sql.catalyst.parser.AstBuilder
@@ -13,7 +11,8 @@ class TSqlAstBuilder extends TSqlParserBaseVisitor[ir.TreeNode] {
 
   // When a node has multiple children, this method is called to aggregate the results and returns
   // the IR that represents the node as a whole.
-  // TODO: JI: This is probably because the grammar is poorly designed. I will get to that later
+  // TODO: JI: Because some elements create nodes with multiple children, we need to aggregate them here.
+  // In this case it is coming from visiting Batch etc and not doing anything with them
   override protected def aggregateResult(aggregate: ir.TreeNode, nextResult: ir.TreeNode): ir.TreeNode = {
     if (nextResult == null) {
       aggregate
@@ -22,17 +21,11 @@ class TSqlAstBuilder extends TSqlParserBaseVisitor[ir.TreeNode] {
     }
   }
 
-  override def visitSelectStatementStandalone(ctx: SelectStatementStandaloneContext): ir.TreeNode = {
-    val rawExpression = ctx.selectStatement().queryExpression().querySpecification()
-    val columnExpression = rawExpression
-      .selectList()
-      .selectListElem()
-      .asScala
-      .map(_.accept(new TSqlExpressionBuilder))
-
-    // [TODO]: Handle Where, Group By, Having, Order By, Limit, Offset
-    val tableSources = Option(rawExpression.tableSources())
-      .fold[ir.Relation](ir.NoTable())(_.accept(new TSqlRelationBuilder))
-    ir.Project(tableSources, columnExpression)
-  }
+  /**
+   * Build a complete AST for a select statement using a dedicated visitor.
+   * @param ctx
+   *   the parse tree
+   */
+  override def visitSelectStatementStandalone(ctx: SelectStatementStandaloneContext): ir.TreeNode =
+    ctx.accept(new TSqlSelectBuilder)
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlColumnBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlColumnBuilder.scala
@@ -16,7 +16,6 @@ class TSqlColumnBuilder extends TSqlExpressionBuilder {
     val right = ctx.expression(1).accept(this)
 
     (left, right) match {
-
       // x.y
       case (c1: ir.Column, c2: ir.Column) =>
         ir.Column(c1.name + "." + c2.name)
@@ -33,14 +32,7 @@ class TSqlColumnBuilder extends TSqlExpressionBuilder {
    * @return
    *   the visited Column object
    */
-  override def visitId_(ctx: Id_Context): ir.Expression = ctx match {
-    case c if c.ID() != null => ir.Column(ctx.getText)
-    case c if c.TEMP_ID() != null => ir.Column(ctx.getText)
-    case c if c.DOUBLE_QUOTE_ID() != null => ir.Column(ctx.getText)
-    case c if c.SQUARE_BRACKET_ID() != null => ir.Column(ctx.getText)
-    case c if c.RAW() != null => ir.Column(ctx.getText)
-    case _ => ir.UnresolvedExpression(ctx.getText)
-  }
+  override def visitId_(ctx: Id_Context): ir.Expression = ir.Column(ctx.getText)
 
   override def visitSelectList(ctx: TSqlParser.SelectListContext): ir.Expression =
     ir.ExpressionList(ctx.selectListElem().asScala.toList.map(_.accept(this)))

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlColumnBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlColumnBuilder.scala
@@ -1,0 +1,116 @@
+package com.databricks.labs.remorph.parsers.tsql
+
+import com.databricks.labs.remorph.parsers.tsql.TSqlParser._
+import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import org.antlr.v4.runtime.Token
+import org.antlr.v4.runtime.tree.TerminalNode
+
+import scala.collection.JavaConverters.asScalaBufferConverter
+
+/**
+ * This class is responsible for building a Column object from various components of a TSql AST. It is used where the
+ * context of the AST is a Full_column_nameContext.
+ */
+class TSqlColumnBuilder extends TSqlExpressionBuilder {
+
+  override def visitFullColumnName(ctx: FullColumnNameContext): ir.Column = ctx.fullTableName.accept(this) match {
+    case table: ir.Table => ir.Column(ctx.id_.getText, Some(table))
+    case _ => ir.Column(ctx.id_.getText)
+  }
+
+  override def visitFullTableName(ctx: FullTableNameContext): ir.Table = {
+    ir.Table(
+      linkedServer = if (ctx.linkedServer == null) None else Option(ctx.linkedServer.getText),
+      database = if (ctx.database == null) None else Option(ctx.database.getText),
+      schema = if (ctx.schema == null) None else Option(ctx.schema.getText),
+      name = ctx.table.getText)
+  }
+
+  override def visitExprDot(ctx: ExprDotContext): ir.Column = {
+    val left = ctx.expression(0).accept(this)
+    val right = ctx.expression(1).accept(this)
+
+    (left, right) match {
+
+      // x.y
+      case (table: ir.Column, column: ir.Column) =>
+        ir.Column(column.name, Some(ir.Table(table.name)))
+      case _ => throw new IllegalArgumentException("Expected a Table and a Column")
+    }
+  }
+
+  /**
+   * This method is used to build components of a column reference from a TerminalNode. The Result is used higher up the
+   * parse tree to construct a column reference.
+   *
+   * @param ctx
+   *   the Id context to visit
+   * @return
+   *   the visited Column object
+   */
+  override def visitId_(ctx: Id_Context): ir.Expression = ctx match {
+    case c if c.ID() != null => ir.Column(ctx.getText)
+    case c if c.TEMP_ID() != null => ir.Column(ctx.getText)
+    case c if c.DOUBLE_QUOTE_ID() != null => ir.Column(ctx.getText)
+    case c if c.SQUARE_BRACKET_ID() != null => ir.Column(ctx.getText)
+    case c if c.RAW() != null => ir.Column(ctx.getText)
+    case _ => ir.UnresolvedExpression(ctx.getText)
+  }
+
+  override def visitSelectList(ctx: TSqlParser.SelectListContext): ir.Expression =
+    ir.ExpressionList(ctx.selectListElem().asScala.toList.map(_.accept(this)))
+
+  // TODO: A lot of work here for things that are not just simple x.y.z
+  override def visitSelectListElem(ctx: TSqlParser.SelectListElemContext): ir.Expression =
+    ctx.expressionElem.accept(this)
+
+  override def visitPrimitiveConstant(ctx: TSqlParser.PrimitiveConstantContext): ir.Expression = {
+    if (ctx.DOLLAR != null) {
+      return ir.Literal(string = Some(ctx.getText))
+    }
+    buildConstant(ctx.con)
+  }
+
+  override def visitTerminal(node: TerminalNode): ir.Expression = buildConstant(node.getSymbol)
+
+  private def removeQuotes(str: String): String = {
+    str.stripPrefix("'").stripSuffix("'")
+  }
+
+  private def buildConstant(con: Token): ir.Expression = con.getType match {
+    case c if c == STRING => ir.Literal(string = Some(removeQuotes(con.getText)))
+    case c if c == INT => ir.Literal(integer = Some(con.getText.toInt))
+    case c if c == FLOAT => ir.Literal(float = Some(con.getText.toFloat))
+    case c if c == HEX => ir.Literal(string = Some(con.getText)) // Preserve format for now
+    case c if c == REAL => ir.Literal(double = Some(con.getText.toDouble))
+    case c if c == NULL_ => ir.Literal(nullType = Some(ir.NullType()))
+    case _ => ir.UnresolvedExpression(con.getText)
+  }
+
+  override def visitScNot(ctx: TSqlParser.ScNotContext): ir.Expression =
+    ir.Not(ctx.searchCondition().accept(this))
+
+  override def visitScAnd(ctx: TSqlParser.ScAndContext): ir.Expression =
+    ir.And(ctx.searchCondition(0).accept(this), ctx.searchCondition(1).accept(this))
+
+  override def visitScOr(ctx: TSqlParser.ScOrContext): ir.Expression =
+    ir.Or(ctx.searchCondition(0).accept(this), ctx.searchCondition(1).accept(this))
+
+  override def visitScPred(ctx: TSqlParser.ScPredContext): ir.Expression = ctx.predicate().accept(this)
+
+  override def visitScPrec(ctx: TSqlParser.ScPrecContext): ir.Expression = ctx.searchCondition.accept(this)
+
+  override def visitPredicate(ctx: TSqlParser.PredicateContext): ir.Expression = {
+    val left = ctx.expression(0).accept(new TSqlColumnBuilder).asInstanceOf[ir.Expression]
+    val right = ctx.expression(1).accept(new TSqlColumnBuilder).asInstanceOf[ir.Expression]
+
+    ctx.comparisonOperator match {
+      case op if op.LT != null && op.EQ != null => ir.LesserThanOrEqual(left, right)
+      case op if op.GT != null && op.EQ != null => ir.GreaterThanOrEqual(left, right)
+      case op if op.LT != null && op.GT != null => ir.NotEquals(left, right)
+      case op if op.EQ != null => ir.Equals(left, right)
+      case op if op.GT != null => ir.GreaterThan(left, right)
+      case op if op.LT != null => ir.LesserThan(left, right)
+    }
+  }
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -3,7 +3,7 @@ package com.databricks.labs.remorph.parsers.tsql
 import org.antlr.v4.runtime.Token
 import org.antlr.v4.runtime.tree.TerminalNode
 
-import com.databricks.labs.remorph.parsers.intermediate.{Column, Literal}
+import com.databricks.labs.remorph.parsers.intermediate.{Column, Literal, Identifier}
 import com.databricks.labs.remorph.parsers.tsql.TSqlParser._
 import com.databricks.labs.remorph.parsers.{IncompleteParser, ParserCommon, intermediate => ir}
 
@@ -67,12 +67,28 @@ class TSqlExpressionBuilder
   }
 
   override def visitPrimitiveConstant(ctx: PrimitiveConstantContext): ir.Expression = ctx match {
+  override def visitExprDot(ctx: ExprDotContext): ir.Expression = {
+    val left = ctx.expression(0).accept(this)
+    val right = ctx.expression(1).accept(this)
+    ir.Dot(left, right)
+  }
+
+  override def visitPrimitive_constant(ctx: Primitive_constantContext): ir.Expression = ctx match {
     case c if c.DOLLAR() != null => wrapUnresolvedInput(ctx.getText)
     case c if c.STRING() != null => c.STRING().accept(this)
     case c if c.INT() != null => c.INT().accept(this)
     case c if c.FLOAT() != null => c.FLOAT().accept(this)
     case c if c.HEX() != null => c.HEX().accept(this)
     case c if c.REAL() != null => c.REAL().accept(this)
+  }
+
+  override def visitId_(ctx: Id_Context): ir.Expression = ctx match {
+    case c if c.ID() != null => Identifier(ctx.getText, isQuoted = false)
+    case c if c.TEMP_ID() != null => Identifier(ctx.getText, isQuoted = false)
+    case c if c.DOUBLE_QUOTE_ID() != null => Identifier(ctx.getText, isQuoted = true)
+    case c if c.SQUARE_BRACKET_ID() != null => Identifier(ctx.getText, isQuoted = true)
+    case c if c.RAW() != null => Identifier(ctx.getText, isQuoted = false)
+    case _ => Identifier(ctx.getText, isQuoted = false)
   }
 
   override def visitTerminal(node: TerminalNode): ir.Expression = node.getSymbol.getType match {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -2,23 +2,11 @@ package com.databricks.labs.remorph.parsers.tsql
 
 import com.databricks.labs.remorph.parsers.intermediate.Identifier
 import com.databricks.labs.remorph.parsers.tsql.TSqlParser._
-import com.databricks.labs.remorph.parsers.{IncompleteParser, ParserCommon, intermediate => ir}
+import com.databricks.labs.remorph.parsers.{ParserCommon, intermediate => ir}
 import org.antlr.v4.runtime.Token
 import org.antlr.v4.runtime.tree.TerminalNode
 
-class TSqlExpressionBuilder
-    extends TSqlParserBaseVisitor[ir.Expression]
-    with ParserCommon
-    with IncompleteParser[ir.Expression] {
-
-  protected override def wrapUnresolvedInput(unparsedInput: String): ir.UnresolvedExpression =
-    ir.UnresolvedExpression(unparsedInput)
-
-//  override def visitFullColumnName(ctx: FullColumnNameContext): ir.Expression =
-//    ctx.accept(new TSqlColumnBuilder) match {
-//      case c: ir.Column => c
-//      case c => wrapUnresolvedInput(ctx.getText)
-//    }
+class TSqlExpressionBuilder extends TSqlParserBaseVisitor[ir.Expression] with ParserCommon {
 
   /**
    * Expression precedence as defined by parenthesis
@@ -85,7 +73,6 @@ class TSqlExpressionBuilder
     case c if c == HEX => ir.Literal(string = Some(con.getText)) // Preserve format for now
     case c if c == REAL => ir.Literal(double = Some(con.getText.toDouble))
     case c if c == NULL_ => ir.Literal(nullType = Some(ir.NullType()))
-    case _ => ir.UnresolvedExpression(con.getText)
   }
 
   override def visitId_(ctx: Id_Context): ir.Expression = ctx match {
@@ -114,7 +101,5 @@ class TSqlExpressionBuilder
       case BIT_XOR => ir.BitwiseXor(left, right)
       case BIT_OR => ir.BitwiseOr(left, right)
       case DOUBLE_BAR => ir.Concat(left, right)
-      case _ => ir.UnresolvedOperator(s"Unsupported operator: ${operator.getText}")
     }
-
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -50,6 +50,7 @@ class TSqlExpressionBuilder
     case MINUS => ir.UMinus(ctx.expression().accept(this))
     case PLUS => ir.UPlus(ctx.expression().accept(this))
   }
+
   override def visitExprOpPrec1(ctx: ExprOpPrec1Context): ir.Expression = {
     buildBinaryExpression(ctx.expression(0).accept(this), ctx.expression(1).accept(this), ctx.op)
   }
@@ -66,14 +67,13 @@ class TSqlExpressionBuilder
     buildBinaryExpression(ctx.expression(0).accept(this), ctx.expression(1).accept(this), ctx.op)
   }
 
-  override def visitPrimitiveConstant(ctx: PrimitiveConstantContext): ir.Expression = ctx match {
   override def visitExprDot(ctx: ExprDotContext): ir.Expression = {
     val left = ctx.expression(0).accept(this)
     val right = ctx.expression(1).accept(this)
     ir.Dot(left, right)
   }
 
-  override def visitPrimitive_constant(ctx: Primitive_constantContext): ir.Expression = ctx match {
+  override def visitPrimitiveConstant(ctx: PrimitiveConstantContext): ir.Expression = ctx match {
     case c if c.DOLLAR() != null => wrapUnresolvedInput(ctx.getText)
     case c if c.STRING() != null => c.STRING().accept(this)
     case c if c.INT() != null => c.INT().accept(this)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -15,6 +15,28 @@ class TSqlRelationBuilder extends TSqlParserBaseVisitor[ir.Relation] with Incomp
     ir.NamedTable(table, Map.empty, is_streaming = false)
   }
 
+  /**
+   * Note that SELECT a, b, c FROM x, y, z is equivalent to SELECT a, b, c FROM x CROSS JOIN y CROSS JOIN z
+   * @param ctx
+   *   the parse tree
+   */
+  override def visitTableSources(ctx: TSqlParser.TableSourcesContext): ir.Relation = {
+    val relations = ctx.tableSource().asScala.toList.map(_.accept(this)).collect { case r: ir.Relation => r }
+    relations match {
+      case head :: Nil => head
+      case head :: tail =>
+        tail.foldLeft(head)((acc, relation) =>
+          ir.Join(
+            acc,
+            relation,
+            None,
+            ir.CrossJoin,
+            Seq.empty,
+            ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
+      case Nil => ir.NoTable()
+    }
+  }
+
   override def visitTableSource(ctx: TableSourceContext): ir.Relation = {
     val left = ctx.tableSourceItem().accept(this)
     // [TODO]: Handle Table Alias ctx.tableAlias().getText
@@ -34,14 +56,14 @@ class TSqlRelationBuilder extends TSqlParserBaseVisitor[ir.Relation] with Incomp
   private def buildJoin(left: ir.Relation, right: JoinPartContext): ir.Join = {
     val joinExpression = right.joinOn()
     val rightRelation = joinExpression.tableSource().accept(this)
-    val joinCondition = joinExpression.searchCondition().accept(new TSqlExpressionBuilder)
+    val joinCondition = joinExpression.searchCondition().accept(new TSqlColumnBuilder)
 
     ir.Join(
       left,
       rightRelation,
       Some(joinCondition),
       translateJoinType(joinExpression),
-      Seq(),
+      Seq.empty,
       ir.JoinDataType(is_left_struct = false, is_right_struct = false))
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlSelectBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlSelectBuilder.scala
@@ -1,0 +1,38 @@
+package com.databricks.labs.remorph.parsers.tsql
+
+import com.databricks.labs.remorph.parsers.{intermediate => ir}
+
+/**
+ * This visitor is responsible for building the IR for a SELECT statement.
+ *
+ * It utilizes specialized visitors for the sub-elements of a SELECT statement, such as a column, a relation, etc.
+ */
+class TSqlSelectBuilder extends TSqlParserBaseVisitor[ir.TreeNode] {
+
+  override def visitSelectStatementStandalone(ctx: TSqlParser.SelectStatementStandaloneContext): ir.TreeNode = {
+
+    // TODO: Process ctx.WithExpression
+    ctx.selectStatement().accept(this)
+    // val tableSources = Option(rawExpression.tableSources()).fold[ir.Relation](ir.NoTable())
+    // (_.accept(new TSqlRelationBuilder))
+  }
+
+  override def visitSelectStatement(ctx: TSqlParser.SelectStatementContext): ir.TreeNode = {
+    // TODO: val orderByClause = Option(ctx.selectOrderByClause).map(_.accept(this))
+    // TODO: val forClause = Option(ctx.forClause).map(_.accept(this))
+    // TODO: val optionClause = Option(ctx.optionClause).map(_.accept(this))
+
+    ctx.queryExpression.accept(this)
+  }
+
+  override def visitQuerySpecification(ctx: TSqlParser.QuerySpecificationContext): ir.TreeNode = {
+
+    // TODO: Process all the other elements of a query specification
+
+    val columns = ctx.selectList.accept(new TSqlColumnBuilder).asInstanceOf[ir.ExpressionList].expressions
+    val from = Option(ctx.tableSources()).map(_.accept(new TSqlRelationBuilder)).getOrElse(ir.NoTable())
+
+    ir.Project(from, columns)
+  }
+
+}

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -50,18 +50,11 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Join(
             NamedTable("DBO.TABLE_X", Map(), is_streaming = false),
             NamedTable("DBO.TABLE_Y", Map(), is_streaming = false),
-            Some(
-              And(
-                Equals(
-                  Column("A", Some(Table("T1", None, None, None))),
-                  Column("A", Some(Table("T2", None, None, None)))),
-                Equals(
-                  Column("B", Some(Table("T1", None, None, None))),
-                  Column("B", Some(Table("T2", None, None, None)))))),
+            Some(And(Equals(Column("T1.A"), Column("T2.A")), Equals(Column("T1.B"), Column("T2.B")))),
             InnerJoin,
             List(),
             JoinDataType(is_left_struct = false, is_right_struct = false)),
-          List(Column("A", Some(Table("T1", None, None, None))), Column("B", Some(Table("T2", None, None, None))))))
+          List(Column("T1.A"), Column("T2.B"))))
     }
     "translate a query with Multiple JOIN AND Condition" in {
       example(
@@ -72,26 +65,16 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             Join(
               NamedTable("DBO.TABLE_X", Map(), is_streaming = false),
               NamedTable("DBO.TABLE_Y", Map(), is_streaming = false),
-              Some(
-                Equals(
-                  Column("A", Some(Table("T1", None, None, None))),
-                  Column("A", Some(Table("T2", None, None, None))))),
+              Some(Equals(Column("T1.A"), Column("T2.A"))),
               InnerJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
             NamedTable("DBO.TABLE_Z", Map(), is_streaming = false),
-            Some(
-              And(
-                Equals(
-                  Column("A", Some(Table("T1", None, None, None))),
-                  Column("A", Some(Table("T3", None, None, None)))),
-                Equals(
-                  Column("B", Some(Table("T1", None, None, None))),
-                  Column("B", Some(Table("T3", None, None, None)))))),
+            Some(And(Equals(Column("T1.A"), Column("T3.A")), Equals(Column("T1.B"), Column("T3.B")))),
             LeftOuterJoin,
             List(),
             JoinDataType(is_left_struct = false, is_right_struct = false)),
-          List(Column("A", Some(Table("T1", None, None, None))), Column("B", Some(Table("T2", None, None, None))))))
+          List(Column("T1.A"), Column("T2.B"))))
     }
     "translate a query with Multiple JOIN OR Conditions" in {
       example(
@@ -102,26 +85,16 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             Join(
               NamedTable("DBO.TABLE_X", Map(), is_streaming = false),
               NamedTable("DBO.TABLE_Y", Map(), is_streaming = false),
-              Some(
-                Equals(
-                  Column("A", Some(Table("T1", None, None, None))),
-                  Column("A", Some(Table("T2", None, None, None))))),
+              Some(Equals(Column("T1.A"), Column("T2.A"))),
               InnerJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
             NamedTable("DBO.TABLE_Z", Map(), is_streaming = false),
-            Some(
-              Or(
-                Equals(
-                  Column("A", Some(Table("T1", None, None, None))),
-                  Column("A", Some(Table("T3", None, None, None)))),
-                Equals(
-                  Column("B", Some(Table("T1", None, None, None))),
-                  Column("B", Some(Table("T3", None, None, None)))))),
+            Some(Or(Equals(Column("T1.A"), Column("T3.A")), Equals(Column("T1.B"), Column("T3.B")))),
             LeftOuterJoin,
             List(),
             JoinDataType(is_left_struct = false, is_right_struct = false)),
-          List(Column("A", Some(Table("T1", None, None, None))), Column("B", Some(Table("T2", None, None, None))))))
+          List(Column("T1.A"), Column("T2.B"))))
     }
     "translate a query with a RIGHT OUTER JOIN" in {
       example(
@@ -130,14 +103,11 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Join(
             NamedTable("DBO.TABLE_X", Map(), is_streaming = false),
             NamedTable("DBO.TABLE_Y", Map(), is_streaming = false),
-            Some(
-              Equals(
-                Column("A", Some(Table("T1", None, None, None))),
-                Column("A", Some(Table("T2", None, None, None))))),
+            Some(Equals(Column("T1.A"), Column("T2.A"))),
             RightOuterJoin,
             List(),
             JoinDataType(is_left_struct = false, is_right_struct = false)),
-          List(Column("A", Some(Table("T1", None, None, None))))))
+          List(Column("T1.A"))))
     }
     "translate a query with a FULL OUTER JOIN" in {
       example(
@@ -146,14 +116,11 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Join(
             NamedTable("DBO.TABLE_X", Map(), is_streaming = false),
             NamedTable("DBO.TABLE_Y", Map(), is_streaming = false),
-            Some(
-              Equals(
-                Column("A", Some(Table("T1", None, None, None))),
-                Column("A", Some(Table("T2", None, None, None))))),
+            Some(Equals(Column("T1.A"), Column("T2.A"))),
             FullOuterJoin,
             List(),
             JoinDataType(is_left_struct = false, is_right_struct = false)),
-          List(Column("A", Some(Table("T1", None, None, None))))))
+          List(Column("T1.A"))))
     }
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -1,10 +1,9 @@
 package com.databricks.labs.remorph.parsers.tsql
 
+import com.databricks.labs.remorph.parsers.intermediate._
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
-import com.databricks.labs.remorph.parsers.intermediate._
 
 class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers {
 
@@ -19,142 +18,142 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         query = "SELECT a FROM dbo.table_x",
         expectedAst = Project(NamedTable("dbo.table_x", Map.empty, is_streaming = false), Seq(Column("a"))))
     }
-
     "accept constants in selects" in {
       example(
-        query = "SELECT 42, 6.4, 0x5A, 2.7E9, $40 FROM dbo.table_x",
+        query = "SELECT 42, 6.4, 0x5A, 2.7E9, $40",
         expectedAst = Project(
-          NamedTable("dbo.table_x", Map.empty, is_streaming = false),
+          NoTable(),
           Seq(
             Literal(integer = Some(42)),
             Literal(float = Some(6.4f)),
             Literal(string = Some("0x5A")),
             Literal(double = Some(2.7e9)),
-            UnresolvedExpression("$40"))))
+            Literal(string = Some("$40")))))
     }
-
+    "infer a cross join" in {
+      example(
+        query = "SELECT a, b, c FROM dbo.table_x, dbo.table_y",
+        expectedAst = Project(
+          Join(
+            NamedTable("dbo.table_x", Map.empty, is_streaming = false),
+            NamedTable("dbo.table_y", Map.empty, is_streaming = false),
+            None,
+            CrossJoin,
+            Seq.empty,
+            JoinDataType(is_left_struct = false, is_right_struct = false)),
+          Seq(Column("a"), Column("b"), Column("c"))))
+    }
     "translate a query with a JOIN" in {
-      val joinCondition = And(Equals(Column("A"), Column("A")), Equals(Column("B"), Column("B")))
-
-      val joinAst = Join(
-        NamedTable("DBO.TABLE_X", Map(), is_streaming = false),
-        NamedTable("DBO.TABLE_Y", Map(), is_streaming = false),
-        Some(joinCondition),
-        InnerJoin,
-        Seq(),
-        JoinDataType(is_left_struct = false, is_right_struct = false))
-
       example(
         query = "SELECT T1.A, T2.B FROM DBO.TABLE_X AS T1 INNER JOIN DBO.TABLE_Y AS T2 ON T1.A = T2.A AND T1.B = T2.B",
-        expectedAst = Project(joinAst, Seq(Column("A"), Column("B"))))
+        expectedAst = Project(
+          Join(
+            NamedTable("DBO.TABLE_X", Map(), is_streaming = false),
+            NamedTable("DBO.TABLE_Y", Map(), is_streaming = false),
+            Some(
+              And(
+                Equals(
+                  Column("A", Some(Table("T1", None, None, None))),
+                  Column("A", Some(Table("T2", None, None, None)))),
+                Equals(
+                  Column("B", Some(Table("T1", None, None, None))),
+                  Column("B", Some(Table("T2", None, None, None)))))),
+            InnerJoin,
+            List(),
+            JoinDataType(is_left_struct = false, is_right_struct = false)),
+          List(Column("A", Some(Table("T1", None, None, None))), Column("B", Some(Table("T2", None, None, None))))))
     }
-
     "translate a query with Multiple JOIN AND Condition" in {
-      val joinConditionX = Equals(Column("A"), Column("A"))
-      val joinConditionZ = And(Equals(Column("A"), Column("A")), Equals(Column("B"), Column("B")))
-
-      val joinFirstAst = Join(
-        NamedTable("DBO.TABLE_X", Map(), is_streaming = false),
-        NamedTable("DBO.TABLE_Y", Map(), is_streaming = false),
-        Some(joinConditionX),
-        InnerJoin,
-        Seq(),
-        JoinDataType(is_left_struct = false, is_right_struct = false))
-
-      val joinMainAst = Join(
-        joinFirstAst,
-        NamedTable("DBO.TABLE_Z", Map(), is_streaming = false),
-        Some(joinConditionZ),
-        LeftOuterJoin,
-        Seq(),
-        JoinDataType(is_left_struct = false, is_right_struct = false))
-
       example(
         query = "SELECT T1.A, T2.B FROM DBO.TABLE_X AS T1 INNER JOIN DBO.TABLE_Y AS T2 ON T1.A = T2.A " +
           "LEFT JOIN DBO.TABLE_Z AS T3 ON T1.A = T3.A AND T1.B = T3.B",
-        expectedAst = Project(joinMainAst, Seq(Column("A"), Column("B"))))
+        expectedAst = Project(
+          Join(
+            Join(
+              NamedTable("DBO.TABLE_X", Map(), is_streaming = false),
+              NamedTable("DBO.TABLE_Y", Map(), is_streaming = false),
+              Some(
+                Equals(
+                  Column("A", Some(Table("T1", None, None, None))),
+                  Column("A", Some(Table("T2", None, None, None))))),
+              InnerJoin,
+              List(),
+              JoinDataType(is_left_struct = false, is_right_struct = false)),
+            NamedTable("DBO.TABLE_Z", Map(), is_streaming = false),
+            Some(
+              And(
+                Equals(
+                  Column("A", Some(Table("T1", None, None, None))),
+                  Column("A", Some(Table("T3", None, None, None)))),
+                Equals(
+                  Column("B", Some(Table("T1", None, None, None))),
+                  Column("B", Some(Table("T3", None, None, None)))))),
+            LeftOuterJoin,
+            List(),
+            JoinDataType(is_left_struct = false, is_right_struct = false)),
+          List(Column("A", Some(Table("T1", None, None, None))), Column("B", Some(Table("T2", None, None, None))))))
     }
-
-    "translate a query with Multiple JOIN OR Condition" in {
-      val joinConditionX = Equals(Column("A"), Column("A"))
-      val joinConditionZ = Or(Equals(Column("A"), Column("A")), Equals(Column("B"), Column("B")))
-
-      val joinFirstAst = Join(
-        NamedTable("DBO.TABLE_X", Map(), is_streaming = false),
-        NamedTable("DBO.TABLE_Y", Map(), is_streaming = false),
-        Some(joinConditionX),
-        InnerJoin,
-        Seq(),
-        JoinDataType(is_left_struct = false, is_right_struct = false))
-
-      val joinMainAst = Join(
-        joinFirstAst,
-        NamedTable("DBO.TABLE_Z", Map(), is_streaming = false),
-        Some(joinConditionZ),
-        LeftOuterJoin,
-        Seq(),
-        JoinDataType(is_left_struct = false, is_right_struct = false))
-
+    "translate a query with Multiple JOIN OR Conditions" in {
       example(
         query = "SELECT T1.A, T2.B FROM DBO.TABLE_X AS T1 INNER JOIN DBO.TABLE_Y AS T2 ON T1.A = T2.A " +
           "LEFT JOIN DBO.TABLE_Z AS T3 ON T1.A = T3.A OR T1.B = T3.B",
-        expectedAst = Project(joinMainAst, Seq(Column("A"), Column("B"))))
+        expectedAst = Project(
+          Join(
+            Join(
+              NamedTable("DBO.TABLE_X", Map(), is_streaming = false),
+              NamedTable("DBO.TABLE_Y", Map(), is_streaming = false),
+              Some(
+                Equals(
+                  Column("A", Some(Table("T1", None, None, None))),
+                  Column("A", Some(Table("T2", None, None, None))))),
+              InnerJoin,
+              List(),
+              JoinDataType(is_left_struct = false, is_right_struct = false)),
+            NamedTable("DBO.TABLE_Z", Map(), is_streaming = false),
+            Some(
+              Or(
+                Equals(
+                  Column("A", Some(Table("T1", None, None, None))),
+                  Column("A", Some(Table("T3", None, None, None)))),
+                Equals(
+                  Column("B", Some(Table("T1", None, None, None))),
+                  Column("B", Some(Table("T3", None, None, None)))))),
+            LeftOuterJoin,
+            List(),
+            JoinDataType(is_left_struct = false, is_right_struct = false)),
+          List(Column("A", Some(Table("T1", None, None, None))), Column("B", Some(Table("T2", None, None, None))))))
     }
     "translate a query with a RIGHT OUTER JOIN" in {
-      val joinCondition = Equals(Column("A"), Column("A"))
-
-      val joinAst = Join(
-        NamedTable("DBO.TABLE_X", Map(), is_streaming = false),
-        NamedTable("DBO.TABLE_Y", Map(), is_streaming = false),
-        Some(joinCondition),
-        RightOuterJoin,
-        Seq(),
-        JoinDataType(is_left_struct = false, is_right_struct = false))
-
       example(
         query = "SELECT T1.A FROM DBO.TABLE_X AS T1 RIGHT OUTER JOIN DBO.TABLE_Y AS T2 ON T1.A = T2.A",
-        expectedAst = Project(joinAst, Seq(Column("A"))))
+        expectedAst = Project(
+          Join(
+            NamedTable("DBO.TABLE_X", Map(), is_streaming = false),
+            NamedTable("DBO.TABLE_Y", Map(), is_streaming = false),
+            Some(
+              Equals(
+                Column("A", Some(Table("T1", None, None, None))),
+                Column("A", Some(Table("T2", None, None, None))))),
+            RightOuterJoin,
+            List(),
+            JoinDataType(is_left_struct = false, is_right_struct = false)),
+          List(Column("A", Some(Table("T1", None, None, None))))))
     }
     "translate a query with a FULL OUTER JOIN" in {
-      val joinCondition = Equals(Column("A"), Column("A"))
-
-      val joinAst = Join(
-        NamedTable("DBO.TABLE_X", Map(), is_streaming = false),
-        NamedTable("DBO.TABLE_Y", Map(), is_streaming = false),
-        Some(joinCondition),
-        FullOuterJoin,
-        Seq(),
-        JoinDataType(is_left_struct = false, is_right_struct = false))
-
       example(
         query = "SELECT T1.A FROM DBO.TABLE_X AS T1 FULL OUTER JOIN DBO.TABLE_Y AS T2 ON T1.A = T2.A",
-        expectedAst = Project(joinAst, Seq(Column("A"))))
+        expectedAst = Project(
+          Join(
+            NamedTable("DBO.TABLE_X", Map(), is_streaming = false),
+            NamedTable("DBO.TABLE_Y", Map(), is_streaming = false),
+            Some(
+              Equals(
+                Column("A", Some(Table("T1", None, None, None))),
+                Column("A", Some(Table("T2", None, None, None))))),
+            FullOuterJoin,
+            List(),
+            JoinDataType(is_left_struct = false, is_right_struct = false)),
+          List(Column("A", Some(Table("T1", None, None, None))))))
     }
-  }
-  "translate SELECT queries with binary expressions" in {
-    example(
-      query = "SELECT a + b FROM dbo.table_x",
-      expectedAst =
-        Project(NamedTable("dbo.table_x", Map.empty, is_streaming = false), Seq(Add(Column("a"), Column("b")))))
-
-    example(
-      query = "SELECT a - b FROM dbo.table_x",
-      expectedAst =
-        Project(NamedTable("dbo.table_x", Map.empty, is_streaming = false), Seq(Subtract(Column("a"), Column("b")))))
-
-    example(
-      query = "SELECT a * b FROM dbo.table_x",
-      expectedAst =
-        Project(NamedTable("dbo.table_x", Map.empty, is_streaming = false), Seq(Multiply(Column("a"), Column("b")))))
-
-    example(
-      query = "SELECT a / b FROM dbo.table_x",
-      expectedAst =
-        Project(NamedTable("dbo.table_x", Map.empty, is_streaming = false), Seq(Divide(Column("a"), Column("b")))))
-
-    example(
-      query = "SELECT a || b FROM dbo.table_x",
-      expectedAst =
-        Project(NamedTable("dbo.table_x", Map.empty, is_streaming = false), Seq(Concat(Column("a"), Column("b")))))
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlColumnBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlColumnBuilderSpec.scala
@@ -1,0 +1,73 @@
+package com.databricks.labs.remorph.parsers.tsql
+
+import com.databricks.labs.remorph.parsers.intermediate._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class TSqlColumnBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers {
+
+  override protected def astBuilder: TSqlParserBaseVisitor[_] = new TSqlColumnBuilder
+
+  "TSqlColumnBuilder" should {
+
+    "translate a simple column" in {
+      example("a", _.selectListElem(), Column("a"))
+      example("#a", _.selectListElem(), Column("#a"))
+      example("[a]", _.selectListElem(), Column("[a]"))
+      example("\"a\"", _.selectListElem(), Column("\"a\""))
+      example("RAW", _.selectListElem(), Column("RAW"))
+    }
+
+    "translate a column with a table" in {
+      example("table_x.a", _.selectListElem(), Column("table_x.a"))
+    }
+
+    "translate a column with a schema" in {
+      example("schema1.table_x.a", _.selectListElem(), Column("schema1.table_x.a"))
+    }
+
+    "translate a column with a database" in {
+      example("database1.schema1.table_x.a", _.selectListElem(), Column("database1.schema1.table_x.a"))
+    }
+
+    "translate a column with a server" in {
+      example("server1..schema1.table_x.a", _.fullColumnName(), Column("server1..schema1.table_x.a"))
+    }
+
+    "translate a column without a table reference" in {
+      example("a", _.fullColumnName(), Column("a"))
+    }
+
+    "translate a list of elements" in {
+      example("a, b, c", _.selectList(), ExpressionList(Seq(Column("a"), Column("b"), Column("c"))))
+    }
+
+    "translate search conditions" in {
+      example("a = b", _.searchCondition(), Equals(Column("a"), Column("b")))
+      example("a > b", _.searchCondition(), GreaterThan(Column("a"), Column("b")))
+      example("a < b", _.searchCondition(), LesserThan(Column("a"), Column("b")))
+      example("a >= b", _.searchCondition(), GreaterThanOrEqual(Column("a"), Column("b")))
+      example("a <= b", _.searchCondition(), LesserThanOrEqual(Column("a"), Column("b")))
+      example("a > = b", _.searchCondition(), GreaterThanOrEqual(Column("a"), Column("b")))
+      example("a <  = b", _.searchCondition(), LesserThanOrEqual(Column("a"), Column("b")))
+      example("a <> b", _.searchCondition(), NotEquals(Column("a"), Column("b")))
+      example("NOT a = b", _.searchCondition(), Not(Equals(Column("a"), Column("b"))))
+      example(
+        "a = b AND c = e",
+        _.searchCondition(),
+        And(Equals(Column("a"), Column("b")), Equals(Column("c"), Column("e"))))
+      example(
+        "a = b OR c = e",
+        _.searchCondition(),
+        Or(Equals(Column("a"), Column("b")), Equals(Column("c"), Column("e"))))
+      example(
+        "a = b AND c = x OR e = f",
+        _.searchCondition(),
+        Or(And(Equals(Column("a"), Column("b")), Equals(Column("c"), Column("x"))), Equals(Column("e"), Column("f"))))
+      example(
+        "a = b AND (c = x OR e = f)",
+        _.searchCondition(),
+        And(Equals(Column("a"), Column("b")), Or(Equals(Column("c"), Column("x")), Equals(Column("e"), Column("f")))))
+    }
+  }
+}

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -2,7 +2,6 @@ package com.databricks.labs.remorph.parsers.tsql
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
 import com.databricks.labs.remorph.parsers.intermediate._
 
 class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers {
@@ -191,6 +190,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
     }
     "correctly resolve quoted identifiers" in {
       example("RAW", _.expression(), Identifier("RAW", isQuoted = false))
+      example("#RAW", _.expression(), Identifier("#RAW", isQuoted = false))
       example("\"a\"", _.expression(), Identifier("\"a\"", isQuoted = true))
       example("[a]", _.expression(), Identifier("[a]", isQuoted = true))
       example("[a].[b]", _.expression(), Dot(Identifier("[a]", isQuoted = true), Identifier("[b]", isQuoted = true)))
@@ -200,6 +200,9 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
         Dot(
           Identifier("[a]", isQuoted = true),
           Dot(Identifier("[b]", isQuoted = true), Identifier("[c]", isQuoted = true))))
+    }
+    "correctly resolve keywords used as identifiers" in {
+      example("ABORT", _.expression(), Identifier("ABORT", isQuoted = false))
     }
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -154,5 +154,20 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
           Literal(integer = Some(1)),
           Multiply(Literal(integer = Some(2)), Add(Literal(integer = Some(3)), Literal(integer = Some(4))))))
     }
+    "correctly resolve dot delimited plain references" in {
+      example("a", _.expression(), Identifier("a", isQuoted = false))
+      example("a.b", _.expression(), Dot(Identifier("a", isQuoted = false), Identifier("b", isQuoted = false)))
+      example("a.b.c", _.expression(), Dot(
+        Identifier("a", isQuoted = false),
+        Dot(Identifier("b", isQuoted = false), Identifier("c", isQuoted = false))))
+    }
+    "correctly resolve quoted identifiers" in {
+      example("\"a\"", _.expression(), Identifier("\"a\"", isQuoted = true))
+      example("[a]", _.expression(), Identifier("\"a\"", isQuoted = true))
+      example("[a].[b]", _.expression(), Dot(Identifier("[a]", isQuoted = true), Identifier("[b]", isQuoted = true)))
+      example("[a].[b].[c]", _.expression(), Dot(
+        Identifier("[a]", isQuoted = true),
+        Dot(Identifier("[b]", isQuoted = true), Identifier("[c]", isQuoted = true))))
+    }
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -34,23 +34,48 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
       example("4 ^ 2", _.expression(), BitwiseXor(Literal(integer = Some(4)), Literal(integer = Some(2))))
     }
     "translate complex binary expressions" in {
-      example("a + b * 2", _.expression(), Add(Column("a"), Multiply(Column("b"), Literal(integer = Some(2)))))
-      example("(a + b) * 2", _.expression(), Multiply(Add(Column("a"), Column("b")), Literal(integer = Some(2))))
-      example("a & b | c", _.expression(), BitwiseOr(BitwiseAnd(Column("a"), Column("b")), Column("c")))
-      example("(a & b) | c", _.expression(), BitwiseOr(BitwiseAnd(Column("a"), Column("b")), Column("c")))
+      example(
+        "a + b * 2",
+        _.expression(),
+        Add(Identifier("a", isQuoted = false), Multiply(Identifier("b", isQuoted = false), Literal(integer = Some(2)))))
+      example(
+        "(a + b) * 2",
+        _.expression(),
+        Multiply(Add(Identifier("a", isQuoted = false), Identifier("b", isQuoted = false)), Literal(integer = Some(2))))
+      example(
+        "a & b | c",
+        _.expression(),
+        BitwiseOr(
+          BitwiseAnd(Identifier("a", isQuoted = false), Identifier("b", isQuoted = false)),
+          Identifier("c", isQuoted = false)))
+      example(
+        "(a & b) | c",
+        _.expression(),
+        BitwiseOr(
+          BitwiseAnd(Identifier("a", isQuoted = false), Identifier("b", isQuoted = false)),
+          Identifier("c", isQuoted = false)))
       example(
         "a % 3 + b * 2 - c / 5",
         _.expression(),
         Subtract(
-          Add(Mod(Column("a"), Literal(integer = Some(3))), Multiply(Column("b"), Literal(integer = Some(2)))),
-          Divide(Column("c"), Literal(integer = Some(5)))))
+          Add(
+            Mod(Identifier("a", isQuoted = false), Literal(integer = Some(3))),
+            Multiply(Identifier("b", isQuoted = false), Literal(integer = Some(2)))),
+          Divide(Identifier("c", isQuoted = false), Literal(integer = Some(5)))))
       example(
         "(a % 3 + b) * 2 - c / 5",
         _.expression(),
         Subtract(
-          Multiply(Add(Mod(Column("a"), Literal(integer = Some(3))), Column("b")), Literal(integer = Some(2))),
-          Divide(Column("c"), Literal(integer = Some(5)))))
-      example(query = "a || b || c", _.expression(), Concat(Concat(Column("a"), Column("b")), Column("c")))
+          Multiply(
+            Add(Mod(Identifier("a", isQuoted = false), Literal(integer = Some(3))), Identifier("b", isQuoted = false)),
+            Literal(integer = Some(2))),
+          Divide(Identifier("c", isQuoted = false), Literal(integer = Some(5)))))
+      example(
+        query = "a || b || c",
+        _.expression(),
+        Concat(
+          Concat(Identifier("a", isQuoted = false), Identifier("b", isQuoted = false)),
+          Identifier("c", isQuoted = false)))
     }
     "correctly apply operator precedence and associativity" in {
       example(
@@ -166,7 +191,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
     }
     "correctly resolve quoted identifiers" in {
       example("\"a\"", _.expression(), Identifier("\"a\"", isQuoted = true))
-      example("[a]", _.expression(), Identifier("\"a\"", isQuoted = true))
+      example("[a]", _.expression(), Identifier("[a]", isQuoted = true))
       example("[a].[b]", _.expression(), Dot(Identifier("[a]", isQuoted = true), Identifier("[b]", isQuoted = true)))
       example(
         "[a].[b].[c]",

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -157,17 +157,23 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
     "correctly resolve dot delimited plain references" in {
       example("a", _.expression(), Identifier("a", isQuoted = false))
       example("a.b", _.expression(), Dot(Identifier("a", isQuoted = false), Identifier("b", isQuoted = false)))
-      example("a.b.c", _.expression(), Dot(
-        Identifier("a", isQuoted = false),
-        Dot(Identifier("b", isQuoted = false), Identifier("c", isQuoted = false))))
+      example(
+        "a.b.c",
+        _.expression(),
+        Dot(
+          Identifier("a", isQuoted = false),
+          Dot(Identifier("b", isQuoted = false), Identifier("c", isQuoted = false))))
     }
     "correctly resolve quoted identifiers" in {
       example("\"a\"", _.expression(), Identifier("\"a\"", isQuoted = true))
       example("[a]", _.expression(), Identifier("\"a\"", isQuoted = true))
       example("[a].[b]", _.expression(), Dot(Identifier("[a]", isQuoted = true), Identifier("[b]", isQuoted = true)))
-      example("[a].[b].[c]", _.expression(), Dot(
-        Identifier("[a]", isQuoted = true),
-        Dot(Identifier("[b]", isQuoted = true), Identifier("[c]", isQuoted = true))))
+      example(
+        "[a].[b].[c]",
+        _.expression(),
+        Dot(
+          Identifier("[a]", isQuoted = true),
+          Dot(Identifier("[b]", isQuoted = true), Identifier("[c]", isQuoted = true))))
     }
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -190,6 +190,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
           Dot(Identifier("b", isQuoted = false), Identifier("c", isQuoted = false))))
     }
     "correctly resolve quoted identifiers" in {
+      example("RAW", _.expression(), Identifier("RAW", isQuoted = false))
       example("\"a\"", _.expression(), Identifier("\"a\"", isQuoted = true))
       example("[a]", _.expression(), Identifier("[a]", isQuoted = true))
       example("[a].[b]", _.expression(), Dot(Identifier("[a]", isQuoted = true), Identifier("[b]", isQuoted = true)))


### PR DESCRIPTION
Distinguishes between column references and expression entities by using context aware walkers. Rejigs SELECT walking with visitor pattern. Corrects grammar for predicates. 

Closes: #326 
Progresses: #275