### PR TITLE
TSQL: Support DISTINCT in SELECT list and aggregate functions

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -3908,7 +3908,6 @@ expression
     | DOLLAR_ACTION                                             #exprDollar
     | <assoc=right> expression DOT expression                   #exprDot
     | LPAREN subquery RPAREN                                    #exprSubquery
-    | ALL expression                                            #exprAll
     | DISTINCT expression                                       #exprDistinct
     | STAR                                                      #exprStar
     ;
@@ -3997,9 +3996,9 @@ sqlUnion
 // https://msdn.microsoft.com/en-us/library/ms176104.aspx
 // TODO: This is too much for one rule and it still misses things - rewrite
 querySpecification
-    : SELECT ad=(ALL | DISTINCT)? topClause? selectListElem (COMMA selectListElem)*
+    : SELECT (ALL | DISTINCT)? topClause? selectListElem (COMMA selectListElem)*
     // https://msdn.microsoft.com/en-us/library/ms188029.aspx
-    (INTO into =tableName)? (FROM tableSources)? (WHERE where = searchCondition)?
+    (INTO tableName)? (FROM tableSources)? (WHERE where=searchCondition)?
     // https://msdn.microsoft.com/en-us/library/ms177673.aspx
     (
         GROUP BY (
@@ -4008,7 +4007,7 @@ querySpecification
                 COMMA groupSets += groupingSetsItem
             )* RPAREN
         )
-    )? (HAVING having = searchCondition)?
+    )? (HAVING having=searchCondition)?
     ;
 
 // https://msdn.microsoft.com/en-us/library/ms189463.aspx

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -5,6 +5,7 @@ trait AstExtension
 case class Column(name: String) extends Expression with AstExtension {}
 case class Identifier(name: String, isQuoted: Boolean) extends Expression with AstExtension {}
 case class DollarAction() extends Expression with AstExtension {}
+case class Distinct(expression: Expression) extends Expression
 
 abstract class Unary(pred: Expression) extends Expression {}
 abstract class Binary(left: Expression, right: Expression) extends Expression {}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -362,4 +362,9 @@ class TSqlExpressionBuilder extends TSqlParserBaseVisitor[ir.Expression] with Pa
       case _ => columnDef
     }
   }
+
+  override def visitExprDistinct(ctx: ExprDistinctContext): ir.Expression = {
+    // Support for functions such as COUNT(DISTINCT column), which is an expression not a relation
+    ir.Distinct(ctx.expression().accept(this))
+  }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -28,8 +28,24 @@ class TSqlRelationBuilder extends TSqlParserBaseVisitor[ir.Relation] {
     val columns =
       ctx.selectListElem().asScala.map(_.accept(new TSqlExpressionBuilder()))
     val from = Option(ctx.tableSources()).map(_.accept(new TSqlRelationBuilder)).getOrElse(ir.NoTable)
+    // Note that ALL is the default so we don't need to check for it
+    ctx match {
+      case c if c.DISTINCT() != null =>
+        buildDistinct(from, columns)
+      case _ =>
+        ir.Project(from, columns)
+    }
+  }
 
