### PR TITLE
TSQL: Implement the special $ACTION column with test coverage

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -4,6 +4,7 @@ trait AstExtension
 
 case class Column(name: String) extends Expression with AstExtension {}
 case class Identifier(name: String, isQuoted: Boolean) extends Expression with AstExtension {}
+case class DollarAction() extends Expression with AstExtension {}
 
 abstract class Unary(pred: Expression) extends Expression {}
 abstract class Binary(left: Expression, right: Expression) extends Expression {}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -123,6 +123,8 @@ class TSqlExpressionBuilder extends TSqlParserBaseVisitor[ir.Expression] with Pa
 
   override def visitExprFunc(ctx: ExprFuncContext): ir.Expression = ctx.functionCall.accept(this)
 
+  override def visitExprDollar(ctx: ExprDollarContext): ir.Expression = ir.DollarAction()
+
   override def visitExprCollate(ctx: ExprCollateContext): ir.Expression =
     ir.Collate(ctx.expression.accept(this), removeQuotes(ctx.id.getText))
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -427,5 +427,9 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
             ir.WhenBranch(ir.Equals(ir.Column("a"), ir.Literal(integer = Some(2))), ir.Literal(string = Some("two")))),
           None))
     }
+
+    "translate the $ACTION special column reference" in {
+      example("$ACTION", _.expression(), ir.DollarAction())
+    }
   }
 }


### PR DESCRIPTION
$ACTION is a special column reference in TSQL that returns a text string such as "INSERT", "DELETE", "UPDATE" and is referenced in the OUTPUT specification of certain statements such as UPDATE, INSERT, DELETE.

New Ir required to specify it.

Progresses: #275