### PR TITLE
TSQL: Adds full support for Money, negative constants

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -1008,29 +1008,32 @@ SINGLE_QUOTE       : '\'';
 SQUARE_BRACKET_ID  : '[' (~']' | ']' ']')* ']';
 LOCAL_ID           : '@' ([A-Z_$@#0-9] | FullWidthLetter)*;
 TEMP_ID            : '#' ([A-Z_$@#0-9] | FullWidthLetter)*;
-INT            : DEC_DIGIT+;
+
 ID                 : ( [A-Z_#] | FullWidthLetter) ( [A-Z_#$@0-9] | FullWidthLetter)*;
 STRING options {
     caseInsensitive = false;
 }      : 'N'? '\'' (~'\'' | '\'\'')* '\'';
-HEX : '0' 'X' HEX_DIGIT*;
-FLOAT  : DEC_DOT_DEC;
-REAL   : (INT | DEC_DOT_DEC) ('E' [+-]? DEC_DIGIT+);
 
-EQ: '=';
+fragment SIGN: [+-];
 
+INT         : SIGN? DEC_DIGIT+;
+HEX         : SIGN? '0' 'X' HEX_DIGIT*;
+FLOAT       : SIGN? DEC_DOT_DEC;
+REAL        : SIGN? (INT | DEC_DOT_DEC) ('E' [+-]? DEC_DIGIT+);
+MONEY       : SIGN? '$' (INT | FLOAT);
+
+EQ          : '=';
 GT          : '>';
 LT          : '<';
 BANG        : '!';
-
-PE  : '+=';
-ME : '-=';
-SE  : '*=';
-DE   : '/=';
-MEA   : '%=';
-AND_ASSIGN   : '&=';
-XOR_ASSIGN   : '^=';
-OR_ASSIGN    : '|=';
+PE          : '+=';
+ME          : '-=';
+SE          : '*=';
+DE          : '/=';
+MEA         : '%=';
+AND_ASSIGN  : '&=';
+XOR_ASSIGN  : '^=';
+OR_ASSIGN   : '|=';
 
 DOUBLE_BAR   : '||';
 DOT          : '.';

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -3927,7 +3927,7 @@ primitiveExpression
     : DEFAULT
     | NULL_
     | LOCAL_ID
-    | primitiveConstant
+    | constant
     ;
 
 // https://docs.microsoft.com/en-us/sql/t-sql/language-elements/case-transact-sql
@@ -4793,23 +4793,14 @@ dataType
 
 // https://msdn.microsoft.com/en-us/library/ms179899.aspx
 constant
-    : STRING // string, datetime or uniqueidentifier
-    | HEX
-    | MINUS? (INT | REAL | FLOAT)                    // float or decimal
-    | MINUS? DOLLAR (MINUS | PLUS)? (INT | FLOAT) // money
-    | parameter
-    ;
-
-// To reduce ambiguity, -X is considered as an application of unary operator
-primitiveConstant
     : con = (
-              STRING // string, datetime or uniqueidentifier
-            | HEX
-            | INT
-            | REAL
-            | FLOAT
-            )
-    | DOLLAR (MINUS | PLUS)? (INT | FLOAT) // money
+          STRING
+        | HEX
+        | INT
+        | REAL
+        | FLOAT
+        | MONEY
+        )
     | parameter
     ;
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -153,3 +153,5 @@ case class Collate(string: Expression, specification: String) extends Expression
 case class Iff(condition: Expression, thenBranch: Expression, elseBranch: Expression) extends Expression {}
 
 case class Timezone(expression: Expression, timeZone: Expression) extends Expression {}
+
+case class Money(value: Literal) extends Expression {}

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -36,7 +36,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
 
     "accept constants in selects" in {
       example(
-        query = "SELECT 42, 6.4, 0x5A, 2.7E9, $40",
+        query = "SELECT 42, 6.4, 0x5A, 2.7E9, 4.24523534425245E10, $40",
         expectedAst = Batch(
           Seq(Project(
             NoTable(),
@@ -44,8 +44,9 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               Literal(integer = Some(42)),
               Literal(float = Some(6.4f)),
               Literal(string = Some("0x5A")),
-              Literal(double = Some(2.7e9)),
-              Literal(string = Some("$40")))))))
+              Literal(long = Some(2700000000L)),
+              Literal(double = Some(4.24523534425245e10)),
+              Money(Literal(string = Some("$40"))))))))
     }
 
     "translate collation specifiers" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -12,11 +12,12 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
     "translate literals" in {
       example("null", _.expression(), ir.Literal(nullType = Some(ir.NullType())))
       example("1", _.expression(), ir.Literal(integer = Some(1)))
+      example("-1", _.expression(), ir.Literal(integer = Some(-1)))
+      example("+1", _.expression(), ir.Literal(integer = Some(1)))
       example("1.1", _.expression(), ir.Literal(float = Some(1.1f)))
       example("'foo'", _.expression(), ir.Literal(string = Some("foo")))
     }
