### PR TITLE
Implement column alias processing for TSQL

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -4127,8 +4127,8 @@ udtElem
     ;
 
 expressionElem
-    : leftAlias = columnAlias eq = EQ leftAssignment = expression
-    | expressionAs = expression asColumnAlias?
+    : columnAlias EQ expression
+    | expression asColumnAlias?
     ;
 
 selectListElem

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -23,6 +23,15 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         query = "SELECT a FROM dbo.table_x",
         expectedAst = Batch(Seq(Project(NamedTable("dbo.table_x", Map.empty, is_streaming = false), Seq(Column("a"))))))
     }
+
+    "translate column aliases" in {
+      example(
+        query = "SELECT a AS b, J = BigCol FROM dbo.table_x",
+        expectedAst = Project(
+          NamedTable("dbo.table_x", Map.empty, is_streaming = false),
+          Seq(Alias(Column("a"), Seq("b"), None), Alias(Column("BigCol"), Seq("J"), None))))
+    }
+
     "accept constants in selects" in {
       example(
         query = "SELECT 42, 6.4, 0x5A, 2.7E9, $40",

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -27,9 +27,11 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
     "translate column aliases" in {
       example(
         query = "SELECT a AS b, J = BigCol FROM dbo.table_x",
-        expectedAst = Project(
-          NamedTable("dbo.table_x", Map.empty, is_streaming = false),
-          Seq(Alias(Column("a"), Seq("b"), None), Alias(Column("BigCol"), Seq("J"), None))))
+        expectedAst = Batch(
+          Seq(
+            Project(
+              NamedTable("dbo.table_x", Map.empty, is_streaming = false),
+              Seq(Alias(Column("a"), Seq("b"), None), Alias(Column("BigCol"), Seq("J"), None))))))
     }
 
     "accept constants in selects" in {


### PR DESCRIPTION
Column aliases are now fully supported within SELECT statements and some other statements. Note that column alias is required in other places as the visitor is expanded.

Progresses: #275 