### PR TITLE
TSQL: Implement WITH CTE

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -3687,11 +3687,11 @@ subquery
     ;
 
 withExpression
-    : WITH ctes += commonTableExpression (COMMA ctes += commonTableExpression)*
+    : WITH commonTableExpression (COMMA commonTableExpression)*
     ;
 
 commonTableExpression
-    : expressionName = id (LPAREN columns = columnNameList RPAREN)? AS LPAREN cteQuery = selectStatement RPAREN
+    : id (LPAREN columnNameList RPAREN)? AS LPAREN selectStatement RPAREN
     ;
 
 updateElem
@@ -4294,7 +4294,7 @@ insertColumnId
     ;
 
 columnNameList
-    : col += id (COMMA col += id)*
+    : id (COMMA id)*
     ;
 
 cursorName

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
@@ -9,6 +9,9 @@ class SnowflakeDDLBuilder
     extends SnowflakeParserBaseVisitor[ir.Catalog]
     with ParserCommon[ir.Catalog]
     with IncompleteParser[ir.Catalog] {
+
+  private val expressionBuilder = new SnowflakeExpressionBuilder
+
   override protected def wrapUnresolvedInput(unparsedInput: String): ir.Catalog = ir.UnresolvedCatalog(unparsedInput)
 
   private def extractString(ctx: StrContext): String = {
@@ -37,7 +40,7 @@ class SnowflakeDDLBuilder
       name = ctx.arg_name().getText,
       dataType = DataTypeBuilder.buildDataType(ctx.arg_data_type().id_().data_type()),
       defaultValue = Option(ctx.arg_default_value_clause())
-        .map(_.expr().accept(new SnowflakeExpressionBuilder(new SnowflakeFunctionBuilder))))
+        .map(_.expr().accept(expressionBuilder)))
   }
 
   private def buildFunctionBody(ctx: Function_definitionContext): String = (ctx match {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -1,14 +1,16 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser._
-import com.databricks.labs.remorph.parsers.{FunctionBuilder, IncompleteParser, ParserCommon, intermediate => ir}
+import com.databricks.labs.remorph.parsers.{IncompleteParser, ParserCommon, intermediate => ir}
 import org.antlr.v4.runtime.Token
 
 import scala.collection.JavaConverters._
-class SnowflakeExpressionBuilder(functionBuilder: FunctionBuilder)
+class SnowflakeExpressionBuilder()
     extends SnowflakeParserBaseVisitor[ir.Expression]
     with ParserCommon[ir.Expression]
     with IncompleteParser[ir.Expression] {
+
+  private val functionBuilder = new SnowflakeFunctionBuilder
 
   protected override def wrapUnresolvedInput(unparsedInput: String): ir.UnresolvedExpression =
     ir.UnresolvedExpression(unparsedInput)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
@@ -8,6 +8,8 @@ import scala.collection.JavaConverters._
 
 class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] with IncompleteParser[ir.Relation] {
 
+  private val expressionBuilder = new SnowflakeExpressionBuilder
+
   protected override def wrapUnresolvedInput(unparsedInput: String): ir.Relation = ir.UnresolvedRelation(unparsedInput)
   override def visitSelect_statement(ctx: Select_statementContext): ir.Relation = {
     val select = ctx.select_optional_clauses().accept(this)
@@ -24,7 +26,7 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] w
           c.select_top_clause().select_list_top().all_distinct(),
           c.select_top_clause().select_list_top().select_list().select_list_elem().asScala)
     }
-    val expressions = selectListElements.map(_.accept(new SnowflakeExpressionBuilder(new SnowflakeFunctionBuilder)))
+    val expressions = selectListElements.map(_.accept(expressionBuilder))
     ir.Project(buildTop(top, buildDistinct(allOrDistinct, relation, expressions)), expressions)
 
   }
