### PR TITLE
Creates a simple error collector for building on in the future

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -93,6 +93,16 @@
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.typesafe.scala-logging</groupId>
+      <artifactId>scala-logging_${scala.binary.version}</artifactId>
+      <version>3.9.5</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.5.6</version>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/ErrorCollector.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/ErrorCollector.scala
@@ -1,0 +1,57 @@
+package com.databricks.labs.remorph.parsers
+
+import com.typesafe.scalalogging.Logger
+import org.antlr.v4.runtime.{BaseErrorListener, RecognitionException, Recognizer, Token}
+import org.json4s._
+import org.json4s.jackson.Serialization
+import org.json4s.jackson.Serialization.write
+
+import scala.collection.mutable.ListBuffer
+
+case class ErrorDetail(line: Int, charPositionInLine: Int, msg: String, offendingToken: Token)
+
+class ErrorCollector(sourceCode: String, fileName: String) extends BaseErrorListener {
+  val errors: ListBuffer[ErrorDetail] = ListBuffer()
+  val logger: Logger = Logger[ErrorCollector]
+
+  implicit val formats: Formats = Serialization.formats(NoTypeHints)
+
+  override def syntaxError(
+      recognizer: Recognizer[_, _],
+      offendingSymbol: Any,
+      line: Int,
+      charPositionInLine: Int,
+      msg: String,
+      e: RecognitionException): Unit = {
+    errors += ErrorDetail(line, charPositionInLine, msg, offendingSymbol.asInstanceOf[Token])
+  }
+
+  def formatErrors(): Seq[String] = {
+    val lines = sourceCode.split("\n")
+    errors.map { error =>
+      val start = Math.max(0, error.offendingToken.getStartIndex - 32)
+      val end = Math.min(lines(error.line - 1).length, error.offendingToken.getStopIndex + 32)
+      val windowedLine = (if (start > 0) "..." else "") + lines(error.line - 1)
+        .substring(start, end) + (if (end < lines(error.line - 1).length) "..." else "")
+      val marker =
+        " " * (error.offendingToken.getStartIndex - start) + "^" *
+          (error.offendingToken.getStopIndex - error.offendingToken.getStartIndex + 1)
+      s"File: $fileName, Line: ${error.line}, Token: ${error.offendingToken.getText}\n$windowedLine\n$marker"
+    }
+  }
+
+  def logErrors(): Unit = {
+    val formattedErrors = formatErrors()
+    if (formattedErrors.nonEmpty) {
+      formattedErrors.foreach(error => logger.error(error))
+    }
+  }
+
+  def errorsAsJson(): String = {
+    write(errors)
+  }
+
+  def errorCount(): Int = {
+    errors.size
+  }
+}

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/ParserTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/ParserTestCommon.scala
@@ -2,28 +2,40 @@ package com.databricks.labs.remorph.parsers
 
 import com.databricks.labs.remorph.parsers.intermediate.{NamedTable, Relation, TreeNode}
 import org.antlr.v4.runtime.tree.ParseTreeVisitor
-import org.antlr.v4.runtime.{CharStream, CharStreams, CommonTokenStream, Parser, RuleContext, TokenSource, TokenStream}
+import org.antlr.v4.runtime._
 import org.scalatest.{Assertion, Assertions}
 
 trait ParserTestCommon[P <: Parser] { self: Assertions =>
 
   protected def makeLexer(chars: CharStream): TokenSource
   protected def makeParser(tokens: TokenStream): P
-
+  protected def makeErrHandler(chars: String): ErrorCollector = null
   protected def astBuilder: ParseTreeVisitor[_]
+  protected var errHandler: ErrorCollector = _
+
   protected def parseString[R <: RuleContext](input: String, rule: P => R): R = {
     val inputString = CharStreams.fromString(input)
     val lexer = makeLexer(inputString)
     val tokenStream = new CommonTokenStream(lexer)
     val parser = makeParser(tokenStream)
+    errHandler = makeErrHandler(input)
+    if (errHandler != null) {
+      parser.removeErrorListeners()
+      parser.addErrorListener(errHandler)
+    }
     val tree = rule(parser)
-    // uncomment the following line if you need a peek in the Snowflake AST
+
+    // uncomment the following line if you need a peek in the Snowflake/TSQL AST
     // println(tree.toStringTree(parser))
     tree
   }
 
   protected def example[R <: RuleContext](query: String, rule: P => R, expectedAst: TreeNode): Assertion = {
     val sfTree = parseString(query, rule)
+    if (errHandler != null && errHandler.errorCount() != 0) {
+      errHandler.logErrors()
+      assert(1 == 2, s"${errHandler.errorCount()} errors found in the input string")
+    }
 
     val result = astBuilder.visit(sfTree)
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -3,7 +3,6 @@ package com.databricks.labs.remorph.parsers.tsql
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
 import com.databricks.labs.remorph.parsers.intermediate._
 
 class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlParserTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlParserTestCommon.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.ParserTestCommon
+import com.databricks.labs.remorph.parsers.{ErrorCollector, ParserTestCommon}
 import org.scalatest.Assertions
 import org.antlr.v4.runtime.{CharStream, TokenSource, TokenStream}
 
@@ -8,5 +8,10 @@ trait TSqlParserTestCommon extends ParserTestCommon[TSqlParser] { self: Assertio
 
   override final protected def makeLexer(chars: CharStream): TokenSource = new TSqlLexer(chars)
 
-  override final protected def makeParser(tokenStream: TokenStream): TSqlParser = new TSqlParser(tokenStream)
+  override protected def makeErrHandler(chars: String): ErrorCollector = new ErrorCollector(chars, "-- test string --")
+
+  override final protected def makeParser(tokenStream: TokenStream): TSqlParser = {
+    val parser = new TSqlParser(tokenStream)
+    parser
+  }
 }


### PR DESCRIPTION
A simple error collector is created, which allows determination of errors in test code and makes that a little easier. In the future, it can be expanded to support different types of errors such as semantic errors.