### PR TITLE
Lose superflous alt in selectListElem

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -3863,7 +3863,6 @@ selectListElem
     : asterisk
     | LOCAL_ID op=(PE | ME | SE | DE | MEA | AND_ASSIGN | XOR_ASSIGN | OR_ASSIGN | EQ) expression
     | expressionElem
-    | udtElem  // TODO: May not be needed as expressionElem could handle this?
     ;
 
 tableSources

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -17,11 +17,9 @@ class TSqlExpressionBuilder(functionBuilder: TSqlFunctionBuilder)
     ctx match {
       // TODO: asterisk not fully handled
       case c if c.asterisk() != null => c.asterisk().accept(this)
-      // TODO: UDT elements seem broken in the grammar
-      case c if c.udtElem() != null => c.udtElem().accept(this)
       case c if c.LOCAL_ID() != null => buildLocalAssign(ctx)
       case c if c.expressionElem() != null => ctx.expressionElem().accept(this)
-      // $COVERAGE-OFF$ all four possible alts in the grammar are covered
+      // $COVERAGE-OFF$ all three possible alts in the grammar are covered
       case _ => ir.UnresolvedExpression("Unsupported SelectListElem")
       // $COVERAGE-ON$
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -77,10 +77,13 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
       example(
         query = "SELECT * FROM dbo.table_x",
         expectedAst = Batch(Seq(Project(NamedTable("dbo.table_x", Map.empty, is_streaming = false), Seq(Star(None))))))
+
       example(query = "SELECT t.*", expectedAst = Batch(Seq(Project(NoTable, Seq(Star(objectName = Some("t")))))))
+
       example(
         query = "SELECT x..b.y.*",
         expectedAst = Batch(Seq(Project(NoTable, Seq(Star(objectName = Some("x..b.y")))))))
+
       // TODO: Add tests for OUTPUT clause once implemented - invalid semantics here to force coverage
       example(query = "SELECT INSERTED.*", expectedAst = Batch(Seq(Project(NoTable, Seq(Inserted(Star(None)))))))
       example(query = "SELECT DELETED.*", expectedAst = Batch(Seq(Project(NoTable, Seq(Deleted(Star(None)))))))

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -444,7 +444,6 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
       selectListElemContextMock.op = eofToken
       when(selectListElemContextMock.LOCAL_ID()).thenReturn(new TerminalNodeImpl(eofToken))
       when(selectListElemContextMock.asterisk()).thenReturn(null)
-      when(selectListElemContextMock.udtElem()).thenReturn(null)
       when(selectListElemContextMock.getText).thenReturn("")
 
       val expressionContextMock = mock(classOf[TSqlParser.ExpressionContext])


### PR DESCRIPTION
Removes superfluous alts defined in select list element rule in TSQL grammar. Also removes the accepts on it which were rightly not used.

Note that the rule for parsing udt column declarations may still be relevant for `CREATE TYPE`, hence it is not removed.