### PR TITLE
Removes VALUE as a special function case

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -923,7 +923,7 @@ VALIDATION                                  : 'VALIDATION';
 VALID_XML                                   : 'VALID_XML';
 VALUE                                       : 'VALUE';
 VALUES                                      : 'VALUES';
-VALUE_SQUARE_BRACKET                        : '[VALUE]';
+VAR                                         : 'VAR';
 VARBINARY_KEYWORD                           : 'VARBINARY';
 VARYING                                     : 'VARYING';
 VERBOSELOGGING                              : 'VERBOSELOGGING';

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -3904,7 +3904,6 @@ expression
     | caseExpression                                            #exprCase
     | expression timeZone                                       #exprTz
     | expression overClause                                     #exprOver
-    | valueCall                                                 #exprValue
     | id                                                        #exprId
     | DOLLAR_ACTION                                             #exprDollar
     | <assoc=right> expression DOT expression                   #exprDot
@@ -4381,11 +4380,7 @@ valueMethod
         | valueId = fullColumnName
         | eventdata = EVENTDATA LPAREN RPAREN
         | LPAREN subquery RPAREN
-    ) DOT call = valueCall
-    ;
-
-valueCall
-    : (VALUE | VALUE_SQUARE_BRACKET) LPAREN xquery = STRING COMMA sqltype = STRING RPAREN
+    ) DOT standardFunction
     ;
 
 hierarchyidStaticMethod
@@ -5228,7 +5223,7 @@ keyword
     | VALID_XML
     | VALIDATION
     | VALUE
-    | VALUE_SQUARE_BRACKET
+    | VAR
     | VARBINARY_KEYWORD
     | VERIFY_CLONEDB
     | VERSION

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/FunctionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/FunctionBuilder.scala
@@ -297,6 +297,17 @@ object FunctionBuilder {
    *   function name for use in lookup/matching
    */
   private def removeQuotesAndBrackets(str: String): String = {
-    str.replaceAll("^['\"\\[]|['\"\\]]$", "")
+    val quotations = Map('\'' -> "'", '"' -> "\"", '[' -> "]", '\\' -> "\\")
+    str match {
+      case s if s.length < 2 => s
+      case s =>
+        quotations.get(s.head).fold(s){ closingQuote =>
+          if (s.endsWith(closingQuote)) {
+            s.substring(1, s.length - 1)
+          } else {
+            s
+          }
+        }
+    }
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/FunctionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/FunctionBuilder.scala
@@ -301,7 +301,7 @@ object FunctionBuilder {
     str match {
       case s if s.length < 2 => s
       case s =>
-        quotations.get(s.head).fold(s){ closingQuote =>
+        quotations.get(s.head).fold(s) { closingQuote =>
           if (s.endsWith(closingQuote)) {
             s.substring(1, s.length - 1)
           } else {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/FunctionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/FunctionBuilder.scala
@@ -277,7 +277,7 @@ object FunctionBuilder {
       // Found the function but the arg count is incorrect
       case Some(_) =>
         ir.UnresolvedFunction(
-          name,
+          irName,
           args,
           is_distinct = false,
           is_user_defined_function = false,
@@ -285,7 +285,7 @@ object FunctionBuilder {
 
       // Unsupported function
       case None =>
-        ir.UnresolvedFunction(name, args, is_distinct = false, is_user_defined_function = false)
+        ir.UnresolvedFunction(irName, args, is_distinct = false, is_user_defined_function = false)
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/FunctionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/FunctionBuilder.scala
@@ -297,12 +297,6 @@ object FunctionBuilder {
    *   function name for use in lookup/matching
    */
   private def removeQuotesAndBrackets(str: String): String = {
-    str
-      .stripPrefix("'")
-      .stripSuffix("'")
-      .stripPrefix("[")
-      .stripSuffix("]")
-      .stripPrefix("\"")
-      .stripSuffix("\"")
+    str.replaceAll("^['\"\\[]|['\"\\]]$", "")
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -1,5 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql
 
+import com.databricks.labs.remorph.parsers.FunctionBuilder
 import com.databricks.labs.remorph.parsers.intermediate._
 import org.mockito.Mockito.{mock, when}
 import org.scalatest.Assertion
@@ -339,6 +340,46 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
       val result = tSqlRelationBuilder.visitTableSources(mockTableSourcesContext)
 
       result shouldBe NoTable
+    }
+  }
+
+  "FunctionBuilder" should {
+
+    "remove quotes and brackets from function names" in {
+      // Test function name with less than 2 characters
+      val result1 = FunctionBuilder.buildFunction("a", Seq())
+      result1 match {
+        case f: UnresolvedFunction => f.function_name shouldBe "a"
+        case _ => fail("Unexpected function type")
+      }
+
+      // Test function name with matching quotes
+      val result2 = FunctionBuilder.buildFunction("'quoted'", Seq())
+      result2 match {
+        case f: UnresolvedFunction => f.function_name shouldBe "quoted"
+        case _ => fail("Unexpected function type")
+      }
+
+      // Test function name with matching brackets
+      val result3 = FunctionBuilder.buildFunction("[bracketed]", Seq())
+      result3 match {
+        case f: UnresolvedFunction => f.function_name shouldBe "bracketed"
+        case _ => fail("Unexpected function type")
+      }
+
+      // Test function name with matching backslashes
+      val result4 = FunctionBuilder.buildFunction("\\backslashed\\", Seq())
+      result4 match {
+        case f: UnresolvedFunction => f.function_name shouldBe "backslashed"
+        case _ => fail("Unexpected function type")
+      }
+
+      // Test function name with non-matching quotes
+      val result5 = FunctionBuilder.buildFunction("'nonmatching", Seq())
+      result5 match {
+        case f: UnresolvedFunction => f.function_name shouldBe "'nonmatching"
+        case _ => fail("Unexpected function type")
+      }
     }
   }
 }


### PR DESCRIPTION
Other than trying to enforce string only arguments, value is not a special case of functions and has been moved to the function table. The parser is not the place to enforce types anyway, as syntax errors are much less useful than semantic errors.

Progresses: #275 