### PR TITLE
Implement timezone and provide test case

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -151,3 +151,5 @@ case class ArrayAccess(array: Expression, index: Expression) extends Expression 
 case class JsonAccess(json: Expression, path: Seq[String]) extends Expression {}
 case class Collate(string: Expression, specification: String) extends Expression {}
 case class Iff(condition: Expression, thenBranch: Expression, elseBranch: Expression) extends Expression {}
+
+case class Timezone(expression: Expression, timeZone: Expression) extends Expression {}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -135,6 +135,12 @@ class TSqlExpressionBuilder extends TSqlParserBaseVisitor[ir.Expression] with Pa
     buildConstant(ctx.con)
   }
 
+  override def visitExprTz(ctx: ExprTzContext): ir.Expression = {
+    val expression = ctx.expression().accept(this)
+    val timezone = ctx.timeZone.expression().accept(this)
+    ir.Timezone(expression, timezone)
+  }
+
   override def visitScNot(ctx: TSqlParser.ScNotContext): ir.Expression =
     ir.Not(ctx.searchCondition().accept(this))
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -431,5 +431,9 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
     "translate the $ACTION special column reference" in {
       example("$ACTION", _.expression(), ir.DollarAction())
     }
+
+    "translate a timezone reference" in {
+      example("a AT TIME ZONE 'UTC'", _.expression(), ir.Timezone(ir.Column("a"), ir.Literal(string = Some("UTC"))))
+    }
   }
 }


### PR DESCRIPTION
Timezone specification is very simple and is part of the expression tree:

```sql
a AT TIME ZONE 'UTC'
```

Visitor implemented and test provided.

Progresses: #275 