### PR TITLE
Refactor Sowflake `expr` rule using labels

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -3679,32 +3679,34 @@ expr_list_sorted
     ;
 
 expr
-    : object_name DOT NEXTVAL
-    | expr LSB expr RSB //array access
-    | expr COLON json_path   //json access
-    | expr DOT (VALUE | expr)
-    | expr COLLATE string
-    | case_expression
-    | iff_expr
-    | bracket_expression
-    | op = ( PLUS | MINUS) expr
-    | expr op = (STAR | DIVIDE | MODULE) expr
-    | expr op = (PLUS | MINUS | PIPE_PIPE) expr
-    | expr comparison_operator expr
-    | op = NOT+ expr
-    | expr AND expr //bool operation
-    | expr OR expr  //bool operation
-    | arr_literal
+    : object_name DOT NEXTVAL                       #exprNextval
+    | expr LSB expr RSB                             #exprArrayAccess
+    | expr COLON json_path                          #exprJsonAccess
+    | expr DOT (VALUE | expr)                       #exprDot
+    | expr COLLATE string                           #exprCollate
+    | case_expression                               #exprCase
+    | iff_expr                                      #exprIff
+    | bracket_expression                            #exprBracket
+    | sign expr                                     #exprSign
+    | expr op = (STAR | DIVIDE | MODULE) expr       #exprPrecedence0
+    | expr op = (PLUS | MINUS | PIPE_PIPE) expr     #exprPrecedence1
+    | expr comparison_operator expr                 #exprComparison
+    | op = NOT+ expr                                #exprNot
+    | expr AND expr                                 #exprAnd
+    | expr OR expr                                  #exprOr
+    | arr_literal                                   #exprArrayLit
     //    | expr time_zone
-    | expr over_clause
-    | cast_expr
-    | expr COLON_COLON data_type // Cast also
-    | json_literal
-    | trim_expression
-    | function_call
-    | subquery // Probably wrong
-    | expr predicate_partial
-    | primitive_expression //Should be latest rule as it's nearly a catch all
+    | expr over_clause                              #exprOver
+    | cast_expr                                     #exprCast
+    | expr COLON_COLON data_type                    #exprAscribe
+    | json_literal                                  #exprJsonLit
+    | trim_expression                               #exprTrim
+    | function_call                                 #exprFuncCall
+    // Probably wrong
+    | subquery                                      #exprSubquery
+    | expr predicate_partial                        #exprPredicate
+    //Should be latest rule as it's nearly a catch all
+    | primitive_expression                          #exprPrimitive
     ;
 
 predicate_partial

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
@@ -1,17 +1,12 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
 import com.databricks.labs.remorph.parsers.intermediate._
-import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser._
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import org.mockito.Mockito._
 import org.scalatest.Checkpoints.Checkpoint
-import org.scalatestplus.mockito.MockitoSugar
 
-import scala.collection.JavaConverters._
-
-class SnowflakeExprSpec extends AnyWordSpec with SnowflakeParserTestCommon with Matchers with MockitoSugar {
+class SnowflakeExprSpec extends AnyWordSpec with SnowflakeParserTestCommon with Matchers {
 
   override protected def astBuilder: SnowflakeExpressionBuilder = new SnowflakeExpressionBuilder
 
@@ -176,17 +171,4 @@ class SnowflakeExprSpec extends AnyWordSpec with SnowflakeParserTestCommon with 
     }
   }
 
-  "SnowflakeExpressionBuilder.buildOp" should {
-    "handle unresolved input" in {
-      val exprContext = mock[ExprContext]
-      val threeOperands = List.fill[ExprContext](3)(mock[ExprContext]).asJava
-      when(exprContext.expr()).thenReturn(threeOperands)
-      val dummyTextForExprContext = "dummy"
-      when(exprContext.getText).thenReturn(dummyTextForExprContext)
-      astBuilder.buildOp(exprContext) shouldBe UnresolvedExpression(dummyTextForExprContext)
-      verify(exprContext).expr()
-      verify(exprContext).getText
-      verifyNoMoreInteractions(exprContext)
-    }
-  }
 }


### PR DESCRIPTION
That allows for simpler implementation of the translation relying on method dispatch rather than pattern-matching.