### PR TITLE
Better coverage reports

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -147,11 +147,11 @@ jobs:
 
 
       - name: Run TSQL Coverage Tests with Maven
-        run: mvn --update-snapshots -B exec:java -pl coverage --file pom.xml --fail-at-end -Dexec.args="-i tests/resources/functional/tsql -o coverage-result.json -s '-- tsql sql:'"
+        run: mvn --update-snapshots -B exec:java -pl coverage --file pom.xml --fail-at-end -DsourceDir=tests/resources/functional/tsql -DoutputPath=coverage-result.json -DsourceDialect=tsql
         continue-on-error: true
 
       - name: Run Snowflake Coverage Tests with Maven
-        run: mvn --update-snapshots -B exec:java -pl coverage --file pom.xml --fail-at-end -Dexec.args="-i tests/resources/functional/snowflake -o coverage-result.json"
+        run: mvn --update-snapshots -B exec:java -pl coverage --file pom.xml --fail-at-end -DsourceDir=tests/resources/functional/snowflake -DoutputPath=coverage-result.json -DsourceDialect=snowflake
         continue-on-error: true
 
       - name: Publish JUnit report

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -14,6 +14,11 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>2.0.9</slf4j.version>
+        <sourceDir></sourceDir>
+        <outputPath></outputPath>
+        <startComment></startComment>
+        <endComment>-- databricks sql:</endComment>
+        <sourceDialect></sourceDialect>
     </properties>
     <dependencies>
         <dependency>
@@ -78,9 +83,15 @@
                     <mainClass>com.databricks.labs.remorph.coverage.Main</mainClass>
                     <arguments>
                         <argument>-i</argument>
-                        <argument>${project.parent.basedir}/tests/resources/functional/snowflake</argument>
+                        <argument>${sourceDir}</argument>
                         <argument>-o</argument>
-                        <argument>${project.build.directory}/coverage-result.json</argument>
+                        <argument>${project.build.directory}/${outputPath}</argument>
+                        <argument>-s</argument>
+                        <argument>${startComment}</argument>
+                        <argument>-e</argument>
+                        <argument>${endComment}</argument>
+                        <argument>-d</argument>
+                        <argument>${sourceDialect}</argument>
                     </arguments>
                 </configuration>
             </plugin>

--- a/tests/resources/functional/tsql/functions/test_get_bit_1.sql
+++ b/tests/resources/functional/tsql/functions/test_get_bit_1.sql
@@ -5,5 +5,5 @@
 -- tsql sql:
 SELECT GET_BIT(42, 7);
 
--- GET_BIT sql:
+-- databricks sql:
 SELECT BIT_COUNT(42);


### PR DESCRIPTION
Previously, tsql coverage report wasn't included in the `coverage-report.json` artifact produced by the build (though they were correctly included in the `Coverage tests results` comment), this PR fixes it.