### PR TITLE
Implement the CASE expression

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -3981,6 +3981,7 @@ predicate
     | expression NOT* IN LPAREN (subquery | expressionList) RPAREN
     | expression NOT* LIKE expression (ESCAPE expression)?
     | expression IS nullNotnull
+    | expression
     ;
 
 queryExpression

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -3933,8 +3933,7 @@ primitiveExpression
 
 // https://docs.microsoft.com/en-us/sql/t-sql/language-elements/case-transact-sql
 caseExpression
-    : CASE caseExpr = expression switchSection+ (ELSE elseExpr = expression)? END
-    | CASE switchSearchConditionSection+ (ELSE elseExpr = expression)? END
+    : CASE caseExpr=expression? switchSection+ (ELSE elseExpr = expression)? END
     ;
 
 subquery
@@ -4442,10 +4441,7 @@ nodesMethod
     ;
 
 switchSection
-    : WHEN expression THEN expression
-    ;
-
-switchSearchConditionSection
+    // Nore that searchCondition includes an expression only but allows too much for case expression.. on purpose
     : WHEN searchCondition THEN expression
     ;
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -36,7 +36,7 @@ case class CTEDefinition(tableName: String, columns: Seq[Expression], cte: Relat
 
 case class Star(objectName: Option[String]) extends Expression {}
 
-case class WhenBranch(condition: Expression, expression: Expression)
+case class WhenBranch(condition: Expression, expression: Expression) extends Expression
 case class Case(expression: Option[Expression], branches: Seq[WhenBranch], otherwise: Option[Expression])
     extends Expression {}
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -112,17 +112,12 @@ class TSqlExpressionBuilder extends TSqlParserBaseVisitor[ir.Expression] with Pa
     val whenThenPairs: Seq[ir.WhenBranch] = ctx
       .switchSection()
       .asScala
-      .map { section =>
-        section.accept(this) match {
-          case wb: ir.WhenBranch => wb
-          case _ => throw new RuntimeException("Expected a WhenBranch") // Cannot reach
-        }
-      }
+      .map(buildWhen)
 
     ir.Case(caseExpr, whenThenPairs, elseExpr)
   }
 
-  override def visitSwitchSection(ctx: SwitchSectionContext): ir.Expression =
+  private def buildWhen(ctx: SwitchSectionContext): ir.WhenBranch =
     ir.WhenBranch(ctx.searchCondition.accept(this), ctx.expression().accept(this))
 
   override def visitExprFunc(ctx: ExprFuncContext): ir.Expression = ctx.functionCall.accept(this)


### PR DESCRIPTION
Implements the CASE expression in both expression and searchCondition form. Note that there is no big difference in the two cases:

```sql
CASE WHEN a <4 AND f > 0 ....
CASE e WHEN  G>5 ...
```

It is just a matter of either having the first expression or not. There is also little point in trying to enforce the difference syntactically, so the grammar is changed to accept searchCondition for all WHEN clauses.