@@ -85,7 +87,7 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] w
 
   private def buildFilter[A](ctx: A, conditionRule: A => ParserRuleContext, input: ir.Relation): ir.Relation =
     Option(ctx).fold(input) { c =>
-      ir.Filter(input, conditionRule(c).accept(new SnowflakeExpressionBuilder(new SnowflakeFunctionBuilder)))
+      ir.Filter(input, conditionRule(c).accept(expressionBuilder))
     }
   private def buildHaving(ctx: Having_clauseContext, input: ir.Relation): ir.Relation =
     buildFilter[Having_clauseContext](ctx, _.search_condition(), input)
@@ -101,7 +103,7 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] w
         c.group_by_list()
           .group_by_elem()
           .asScala
-          .map(_.accept(new SnowflakeExpressionBuilder(new SnowflakeFunctionBuilder)))
+          .map(_.accept(expressionBuilder))
       val aggregate =
         ir.Aggregate(input = input, group_type = ir.GroupBy, grouping_expressions = groupingExpressions, pivot = None)
       buildHaving(c.having_clause(), aggregate)
@@ -111,7 +113,7 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] w
   private def buildOrderBy(ctx: Order_by_clauseContext, input: ir.Relation): ir.Relation = {
     Option(ctx).fold(input) { c =>
       val sortOrders = c.order_item().asScala.map { orderItem =>
-        val expression = orderItem.accept(new SnowflakeExpressionBuilder(new SnowflakeFunctionBuilder))
+        val expression = orderItem.accept(expressionBuilder)
         if (orderItem.DESC() == null) {
           if (orderItem.NULLS() != null && orderItem.FIRST() != null) {
             ir.SortOrder(expression, ir.AscendingSortDirection, ir.SortNullsFirst)
@@ -139,7 +141,6 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] w
     Option(ctx.as_alias()).map(a => ir.SubqueryAlias(subquery, a.alias().getText, "")).getOrElse(subquery)
   }
   override def visitValues_table_body(ctx: Values_table_bodyContext): ir.Relation = {
-    val expressionBuilder = new SnowflakeExpressionBuilder(new SnowflakeFunctionBuilder)
     val expressions =
       ctx.expr_list_in_parentheses().asScala.map(l => expressionBuilder.visitSeq(l.expr_list().expr().asScala))
     ir.Values(expressions)
@@ -163,8 +164,8 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] w
 
   private def buildPivot(ctx: Pivot_unpivotContext, relation: ir.Relation): ir.Relation = {
     val pivotValues: Seq[ir.Literal] =
-      ctx.literal().asScala.map(_.accept(new SnowflakeExpressionBuilder(new SnowflakeFunctionBuilder))).collect {
-        case lit: ir.Literal => lit
+      ctx.literal().asScala.map(_.accept(expressionBuilder)).collect { case lit: ir.Literal =>
+        lit
       }
     val pivotColumn = ir.Column(ctx.id_(2).getText)
     val aggregateFunction = translateAggregateFunction(ctx.id_(0), ctx.id_(1))
@@ -180,7 +181,7 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] w
       .column_list()
       .column_name()
       .asScala
-      .map(_.accept(new SnowflakeExpressionBuilder(new SnowflakeFunctionBuilder)))
+      .map(_.accept(expressionBuilder))
     val variableColumnName = ctx.id_(0).getText
     val valueColumnName = ctx.column_name().id_(0).getText
     ir.Unpivot(
@@ -237,7 +238,7 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] w
       .column_list()
       .column_name()
       .asScala
-      .map(_.accept(new SnowflakeExpressionBuilder(new SnowflakeFunctionBuilder)))
+      .map(_.accept(expressionBuilder))
     val query = ctx.select_statement().accept(this)
     ir.CTEDefinition(tableName, columns, query)
   }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -7,9 +7,9 @@ import org.antlr.v4.runtime.tree.{TerminalNode, Trees}
 
 import scala.collection.JavaConverters._
 
-class TSqlExpressionBuilder(functionBuilder: TSqlFunctionBuilder)
-    extends TSqlParserBaseVisitor[ir.Expression]
-    with ParserCommon[ir.Expression] {
+class TSqlExpressionBuilder() extends TSqlParserBaseVisitor[ir.Expression] with ParserCommon[ir.Expression] {
+
+  private val functionBuilder = new TSqlFunctionBuilder
 
   private val dataTypeBuilder: DataTypeBuilder = new DataTypeBuilder
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
@@ -8,8 +8,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class SnowflakeExprSpec extends AnyWordSpec with SnowflakeParserTestCommon with Matchers {
 
-  override protected def astBuilder: SnowflakeExpressionBuilder = new SnowflakeExpressionBuilder(
-    new SnowflakeFunctionBuilder)
+  override protected def astBuilder: SnowflakeExpressionBuilder = new SnowflakeExpressionBuilder
 
   private def example(input: String, expectedAst: Expression): Assertion = example(input, _.expr(), expectedAst)
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
@@ -14,7 +14,7 @@ class SnowflakeExpressionBuilderSpec
     with MockitoSugar {
 
   override protected def astBuilder: SnowflakeExpressionBuilder =
-    new SnowflakeExpressionBuilder(new SnowflakeFunctionBuilder())
+    new SnowflakeExpressionBuilder
 
   "SnowflakeExpressionBuilder" should {
     "translate literals" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -12,7 +12,8 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers {
 
-  override protected def astBuilder: TSqlParserBaseVisitor[_] = new TSqlExpressionBuilder(new TSqlFunctionBuilder)
+  override protected def astBuilder: TSqlParserBaseVisitor[_] = new TSqlExpressionBuilder
+  private val exprBuilder = new TSqlExpressionBuilder
 
   "TSqlExpressionBuilder" should {
     "translate literals" in {
@@ -257,14 +258,13 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
     }
 
     "return ir.Dot for otherwise unhandled DotExpr" in {
-      val builder = new TSqlExpressionBuilder(new TSqlFunctionBuilder)
       val mockDotExprCtx = mock(classOf[TSqlParser.ExprDotContext])
       val mockExpressionCtx = mock(classOf[TSqlParser.ExpressionContext])
       val mockVisitor = mock(classOf[TSqlExpressionBuilder])
 
       when(mockDotExprCtx.expression(anyInt())).thenReturn(mockExpressionCtx)
       when(mockExpressionCtx.accept(mockVisitor)).thenReturn(ir.Literal(string = Some("a")))
-      val result = builder.visitExprDot(mockDotExprCtx)
+      val result = astBuilder.visitExprDot(mockDotExprCtx)
 
       result shouldBe a[ir.Dot]
     }
@@ -277,8 +277,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
       when(mockCtx.CURRENT()).thenReturn(null)
       when(mockCtx.INT()).thenReturn(null)
 
-      val builder = new TSqlExpressionBuilder(new TSqlFunctionBuilder)
-      val result = builder.buildFrame(mockCtx)
+      val result = exprBuilder.buildFrame(mockCtx)
 
       // Verify the result
       result shouldBe a[FrameBoundary]
@@ -351,7 +350,6 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
     }
 
     "cover case that cannot happen with dot" in {
-      val builder = new TSqlExpressionBuilder(new TSqlFunctionBuilder)
 
       val mockCtx = mock(classOf[TSqlParser.ExprDotContext])
       val expressionMockColumn = mock(classOf[TSqlParser.ExpressionContext])
@@ -360,7 +358,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
       val expressionMockFunc = mock(classOf[TSqlParser.ExpressionContext])
       when(mockCtx.expression(1)).thenReturn(expressionMockFunc)
       when(expressionMockFunc.accept(any())).thenReturn(ir.CallFunction("UNKNOWN_FUNCTION", List()))
-      val result = builder.visitExprDot(mockCtx)
+      val result = exprBuilder.visitExprDot(mockCtx)
       result shouldBe a[ir.Dot]
     }
 
@@ -423,7 +421,6 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
     }
 
     "return UnresolvedExpression for unsupported SelectListElem" in {
-      val builder = new TSqlExpressionBuilder(new TSqlFunctionBuilder)
 
       val mockCtx = mock(classOf[TSqlParser.SelectListElemContext])
 
@@ -432,7 +429,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
       when(mockCtx.expressionElem()).thenReturn(null)
 
       // Call the method with the mock instance
-      val result = builder.visitSelectListElem(mockCtx)
+      val result = exprBuilder.visitSelectListElem(mockCtx)
 
       // Verify the result
       result shouldBe a[ir.UnresolvedExpression]
@@ -451,8 +448,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
       when(expressionContextMock.accept(any())).thenReturn(null)
       when(selectListElemContextMock.expression()).thenReturn(expressionContextMock)
 
-      val builder = new TSqlExpressionBuilder(new TSqlFunctionBuilder)
-      val result = builder.visitSelectListElem(selectListElemContextMock)
+      val result = exprBuilder.visitSelectListElem(selectListElemContextMock)
 
       result shouldBe a[ir.UnresolvedExpression]
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers {
 
-  override protected def astBuilder: TSqlParserBaseVisitor[_] = new TSqlExpressionBuilder(new TSqlFunctionBuilder)
+  override protected def astBuilder: TSqlParserBaseVisitor[_] = new TSqlExpressionBuilder
 
   "translate functions with no parameters" in {
     example("APP_NAME()", _.expression(), ir.CallFunction("APP_NAME", List()))

--- a/tests/resources/functional/tsql/select/test_cte_1.sql
+++ b/tests/resources/functional/tsql/select/test_cte_1.sql
@@ -1,0 +1,10 @@
+-- ## WITH cte SELECT
+--
+-- The use of CTEs is generally the same in Databricks SQL as TSQL but there are some differences with
+-- nesting CTE support.
+--
+-- tsql sql:
+WITH cte AS (SELECT * FROM t) SELECT * FROM cte
+GO
+-- databricks sql:
+WITH cte AS (SELECT * FROM t) SELECT * FROM cte

--- a/tests/resources/functional/tsql/select/test_cte_2.sql
+++ b/tests/resources/functional/tsql/select/test_cte_2.sql
@@ -1,0 +1,38 @@
+-- ## WITH cte SELECT
+--
+-- The use of CTEs is generally the same in Databricks SQL as TSQL but there are some differences with
+-- nesting CTE support.
+--
+-- tsql sql:
+
+WITH cteTable1 (col1, col2, col3count)
+         AS
+         (
+             SELECT col1, fred, COUNT(OrderDate) AS counter
+             FROM Table1
+         ),
+     cteTable2 (colx, coly, colxcount)
+         AS
+         (
+             SELECT col1, fred, COUNT(OrderDate) AS counter
+             FROM Table2
+         )
+SELECT col2, col1, col3count, cteTable2.colx, cteTable2.coly, cteTable2.colxcount
+FROM cteTable1
+GO
+
+-- databricks sql:
+WITH cteTable1 (col1, col2, col3count)
+         AS
+         (
+             SELECT col1, fred, COUNT(OrderDate) AS counter
+             FROM Table1
+         ),
+     cteTable2 (colx, coly, colxcount)
+         AS
+         (
+             SELECT col1, fred, COUNT(OrderDate) AS counter
+             FROM Table2
+         )
+SELECT col2, col1, col3count, cteTable2.colx, cteTable2.coly, cteTable2.colxcount
+FROM cteTable1


### PR DESCRIPTION
We implement CTE support for TSQL as in the following example:

```tsql
WITH cteTable (col1, col2, col3count)
AS
    SELECT col1, fred, COUNT(OrderDate) AS counter
    FROM Table1
    WHERE fred IS NOT NULL
)
SELECT col2, col1, col3
FROM cteTable
```