-    ir.Project(from, columns)
+  private def buildDistinct(from: ir.Relation, columns: Seq[ir.Expression]): ir.Relation = {
+    val columnNames = columns.collect {
+      case ir.Column(c) => Seq(c)
+      case ir.Alias(_, a, _) => a
+      // Note that the ir.Star(None) is not matched so that we set all_columns_as_keys to true
+    }.flatten
+    ir.Project(
+      ir.Deduplicate(from, columnNames, all_columns_as_keys = columnNames.isEmpty, within_watermark = false),
+      columns)
   }
 
   override def visitTableName(ctx: TableNameContext): ir.NamedTable = {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/common/FunctionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/common/FunctionBuilderSpec.scala
@@ -1,5 +1,6 @@
 package com.databricks.labs.remorph.parsers.common
 
+import com.databricks.labs.remorph.parsers.intermediate.UnresolvedFunction
 import com.databricks.labs.remorph.parsers.{FixedArity, FunctionArity, FunctionBuilder, FunctionType, StandardFunction, UnknownFunction, VariableArity, XmlFunction}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -278,6 +279,43 @@ class FunctionBuilderSpec extends AnyFlatSpec with Matchers with TableDrivenProp
     val variableArity = VariableArity(argMin = 1, argMax = 2)
     variableArity.isConvertible should be(true)
 
+  }
+
+  "buildFunction" should "remove quotes and brackets from function names" in {
+    // Test function name with less than 2 characters
+    val result1 = FunctionBuilder.buildFunction("a", Seq())
+    result1 match {
+      case f: UnresolvedFunction => f.function_name shouldBe "a"
+      case _ => fail("Unexpected function type")
+    }
+
+    // Test function name with matching quotes
+    val result2 = FunctionBuilder.buildFunction("'quoted'", Seq())
+    result2 match {
+      case f: UnresolvedFunction => f.function_name shouldBe "quoted"
+      case _ => fail("Unexpected function type")
+    }
+
+    // Test function name with matching brackets
+    val result3 = FunctionBuilder.buildFunction("[bracketed]", Seq())
+    result3 match {
+      case f: UnresolvedFunction => f.function_name shouldBe "bracketed"
+      case _ => fail("Unexpected function type")
+    }
+
+    // Test function name with matching backslashes
+    val result4 = FunctionBuilder.buildFunction("\\backslashed\\", Seq())
+    result4 match {
+      case f: UnresolvedFunction => f.function_name shouldBe "backslashed"
+      case _ => fail("Unexpected function type")
+    }
+
+    // Test function name with non-matching quotes
+    val result5 = FunctionBuilder.buildFunction("'nonmatching", Seq())
+    result5 match {
+      case f: UnresolvedFunction => f.function_name shouldBe "'nonmatching"
+      case _ => fail("Unexpected function type")
+    }
   }
 
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
@@ -205,6 +205,10 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
 
   }
 
+  "translate functions with DISTINCT arguments" in {
+    example("COUNT(DISTINCT salary)", _.expression(), ir.CallFunction("COUNT", Seq(ir.Distinct(ir.Column("salary")))))
+  }
+
   // TODO: Analytic functions are next
   "translate analytic windowing functions in all forms" ignore {
     example(
@@ -220,9 +224,5 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
           ir.UndefinedFrame,
           ir.FrameBoundary(current_row = false, unbounded = false, ir.Noop),
           ir.FrameBoundary(current_row = false, unbounded = false, ir.Noop))))
-
-    "translate functions with DISTINCT arguments" ignore {
-      example("COUNT(DISTINCT salary)", _.expression(), ir.CallFunction("COUNT", Seq(ir.Distinct(ir.Column("salary")))))
-    }
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
@@ -220,5 +220,9 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
           ir.UndefinedFrame,
           ir.FrameBoundary(current_row = false, unbounded = false, ir.Noop),
           ir.FrameBoundary(current_row = false, unbounded = false, ir.Noop))))
+
+    "translate functions with DISTINCT arguments" ignore {
+      example("COUNT(DISTINCT salary)", _.expression(), ir.CallFunction("COUNT", Seq(ir.Distinct(ir.Column("salary")))))
+    }
   }
 }


### PR DESCRIPTION
There are two use cases for DISTINCT, one is in a `SELECT` _list_ such as:

```sql
SELECT DISTINCT a, b, c ....
```

The other is in aggregate functions, which is usually `COUNT` such as:

```sql
SELECT COUNT(DISTINCT x), y, z ...
```

Here we support `DISTINCT <expression>` and `DISTINCT` arguments to aggregate functions.

Note that `ALL` is the default behavior in SQL and therefore ALL causes no changes in the ir from how it was produced prior to this PR.

Closes: #387 