### PR TITLE
Removing quotes from exception message

### DIFF
--- a/tests/unit/reconcile/test_execute.py
+++ b/tests/unit/reconcile/test_execute.py
@@ -1350,7 +1350,7 @@ def test_schema_recon_with_data_source_exception(
         data=[
             (
                 33333,
-                ((0, 0), (0, 0, ""), False),
+                (None, None, None),
                 (
                     False,
                     "remorph",
@@ -1415,7 +1415,7 @@ def test_schema_recon_with_general_exception(
         data=[
             (
                 33333,
-                (None, None, False),
+                (None, None, None),
                 (
                     False,
                     "remorph",
@@ -1482,7 +1482,7 @@ def test_data_recon_with_general_exception(
         data=[
             (
                 33333,
-                ((0, 0), (0, 0, ""), None),
+                (None, None, None),
                 (
                     False,
                     "remorph",
@@ -1549,7 +1549,7 @@ def test_data_recon_with_source_exception(
         data=[
             (
                 33333,
-                ((0, 0), (0, 0, ""), None),
+                (None, None, None),
                 (
                     False,
                     "remorph",

--- a/tests/unit/reconcile/test_recon_capture.py
+++ b/tests/unit/reconcile/test_recon_capture.py
@@ -380,7 +380,7 @@ def test_recon_capture_start_oracle_with_exception(mock_workspace_client, mock_s
     # assert metrics
     remorph_recon_metrics_df = spark.sql("select * from DEFAULT.metrics")
     row = remorph_recon_metrics_df.collect()[0]
-    assert row.recon_metrics.schema_comparison is True
+    assert row.recon_metrics.schema_comparison is None
     assert row.run_metrics.status is False
     assert row.run_metrics.exception_message == "Test exception"
 


### PR DESCRIPTION
* Removing quotes from the exception message
* During exception, no output is given for metrics, not even default values.