### PR TITLE
TSQL: Add support for *, INSERTED.*, DELETED.* in SELECT <list>

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,2 @@
 ignore:
-  - "**/*.g4"
   - core/src/main/scala/com/databricks/labs/remorph/parsers/FunctionBuilder.scala

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,3 @@
 ignore:
+  - "**/*.g4"
   - core/src/main/scala/com/databricks/labs/remorph/parsers/FunctionBuilder.scala

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -131,7 +131,6 @@ BINDING                                     : 'BINDING';
 BLOB_STORAGE                                : 'BLOB_STORAGE';
 BLOCK                                       : 'BLOCK';
 BLOCKERS                                    : 'BLOCKERS';
-BLOCKING_HIERARCHY                          : 'BLOCKING_HIERARCHY';
 BLOCKSIZE                                   : 'BLOCKSIZE';
 BREAK                                       : 'BREAK';
 BROKER                                      : 'BROKER';

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -4116,8 +4116,8 @@ udtMethodArguments
 
 // https://docs.microsoft.com/ru-ru/sql/t-sql/queries/select-clause-transact-sql
 asterisk
-    : (tableName DOT)? STAR
-    | (INSERTED | DELETED) DOT STAR
+    : (INSERTED | DELETED) DOT STAR
+    | (tableName DOT)? STAR
     ;
 
 udtElem

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -2050,7 +2050,7 @@ createPartitionScheme
     ;
 
 createQueue
