### PR TITLE
Implement scalar sub queries for expressions

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -152,4 +152,6 @@ case class JsonAccess(json: Expression, path: Seq[String]) extends Expression {}
 case class Collate(string: Expression, specification: String) extends Expression {}
 case class Iff(condition: Expression, thenBranch: Expression, elseBranch: Expression) extends Expression {}
 
+case class ScalarSubquery(relation: Relation) extends Expression {}
+
 case class Timezone(expression: Expression, timeZone: Expression) extends Expression {}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -135,6 +135,10 @@ class TSqlExpressionBuilder extends TSqlParserBaseVisitor[ir.Expression] with Pa
     buildConstant(ctx.con)
   }
 
+  override def visitExprSubquery(ctx: ExprSubqueryContext): ir.Expression = {
+    ir.ScalarSubquery(ctx.subquery().accept(new TSqlRelationBuilder))
+  }
+
   override def visitExprTz(ctx: ExprTzContext): ir.Expression = {
     val expression = ctx.expression().accept(this)
     val timezone = ctx.timeZone.expression().accept(this)

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -163,5 +163,24 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               JoinDataType(is_left_struct = false, is_right_struct = false)),
             List(Column("T1.A"))))))
     }
+    "translate scalar subqueries" in {
+      example(
+        query = """SELECT
+                          EmployeeID,
+                          Name,
+                          (SELECT AvgSalary FROM Employees) AS AverageSalary
+                      FROM
+                          Employees;""",
+        expectedAst = Batch(
+          Seq(Project(
+            NamedTable("Employees", Map(), is_streaming = false),
+            Seq(
+              Column("EmployeeID"),
+              Column("Name"),
+              Alias(
+                ScalarSubquery(Project(NamedTable("Employees", Map(), is_streaming = false), Seq(Column("AvgSalary")))),
+                Seq("AverageSalary"),
+                None))))))
+    }
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -163,7 +163,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               JoinDataType(is_left_struct = false, is_right_struct = false)),
             List(Column("T1.A"))))))
     }
-    "translate scalar subqueries" in {
+    "translate scalar subqueries as expressions in select list" in {
       example(
         query = """SELECT
                           EmployeeID,


### PR DESCRIPTION
Scalar subqueries return exactly one row with one column and can be used as expressions in SELECT lists and WHERE clauses amongst other things.  

Note that the parser and AST builder do not check to see if the sub-query is actually a scalar.