### PR TITLE
Provide a rudimentary error collector for syntax errors and future semantic and linting errors

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -98,11 +98,6 @@
       <artifactId>scala-logging_${scala.binary.version}</artifactId>
       <version>3.9.5</version>
     </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <version>1.5.6</version>
-    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -93,6 +93,16 @@
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.typesafe.scala-logging</groupId>
+      <artifactId>scala-logging_${scala.binary.version}</artifactId>
+      <version>3.9.5</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.5.6</version>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/ErrorCollector.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/ErrorCollector.scala
@@ -33,8 +33,10 @@ class ErrorCollector(sourceCode: String, fileName: String) extends BaseErrorList
       val end = Math.min(lines(error.line - 1).length, error.offendingToken.getStopIndex + 32)
       val windowedLine = (if (start > 0) "..." else "") + lines(error.line - 1)
         .substring(start, end) + (if (end < lines(error.line - 1).length) "..." else "")
+      val markerStart =
+        if (start > 0) error.offendingToken.getStartIndex - start + 3 else error.offendingToken.getStartIndex - start
       val marker =
-        " " * (error.offendingToken.getStartIndex - start) + "^" *
+        " " * markerStart + "^" *
           (error.offendingToken.getStopIndex - error.offendingToken.getStartIndex + 1)
       s"File: $fileName, Line: ${error.line}, Token: ${error.offendingToken.getText}\n$windowedLine\n$marker"
     }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/ErrorCollector.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/ErrorCollector.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers
 
-import com.typesafe.scalalogging.Logger
+import org.apache.logging.log4j.{LogManager, Logger}
 import org.antlr.v4.runtime.{BaseErrorListener, RecognitionException, Recognizer, Token}
 import org.json4s._
 import org.json4s.jackson.Serialization