-    : CREATE QUEUE (fullTableName | queueName = id) queueSettings? (
+    : CREATE QUEUE (tableName | queueName = id) queueSettings? (
         ON filegroup = id
         | DEFAULT
     )?
@@ -2072,7 +2072,7 @@ queueSettings
     ;
 
 alterQueue
-    : ALTER QUEUE (fullTableName | queueName = id) (queueSettings | queueAction)
+    : ALTER QUEUE (tableName | queueName = id) (queueSettings | queueAction)
     ;
 
 queueAction
@@ -2164,7 +2164,7 @@ insertStatementValue
     ;
 
 receiveStatement
-    : LPAREN? RECEIVE (ALL | DISTINCT | topClause | STAR) (LOCAL_ID EQ expression COMMA?)* FROM fullTableName (
+    : LPAREN? RECEIVE (ALL | DISTINCT | topClause | STAR) (LOCAL_ID EQ expression COMMA?)* FROM tableName (
         INTO tableVariable = id (WHERE where = searchCondition)
     )? RPAREN?
     ;
@@ -2487,7 +2487,7 @@ createStatistics
     ;
 
 updateStatistics
-    : UPDATE STATISTICS fullTableName (id | LPAREN id ( COMMA id)* RPAREN)? updateStatisticsOptions?
+    : UPDATE STATISTICS tableName (id | LPAREN id ( COMMA id)* RPAREN)? updateStatisticsOptions?
     ;
 
 updateStatisticsOptions
@@ -2893,7 +2893,7 @@ dropIndex
     ;
 
 dropRelationalOrXmlOrSpatialIndex
-    : indexName = id ON fullTableName
+    : indexName = id ON tableName
     ;
 
 dropBackwardCompatibleIndex
@@ -4153,8 +4153,8 @@ tableSource
     ;
 
 tableSourceItem
-    : fullTableName deprecatedTableHint asTableAlias // this is currently allowed
-    | fullTableName asTableAlias? (
+    : tableName deprecatedTableHint asTableAlias // this is currently allowed
+    | tableName asTableAlias? (
         withTableHints
         | deprecatedTableHint
         | sybaseLegacyHints
@@ -4638,20 +4638,8 @@ entityNameForParallelDw
     | schema = id DOT objectName = id
     ;
 
-fullTableName
-    : (
-        linkedServer = id DOT DOT schema = id DOT
-        | server = id DOT database = id DOT schema = id DOT
-        | database = id DOT schema = id? DOT
-        | schema = id DOT
-    )? table = id
-    ;
-
 tableName
-    : (database = id DOT schema = id? DOT | schema = id DOT)? (
-        table = id
-        | blockingHierarchy = BLOCKING_HIERARCHY
-    )
+    : (linkedServer = id DOT DOT)? ids+=id (DOT ids +=id)*
     ;
 
 simpleName
@@ -4673,12 +4661,12 @@ funcProcNameServerDatabaseSchema
     ;
 
 ddlObject
-    : fullTableName
+    : tableName
     | LOCAL_ID
     ;
 
 fullColumnName
-    : ((DELETED | INSERTED | fullTableName) DOT)? (
+    : ((DELETED | INSERTED | tableName) DOT)? (
           id
         | (DOLLAR (IDENTITY | ROWGUID))
     )
@@ -5363,7 +5351,6 @@ keyword
     | BLOCK
     | BLOCKERS
     | BLOCKSIZE
-    | BLOCKING_HIERARCHY
     | BUFFER
     | BUFFERCOUNT
     | CACHE

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -54,8 +54,6 @@ case class RLike(expression: Expression, pattern: Expression) extends Expression
 
 case class IsNull(expression: Expression) extends Expression {}
 
-case class UnresolvedOperator(unparsed_target: String) extends Expression {}
-
 // TODO: TSQL grammar has a number of operators not yet supported - add them here, if not already supported
 
 // Operators, in order of precedence
@@ -84,7 +82,8 @@ case class BitwiseXor(left: Expression, right: Expression) extends Binary(left, 
 case class Concat(left: Expression, right: Expression) extends Binary(left, right) {}
 
 // Some statements, such as SELECT, do not require a table specification
-case class NoTable() extends Relation {}
+case object NoTable extends Relation {}
+
 // It was not clear to me the NamedTable options should be used for the alias. I'm assuming it is not what
 // they are for.
 case class TableAlias(relation: Relation, alias: String) extends Relation {}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -36,6 +36,8 @@ case class WithCTE(ctes: Seq[Relation], query: Relation) extends RelationCommon 
 case class CTEDefinition(tableName: String, columns: Seq[Expression], cte: Relation) extends RelationCommon {}
 
 case class Star(objectName: Option[String]) extends Expression {}
+case class Inserted(selection: Expression) extends Expression()
+case class Deleted(selection: Expression) extends Expression()
 
 case class WhenBranch(condition: Expression, expression: Expression) extends Expression
 case class Case(expression: Option[Expression], branches: Seq[WhenBranch], otherwise: Option[Expression])

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -14,9 +14,7 @@ class TSqlExpressionBuilder extends TSqlParserBaseVisitor[ir.Expression] with Pa
       // TODO: asterisk not fully handled
       case c if c.asterisk() != null => c.asterisk().accept(this)
       case c if c.expressionElem() != null => ctx.expressionElem().accept(this)
-      // $COVERAGE-OFF$  coverage is complete for what we have written so far
       case _ => ir.UnresolvedExpression("Unsupported SelectListElem")
-      // $COVERAGE-ON$
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -14,7 +14,9 @@ class TSqlExpressionBuilder extends TSqlParserBaseVisitor[ir.Expression] with Pa
       // TODO: asterisk not fully handled
       case c if c.asterisk() != null => c.asterisk().accept(this)
       case c if c.expressionElem() != null => ctx.expressionElem().accept(this)
+      // $COVERAGE-OFF$  coverage is complete for what we have written so far
       case _ => ir.UnresolvedExpression("Unsupported SelectListElem")
+      // $COVERAGE-ON$
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -56,9 +56,9 @@ class TSqlRelationBuilder extends TSqlParserBaseVisitor[ir.Relation] {
             ir.CrossJoin,
             Seq.empty,
             ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
-      // GCOVR_EXCL_START  ctx.tableSource always returns at least 1 element
+      // $COVERAGE-OFF$  ctx.tableSource always returns at least 1 element
       case _ => ir.NoTable
-      // GCOVR_EXCL_STOP
+      // $COVERAGE-ON$
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -27,7 +27,7 @@ class TSqlRelationBuilder extends TSqlParserBaseVisitor[ir.Relation] {
 
     val columns =
       ctx.selectListElem().asScala.map(_.accept(new TSqlExpressionBuilder()))
-    val from = Option(ctx.tableSources()).map(_.accept(new TSqlRelationBuilder)).getOrElse(ir.NoTable())
+    val from = Option(ctx.tableSources()).map(_.accept(new TSqlRelationBuilder)).getOrElse(ir.NoTable)
 
     ir.Project(from, columns)
   }
@@ -57,7 +57,7 @@ class TSqlRelationBuilder extends TSqlParserBaseVisitor[ir.Relation] {
             Seq.empty,
             ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
       // GCOVR_EXCL_START  ctx.tableSource always returns at least 1 element
-      case _ => ir.NoTable()
+      case _ => ir.NoTable
       // GCOVR_EXCL_STOP
     }
   }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -56,9 +56,7 @@ class TSqlRelationBuilder extends TSqlParserBaseVisitor[ir.Relation] {
             ir.CrossJoin,
             Seq.empty,
             ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
-      // $COVERAGE-OFF$  ctx.tableSource always returns at least 1 element
       case _ => ir.NoTable
-      // $COVERAGE-ON$
     }
   }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -1,9 +1,12 @@
 package com.databricks.labs.remorph.parsers.tsql
 
 import com.databricks.labs.remorph.parsers.intermediate._
+import org.mockito.Mockito.{mock, when}
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import java.util.Collections
 
 class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers {
 
@@ -195,6 +198,20 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 ScalarSubquery(Project(NamedTable("Employees", Map(), is_streaming = false), Seq(Column("AvgSalary")))),
                 Seq("AverageSalary"),
                 None))))))
