### PR TITLE
Use default_factory in recon_config.py

### DIFF
--- a/src/databricks/labs/remorph/reconcile/recon_config.py
+++ b/src/databricks/labs/remorph/reconcile/recon_config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from pyspark.sql import DataFrame
 from sqlglot import Dialect
@@ -209,10 +209,10 @@ class DataReconcileOutput:
     mismatch_count: int = 0
     missing_in_src_count: int = 0
     missing_in_tgt_count: int = 0
-    mismatch: MismatchOutput = MismatchOutput()
+    mismatch: MismatchOutput = field(default_factory=MismatchOutput)
     missing_in_src: DataFrame | None = None
     missing_in_tgt: DataFrame | None = None
-    threshold_output: ThresholdOutput = ThresholdOutput()
+    threshold_output: ThresholdOutput = field(default_factory=ThresholdOutput)
     exception: str | None = None
 
 
@@ -255,7 +255,7 @@ class StatusOutput:
 class ReconcileTableOutput:
     target_table_name: str
     source_table_name: str
-    status: StatusOutput = StatusOutput()
+    status: StatusOutput = field(default_factory=StatusOutput)
     exception_message: str | None = None
 
 


### PR DESCRIPTION
With Python version 3.11, when trying to initialize the config classes, we are getting ValueError: mutable default <class 'databricks.labs.remorph.reconcile.recon_config.StatusOutput'> for field status is not allowed: use default_factory

This change addresses this error by using default_factory.