-    // TODO: note that scientific notation and decimals are not correctly handled if we copy SnowFlake
-    "translate scientific notation" ignore {
+    "translate scientific notation" in {
       example("1.1e2", _.expression(), ir.Literal(integer = Some(110)))
       example("1.1e-2", _.expression(), ir.Literal(float = Some(0.011f)))
       example("1e2", _.expression(), ir.Literal(integer = Some(100)))
@@ -79,7 +80,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
       example(
         "1 + -++-2",
         _.expression(),
-        ir.Add(ir.Literal(integer = Some(1)), ir.UMinus(ir.UPlus(ir.UPlus(ir.UMinus(ir.Literal(integer = Some(2))))))))
+        ir.Add(ir.Literal(integer = Some(1)), ir.UMinus(ir.UPlus(ir.UPlus(ir.Literal(integer = Some(-2)))))))
       example(
         "1 + ~ 2 * 3",
         _.expression(),
@@ -91,7 +92,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
         _.expression(),
         ir.Add(
           ir.Literal(integer = Some(1)),
-          ir.Multiply(ir.UMinus(ir.Literal(integer = Some(2))), ir.Literal(integer = Some(3)))))
+          ir.Multiply(ir.Literal(integer = Some(-2)), ir.Literal(integer = Some(3)))))
       example(
         "1 + -2 * 3 + 7 & 66",
         _.expression(),
@@ -99,7 +100,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
           ir.Add(
             ir.Add(
               ir.Literal(integer = Some(1)),
-              ir.Multiply(ir.UMinus(ir.Literal(integer = Some(2))), ir.Literal(integer = Some(3)))),
+              ir.Multiply(ir.Literal(integer = Some(-2)), ir.Literal(integer = Some(3)))),
             ir.Literal(integer = Some(7))),
           ir.Literal(integer = Some(66))))
       example(
@@ -109,7 +110,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
           ir.Add(
             ir.Add(
               ir.Literal(integer = Some(1)),
-              ir.Multiply(ir.UMinus(ir.Literal(integer = Some(2))), ir.Literal(integer = Some(3)))),
+              ir.Multiply(ir.Literal(integer = Some(-2)), ir.Literal(integer = Some(3)))),
             ir.Literal(integer = Some(7))),
           ir.Literal(integer = Some(66))))
       example(
@@ -119,7 +120,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
           ir.Add(
             ir.Add(
               ir.Literal(integer = Some(1)),
-              ir.Multiply(ir.UMinus(ir.Literal(integer = Some(2))), ir.Literal(integer = Some(3)))),
+              ir.Multiply(ir.Literal(integer = Some(-2)), ir.Literal(integer = Some(3)))),
             ir.Literal(integer = Some(7))),
           ir.Literal(integer = Some(66))))
       example(
@@ -129,7 +130,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
           ir.Add(
             ir.Add(
               ir.Literal(integer = Some(1)),
-              ir.Multiply(ir.UMinus(ir.Literal(integer = Some(2))), ir.Literal(integer = Some(3)))),
+              ir.Multiply(ir.Literal(integer = Some(-2)), ir.Literal(integer = Some(3)))),
             ir.Literal(integer = Some(7))),
           ir.BitwiseNot(ir.Literal(integer = Some(66)))))
       example(
@@ -142,7 +143,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
                 ir.Add(
                   ir.Add(
                     ir.Literal(integer = Some(1)),
-                    ir.Multiply(ir.UMinus(ir.Literal(integer = Some(2))), ir.Literal(integer = Some(3)))),
+                    ir.Multiply(ir.Literal(integer = Some(-2)), ir.Literal(integer = Some(3)))),
                   ir.Literal(integer = Some(7))),
                 ir.Literal(integer = Some(1980))),
               ir.Literal(string = Some("leeds1"))),


### PR DESCRIPTION
Moves negative constants to the lexer, where they are more easily processed.  Performs numeric conversion as per Snowflake, whereby the smallest numeric representation is used but no smaller than integer. We also support Money directly as it is a specific type and is represented as such in the IR.