@@ -12,7 +12,7 @@ case class ErrorDetail(line: Int, charPositionInLine: Int, msg: String, offendin
 
 class ErrorCollector(sourceCode: String, fileName: String) extends BaseErrorListener {
   val errors: ListBuffer[ErrorDetail] = ListBuffer()
-  val logger: Logger = Logger[ErrorCollector]
+  val logger: Logger = LogManager.getLogger(classOf[ErrorCollector])
 
   implicit val formats: Formats = Serialization.formats(NoTypeHints)
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/ErrorCollector.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/ErrorCollector.scala
@@ -16,6 +16,8 @@ sealed trait ErrorCollector extends BaseErrorListener {
   def reset(): Unit = {}
 }
 
+class EmptyErrorCollector extends ErrorCollector
+
 case class ErrorDetail(line: Int, charPositionInLine: Int, msg: String, offendingToken: Token)
 
 class DefaultErrorCollector extends ErrorCollector {
@@ -80,4 +82,6 @@ class ProductionErrorCollector(sourceCode: String, fileName: String) extends Err
   override def errorsAsJson: String = write(errors)
 
   override def errorCount: Int = errors.size
+
+  override def reset(): Unit = errors.clear()
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/ErrorCollector.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/ErrorCollector.scala
@@ -1,0 +1,57 @@
+package com.databricks.labs.remorph.parsers
+
+import com.typesafe.scalalogging.Logger
+import org.antlr.v4.runtime.{BaseErrorListener, RecognitionException, Recognizer, Token}
+import org.json4s._
+import org.json4s.jackson.Serialization
+import org.json4s.jackson.Serialization.write
+
+import scala.collection.mutable.ListBuffer
+
+case class ErrorDetail(line: Int, charPositionInLine: Int, msg: String, offendingToken: Token)
+
+class ErrorCollector(sourceCode: String, fileName: String) extends BaseErrorListener {
+  val errors: ListBuffer[ErrorDetail] = ListBuffer()
+  val logger: Logger = Logger[ErrorCollector]
+
+  implicit val formats: Formats = Serialization.formats(NoTypeHints)
+
+  override def syntaxError(
+      recognizer: Recognizer[_, _],
+      offendingSymbol: Any,
+      line: Int,
+      charPositionInLine: Int,
+      msg: String,
+      e: RecognitionException): Unit = {
+    errors += ErrorDetail(line, charPositionInLine, msg, offendingSymbol.asInstanceOf[Token])
+  }
+
+  def formatErrors(): Seq[String] = {
+    val lines = sourceCode.split("\n")
+    errors.map { error =>
+      val start = Math.max(0, error.offendingToken.getStartIndex - 32)
+      val end = Math.min(lines(error.line - 1).length, error.offendingToken.getStopIndex + 32)
+      val windowedLine = (if (start > 0) "..." else "") + lines(error.line - 1)
+        .substring(start, end) + (if (end < lines(error.line - 1).length) "..." else "")
+      val marker =
+        " " * (error.offendingToken.getStartIndex - start) + "^" *
+          (error.offendingToken.getStopIndex - error.offendingToken.getStartIndex + 1)
+      s"File: $fileName, Line: ${error.line}, Token: ${error.offendingToken.getText}\n$windowedLine\n$marker"
+    }
+  }
+
+  def logErrors(): Unit = {
+    val formattedErrors = formatErrors()
+    if (formattedErrors.nonEmpty) {
+      formattedErrors.foreach(error => logger.error(error))
+    }
+  }
+
+  def errorsAsJson(): String = {
+    write(errors)
+  }
+
+  def errorCount(): Int = {
+    errors.size
+  }
+}

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/ParserTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/ParserTestCommon.scala
@@ -2,28 +2,40 @@ package com.databricks.labs.remorph.parsers
 
 import com.databricks.labs.remorph.parsers.intermediate.{NamedTable, Relation, TreeNode}
 import org.antlr.v4.runtime.tree.ParseTreeVisitor
-import org.antlr.v4.runtime.{CharStream, CharStreams, CommonTokenStream, Parser, RuleContext, TokenSource, TokenStream}
+import org.antlr.v4.runtime._
 import org.scalatest.{Assertion, Assertions}
 
 trait ParserTestCommon[P <: Parser] { self: Assertions =>
 
   protected def makeLexer(chars: CharStream): TokenSource
   protected def makeParser(tokens: TokenStream): P
-
+  protected def makeErrHandler(chars: String): ErrorCollector = null
   protected def astBuilder: ParseTreeVisitor[_]
+  protected var errHandler: ErrorCollector = _
+
   protected def parseString[R <: RuleContext](input: String, rule: P => R): R = {
     val inputString = CharStreams.fromString(input)
     val lexer = makeLexer(inputString)
     val tokenStream = new CommonTokenStream(lexer)
     val parser = makeParser(tokenStream)
+    errHandler = makeErrHandler(input)
+    if (errHandler != null) {
+      parser.removeErrorListeners()
+      parser.addErrorListener(errHandler)
+    }
     val tree = rule(parser)
-    // uncomment the following line if you need a peek in the Snowflake AST
+
+    // uncomment the following line if you need a peek in the Snowflake/TSQL AST
     // println(tree.toStringTree(parser))
     tree
   }
 
   protected def example[R <: RuleContext](query: String, rule: P => R, expectedAst: TreeNode): Assertion = {
     val sfTree = parseString(query, rule)
+    if (errHandler != null && errHandler.errorCount() != 0) {
+      errHandler.logErrors()
+      assert(1 == 2, s"${errHandler.errorCount()} errors found in the input string")
+    }
 
     val result = astBuilder.visit(sfTree)
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlErrorHandlerSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlErrorHandlerSpec.scala
@@ -1,0 +1,101 @@
+package com.databricks.labs.remorph.parsers.tsql
+
+import ch.qos.logback.classic.{Level, Logger}
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import com.databricks.labs.remorph.parsers.{ErrorCollector, ErrorDetail}
+import org.antlr.v4.runtime.CommonToken
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.slf4j.LoggerFactory
+
+import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
+
+class TSqlErrorHandlerSpec extends AnyFlatSpec with Matchers {
+
+  "ErrorCollector" should "collect syntax errors correctly" in {
+    val errorCollector = new ErrorCollector("sourceCode", "fileName")
+    val token = new CommonToken(1)
+    val recognizer: Null = null
+    val e: Null = null
+    errorCollector.syntaxError(recognizer, token, 1, 1, "msg", e)
+    errorCollector.errors.head shouldBe ErrorDetail(1, 1, "msg", token)
+  }
+
+  it should "format errors correctly" in {
+    val errorCollector = new ErrorCollector("sourceCode", "fileName")
+    val token = new CommonToken(1)
+    token.setLine(1)
+    token.setCharPositionInLine(1)
+    token.setText("text")
+    errorCollector.errors += ErrorDetail(1, 1, "msg", token)
+    errorCollector.formatErrors().head should include("Token: text")
+  }
+
+  it should "convert errors to JSON correctly" in {
+    val errorCollector = new ErrorCollector("sourceCode", "fileName")
+    val token = new CommonToken(1)
+    token.setLine(1)
+    token.setCharPositionInLine(1)
+    token.setText("text")
+    errorCollector.errors += ErrorDetail(1, 1, "msg", token)
+    errorCollector.errorsAsJson() should include("\"line\":1")
+  }
+
+  it should "count errors correctly" in {
+    val errorCollector = new ErrorCollector("sourceCode", "fileName")
+    val token = new CommonToken(1)
+    token.setLine(1)
+    token.setCharPositionInLine(1)
+    token.setText("text")
+    errorCollector.errors += ErrorDetail(1, 1, "msg", token)
+    errorCollector.errorCount() shouldBe 1
+  }
+
+  it should "window long lines correctly" in {
+    val longLine = "a" * 40 + "error" + "a" * 40
+    val errorCollector = new ErrorCollector(longLine, "fileName")
+    val token = new CommonToken(1)
+    token.setLine(1)
+    token.setCharPositionInLine(40)
+    token.setStartIndex(40)
+    token.setStopIndex(44)
+    token.setText("error")
+    errorCollector.errors += ErrorDetail(1, 40, "msg", token)
+
+    // Call the method
+    val formattedErrors = errorCollector.formatErrors()
+
+    // Check the windowing
+    val s = "..." + "a" * 32 + "error" + "a" * 31 + "...\n" + " " * 35 + "^^^^^"
+    formattedErrors.head should include(s)
+  }
+
+  it should "log errors correctly" in {
+    val errorCollector = new ErrorCollector("sourceCode", "fileName")
+    val token = new CommonToken(1)
+    token.setLine(1)
+    token.setCharPositionInLine(1)
+    token.setText("text")
+    errorCollector.errors += ErrorDetail(1, 1, "msg", token)
+
+    // Capture the logs
+    val logger = LoggerFactory.getLogger("com.databricks.labs.remorph.parsers.ErrorCollector").asInstanceOf[Logger]
+    val originalLevel = logger.getLevel
+    logger.setLevel(Level.ERROR)
+    val listAppender = new ListAppender[ILoggingEvent]
+    listAppender.start()
+    logger.addAppender(listAppender)
+
+    // Call the method
+    errorCollector.logErrors()
+
+    // Check the logs
+    val logs = listAppender.list.map(_.getFormattedMessage)
+    logs.exists(log => log.startsWith("File: fileName, Line: 1")) shouldBe true
+
+    // Reset the logger
+    logger.detachAppender(listAppender)
+    logger.setLevel(originalLevel)
+  }
+}

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlErrorHandlerSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlErrorHandlerSpec.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.{ErrorCollector, ErrorDetail}
+import com.databricks.labs.remorph.parsers.{ErrorDetail, ProductionErrorCollector}
 import org.antlr.v4.runtime.CommonToken
 import org.apache.logging.log4j.core.appender.AbstractAppender
 import org.apache.logging.log4j.core.config.{Configuration, Configurator}
@@ -15,7 +15,7 @@ import scala.collection.mutable.ListBuffer
 class TSqlErrorHandlerSpec extends AnyFlatSpec with Matchers {
 
   "ErrorCollector" should "collect syntax errors correctly" in {
-    val errorCollector = new ErrorCollector("sourceCode", "fileName")
+    val errorCollector = new ProductionErrorCollector("sourceCode", "fileName")
     val token = new CommonToken(1)
     val recognizer: Null = null
     val e: Null = null
@@ -24,38 +24,38 @@ class TSqlErrorHandlerSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "format errors correctly" in {
-    val errorCollector = new ErrorCollector("sourceCode", "fileName")
+    val errorCollector = new ProductionErrorCollector("sourceCode", "fileName")
     val token = new CommonToken(1)
     token.setLine(1)
     token.setCharPositionInLine(1)
     token.setText("text")
     errorCollector.errors += ErrorDetail(1, 1, "msg", token)
-    errorCollector.formatErrors().head should include("Token: text")
+    errorCollector.formatErrors.head should include("Token: text")
   }
 
   it should "convert errors to JSON correctly" in {
-    val errorCollector = new ErrorCollector("sourceCode", "fileName")
+    val errorCollector = new ProductionErrorCollector("sourceCode", "fileName")
     val token = new CommonToken(1)
     token.setLine(1)
     token.setCharPositionInLine(1)
     token.setText("text")
     errorCollector.errors += ErrorDetail(1, 1, "msg", token)
-    errorCollector.errorsAsJson() should include("\"line\":1")
+    errorCollector.errorsAsJson should include("\"line\":1")
   }
 
   it should "count errors correctly" in {
-    val errorCollector = new ErrorCollector("sourceCode", "fileName")
+    val errorCollector = new ProductionErrorCollector("sourceCode", "fileName")
     val token = new CommonToken(1)
     token.setLine(1)
     token.setCharPositionInLine(1)
     token.setText("text")
     errorCollector.errors += ErrorDetail(1, 1, "msg", token)
-    errorCollector.errorCount() shouldBe 1
+    errorCollector.errorCount shouldBe 1
   }
 
   it should "window long lines correctly" in {
     val longLine = "a" * 40 + "error" + "a" * 40
-    val errorCollector = new ErrorCollector(longLine, "fileName")
+    val errorCollector = new ProductionErrorCollector(longLine, "fileName")
     val token = new CommonToken(1)
     token.setLine(1)
     token.setCharPositionInLine(40)
@@ -65,7 +65,7 @@ class TSqlErrorHandlerSpec extends AnyFlatSpec with Matchers {
     errorCollector.errors += ErrorDetail(1, 40, "msg", token)
 
     // Call the method
-    val formattedErrors = errorCollector.formatErrors()
+    val formattedErrors = errorCollector.formatErrors
 
     // Check the windowing
     val s = "..." + "a" * 32 + "error" + "a" * 31 + "...\n" + " " * 35 + "^^^^^"
@@ -73,7 +73,7 @@ class TSqlErrorHandlerSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "log errors correctly" in {
-    val errorCollector = new ErrorCollector("sourceCode", "fileName")
+    val errorCollector = new ProductionErrorCollector("sourceCode", "fileName")
     val token = new CommonToken(1)
     token.setLine(1)
     token.setCharPositionInLine(1)

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlParserTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlParserTestCommon.scala
@@ -1,17 +1,16 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.{ErrorCollector, ParserTestCommon}
-import org.scalatest.Assertions
+import com.databricks.labs.remorph.parsers.{ErrorCollector, ParserTestCommon, ProductionErrorCollector}
 import org.antlr.v4.runtime.{CharStream, TokenSource, TokenStream}
+import org.scalatest.Assertions
 
 trait TSqlParserTestCommon extends ParserTestCommon[TSqlParser] { self: Assertions =>
 
   override final protected def makeLexer(chars: CharStream): TokenSource = new TSqlLexer(chars)
 
-  override protected def makeErrHandler(chars: String): ErrorCollector = new ErrorCollector(chars, "-- test string --")
+  override protected def makeErrHandler(chars: String): ErrorCollector =
+    new ProductionErrorCollector(chars, "-- test string --")
 
-  override final protected def makeParser(tokenStream: TokenStream): TSqlParser = {
-    val parser = new TSqlParser(tokenStream)
-    parser
-  }
+  override final protected def makeParser(tokenStream: TokenStream): TSqlParser =
+    new TSqlParser(tokenStream)
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlParserTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlParserTestCommon.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.ParserTestCommon
+import com.databricks.labs.remorph.parsers.{ErrorCollector, ParserTestCommon}
 import org.scalatest.Assertions
 import org.antlr.v4.runtime.{CharStream, TokenSource, TokenStream}
 
@@ -8,5 +8,10 @@ trait TSqlParserTestCommon extends ParserTestCommon[TSqlParser] { self: Assertio
 
   override final protected def makeLexer(chars: CharStream): TokenSource = new TSqlLexer(chars)
 
-  override final protected def makeParser(tokenStream: TokenStream): TSqlParser = new TSqlParser(tokenStream)
+  override protected def makeErrHandler(chars: String): ErrorCollector = new ErrorCollector(chars, "-- test string --")
+
+  override final protected def makeParser(tokenStream: TokenStream): TSqlParser = {
+    val parser = new TSqlParser(tokenStream)
+    parser
+  }
 }


### PR DESCRIPTION
A simple error collector is created, which allows determination of errors in test code and makes that a little easier. In the future, it can be expanded to support different types of errors such as semantic errors.

Closes: #340 