+    }
+  }
+
+  "visitTableSources" should {
+    "return NoTable when tableSource is empty" in {
+      val mockTableSourcesContext: TSqlParser.TableSourcesContext = mock(classOf[TSqlParser.TableSourcesContext])
+
+      when(mockTableSourcesContext.tableSource())
+        .thenReturn(Collections.emptyList().asInstanceOf[java.util.List[TSqlParser.TableSourceContext]])
+
+      val tSqlRelationBuilder = new TSqlRelationBuilder()
+      val result = tSqlRelationBuilder.visitTableSources(mockTableSourcesContext)
+
+      result shouldBe NoTable
     }
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -1,6 +1,7 @@
 package com.databricks.labs.remorph.parsers.tsql
 
 import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import org.mockito.Mockito.{mock, when}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -436,5 +437,21 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
     "translate a timezone reference" in {
       example("a AT TIME ZONE 'UTC'", _.expression(), ir.Timezone(ir.Column("a"), ir.Literal(string = Some("UTC"))))
     }
+
+    "return UnresolvedExpression for unsupported SelectListElem" in {
+      val builder = new TSqlExpressionBuilder
+      val mockCtx = mock(classOf[TSqlParser.SelectListElemContext])
+
+      // Ensure that both asterisk() and expressionElem() methods return null
+      when(mockCtx.asterisk()).thenReturn(null)
+      when(mockCtx.expressionElem()).thenReturn(null)
+
+      // Call the method with the mock instance
+      val result = builder.visitSelectListElem(mockCtx)
+
+      // Verify the result
+      result shouldBe a[ir.UnresolvedExpression]
+    }
   }
+
 }


### PR DESCRIPTION
 Adds support for select list elements involving `*`:
  
  ```sql
SELECT *
SELECT t.*
SELECT server..t.x.*

DELETE FROM TestTable
   OUTPUT deleted.*
   WHERE ID = 2; 
 ``` 
  
 Also simplifies tableName and removes fullTableName
 
 Relies on: #373 
 