### PR TITLE
Add lexer tests for TSql and Snowflake lexers

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -134,7 +134,9 @@
         </executions>
         <configuration>
           <visitor>true</visitor>
+          <listener>false</listener>
           <sourceDirectory>src/main/antlr4</sourceDirectory>
+          <treatWarningsAsErrors>true</treatWarningsAsErrors>
         </configuration>
       </plugin>
       <plugin>

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
@@ -1119,25 +1119,19 @@ LISTAGG: 'LISTAGG';
 
 DUMMY: 'DUMMY'; //Dummy is not a keyword but rules reference it. As to be cleaned.
 
-SPACE: [ \t\r\n]+ -> channel(HIDDEN);
+SPACE: [ \t\r\n]+ -> skip;
 
 SQL_COMMENT    : '/*' (SQL_COMMENT | .)*? '*/' -> channel(HIDDEN);
 LINE_COMMENT   : '--' ~[\r\n]*                 -> channel(HIDDEN);
 LINE_COMMENT_2 : '//' ~[\r\n]*                 -> channel(HIDDEN);
 
 // TODO: ID can be not only Latin.
-DOUBLE_QUOTE_ID    : '"' ~'"'+ '"';
+DOUBLE_QUOTE_ID    : '"' ~[\r\n"]+ '"';
 DOUBLE_QUOTE_BLANK : '""';
 SINGLE_QUOTE       : '\'';
 
 ID  : [A-Z_] [A-Z0-9_@$]*;
 ID2 : DOLLAR [A-Z_] [A-Z0-9_]*;
-
-S3_PATH    : SINGLE_QUOTE 's3://' Uri SINGLE_QUOTE;
-S3GOV_PATH : SINGLE_QUOTE 's3gov://' Uri SINGLE_QUOTE;
-GCS_PATH   : SINGLE_QUOTE 'gcs://' Uri SINGLE_QUOTE;
-AZURE_PATH : SINGLE_QUOTE 'azure://' Uri SINGLE_QUOTE;
-FILE_PATH  : 'file://' ( DIVIDE Uri | WindowsPath); //file://<path_to_file>/<filename>
 
 DBL_DOLLAR: '$$' (~'$' | '\\$' | '$' ~'$')*? '$$';
 

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
@@ -1117,7 +1117,7 @@ VARIANT          : 'VARIANT';
 
 LISTAGG: 'LISTAGG';
 
-DUMMY: 'DUMMY'; //Dummy is not a keyword but rules reference it. As to be cleaned.
+DUMMY: 'DUMMY'; //Dummy is not a keyword but rules reference it in unfinished grammar - need to get rid
 
 SPACE: [ \t\r\n]+ -> skip;
 
@@ -1128,14 +1128,13 @@ LINE_COMMENT_2 : '//' ~[\r\n]*                 -> channel(HIDDEN);
 // TODO: ID can be not only Latin.
 DOUBLE_QUOTE_ID    : '"' ~[\r\n"]+ '"';
 DOUBLE_QUOTE_BLANK : '""';
-SINGLE_QUOTE       : '\'';
 
 ID  : [A-Z_] [A-Z0-9_@$]*;
 ID2 : DOLLAR [A-Z_] [A-Z0-9_]*;
 
 DBL_DOLLAR: '$$' (~'$' | '\\$' | '$' ~'$')*? '$$';
 
-STRING: '\'' ('\\' . | '\'\'' | ~('\'' | '\\'))* '\'';
+STRING: '\'' (~['] | '\\' .) * '\'';
 
 DECIMAL : DEC_DIGIT+;
 FLOAT   : DEC_DOT_DEC;
@@ -1150,12 +1149,7 @@ fragment EscapeSequence:
 ;
 
 fragment HexDigit: [0-9a-f];
-
 fragment HexString: [A-Z0-9|.] [A-Z0-9+\-|.]*;
-
-fragment Uri: HexString (DIVIDE HexString)* DIVIDE?;
-
-fragment WindowsPath: [A-Z] COLON '\\' HexString ('\\' HexString)* '\\'?;
 
 ARROW : '->';
 ASSOC : '=>';

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
@@ -1126,7 +1126,7 @@ LINE_COMMENT   : '--' ~[\r\n]*                 -> channel(HIDDEN);
 LINE_COMMENT_2 : '//' ~[\r\n]*                 -> channel(HIDDEN);
 
 // TODO: ID can be not only Latin.
-DOUBLE_QUOTE_ID    : '"' ~[\r\n"]+ '"';
+DOUBLE_QUOTE_ID    : '"' (~[\r\n"] | '"''"')+ '"';
 DOUBLE_QUOTE_BLANK : '""';
 
 ID  : [A-Z_] [A-Z0-9_@$]*;

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -2105,17 +2105,17 @@ awsCredentialOrStorageIntegration
 
 externalStageParams
     //(for Amazon S3)
-    : URL EQ s3Url = (S3_PATH | S3GOV_PATH) (
+    : URL EQ s3Url = STRING (
         awsCredentialOrStorageIntegration? stageEncryptionOptsAws
         | stageEncryptionOptsAws? awsCredentialOrStorageIntegration
     )?
     //(for Google Cloud Storage)
-    | URL EQ gcUrl = GCS_PATH (
+    | URL EQ STRING (
         storageIntegrationEqId? stageEncryptionOptsGcp
         | stageEncryptionOptsGcp? storageIntegrationEqId
     )?
     //(for Microsoft Azure)
-    | URL EQ azureUrl = AZURE_PATH (
+    | URL EQ STRING (
         azCredentialOrStorageIntegration? stageEncryptionOptsAz
         | stageEncryptionOptsAz? azCredentialOrStorageIntegration
     )?

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -2057,7 +2057,7 @@ parenStringOptions
     ;
 
 stringOption
-    : id_ EQ STRING
+    : id EQ STRING
     ;
 
 externalStageParams
@@ -3543,9 +3543,7 @@ ternaryBuiltinFunction
 listFunction
     // lexer entry of function name which admit a list of comma separated expr
     // expr rule use this
-    : CONCAT
-    | CONCAT_WS
-    | COALESCE
+    : COALESCE
     | HASH
     // To complete as needed
     ;

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -971,7 +971,7 @@ COMMENT      : '/*' (COMMENT | .)*? '*/' -> channel(HIDDEN);
 LINE_COMMENT : '--' ~[\r\n]*             -> channel(HIDDEN);
 
 // TODO: ID can be not only Latin.
-DOUBLE_QUOTE_ID    : '"' ~'"'+ '"';
+DOUBLE_QUOTE_ID    : '"' ~["\r\n]+ '"';
 SINGLE_QUOTE       : '\'';
 SQUARE_BRACKET_ID  : '[' (~']' | ']' ']')* ']';
 LOCAL_ID           : '@' ([A-Z_$@#0-9] | FullWidthLetter)*;

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -972,7 +972,6 @@ LINE_COMMENT : '--' ~[\r\n]*             -> channel(HIDDEN);
 
 // TODO: ID can be not only Latin.
 DOUBLE_QUOTE_ID    : '"' ~["\r\n]+ '"';
-SINGLE_QUOTE       : '\'';
 SQUARE_BRACKET_ID  : '[' (~']' | ']' ']')* ']';
 LOCAL_ID           : '@' ([A-Z_$@#0-9] | FullWidthLetter)*;
 TEMP_ID            : '#' ([A-Z_$@#0-9] | FullWidthLetter)*;
@@ -980,7 +979,7 @@ TEMP_ID            : '#' ([A-Z_$@#0-9] | FullWidthLetter)*;
 ID                 : ( [A-Z_#] | FullWidthLetter) ( [A-Z_#$@0-9] | FullWidthLetter)*;
 STRING options {
     caseInsensitive = false;
-}      : 'N'? '\'' (~'\'' | '\'\'')* '\'';
+}      : 'N'? '\'' (~['] | '\\' .)* '\'';
 
 fragment SIGN: [+-];
 

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -971,7 +971,7 @@ COMMENT      : '/*' (COMMENT | .)*? '*/' -> channel(HIDDEN);
 LINE_COMMENT : '--' ~[\r\n]*             -> channel(HIDDEN);
 
 // TODO: ID can be not only Latin.
-DOUBLE_QUOTE_ID    : '"' ~["\r\n]+ '"';
+DOUBLE_QUOTE_ID    : '"' (~[\r\n"] | '"''"')+ '"';
 SQUARE_BRACKET_ID  : '[' (~']' | ']' ']')* ']';
 LOCAL_ID           : '@' ([A-Z_$@#0-9] | FullWidthLetter)*;
 TEMP_ID            : '#' ([A-Z_$@#0-9] | FullWidthLetter)*;

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -387,7 +387,7 @@ alterAssemblyClause
     ;
 
 alterAssemblyFromClause
-    : alterAssemblyFromClauseStart (clientAssemblySpecifier | alterAssemblyFileBits)
+    : alterAssemblyFromClauseStart (STRING | alterAssemblyFileBits)
     ;
 
 alterAssemblyFromClauseStart
@@ -400,7 +400,7 @@ alterAssemblyDropClause
 
 alterAssemblyDropMultipleFiles
     : ALL
-    | multipleLocalFiles
+    | STRING (COMMA STRING)*
     ;
 
 alterAssemblyDrop
@@ -439,47 +439,11 @@ alterAssemblyWith
     : WITH
     ;
 
-clientAssemblySpecifier
-    : networkFileShare
-    | localFile
-    | STRING
-    ;
-
 assemblyOption
     : PERMISSION_SET EQ (SAFE | EXTERNAL_ACCESS | UNSAFE)
     | VISIBILITY EQ onOff
     | UNCHECKED DATA
     | assemblyOption COMMA
-    ;
-
-networkFileShare
-    : BACKSLASH BACKSLASH networkComputer filePath
-    ;
-
-networkComputer
-    : computerName = id
-    ;
-
-filePath
-    : BACKSLASH filePath
-    | id
-    ;
-
-localFile
-    : localDrive filePath
-    ;
-
-localDrive
-    : DISK_DRIVE
-    ;
-
-multipleLocalFiles
-    : multipleLocalFileStart localFile SINGLE_QUOTE COMMA
-    | localFile
-    ;
-
-multipleLocalFileStart
-    : SINGLE_QUOTE
     ;
 
 createAssembly

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowLexerSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowLexerSpec.scala
@@ -1,0 +1,32 @@
+package com.databricks.labs.remorph.parsers.snowflake
+
+import org.antlr.v4.runtime.{CharStreams, Token}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.wordspec.AnyWordSpec
+
+class SnowLexerSpec extends AnyWordSpec with Matchers with TableDrivenPropertyChecks {
+
+  private val lexer = new SnowflakeLexer(null)
+
+  "Snowflake Lexer" should {
+    "parse string literals" in {
+
+      val testInput = Table(
+        ("input", "expected"), // Headers
+        (""""quoted""id""", SnowflakeLexer.DOUBLE_QUOTE_ID),
+        ("\"quote\"\"andunquote\"\"\"", SnowflakeLexer.DOUBLE_QUOTE_ID),
+        ("'hello'", SnowflakeLexer.STRING))
+
+      forAll(testInput) { (input: String, expected: Int) =>
+        val inputString = CharStreams.fromString(input)
+
+        lexer.setInputStream(inputString)
+        val tok: Token = lexer.nextToken()
+        tok.getType should be(expected)
+      }
+    }
+
+  }
+
+}

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowLexerSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowLexerSpec.scala
@@ -15,16 +15,17 @@ class SnowLexerSpec extends AnyWordSpec with Matchers with TableDrivenPropertyCh
 
       val testInput = Table(
         ("input", "expected"), // Headers
-        (""""quoted""id""", SnowflakeLexer.DOUBLE_QUOTE_ID),
+        (""""quoted""id"""", SnowflakeLexer.DOUBLE_QUOTE_ID),
         ("\"quote\"\"andunquote\"\"\"", SnowflakeLexer.DOUBLE_QUOTE_ID),
         ("'hello'", SnowflakeLexer.STRING))
 
-      forAll(testInput) { (input: String, expected: Int) =>
+      forAll(testInput) { (input: String, expectedType: Int) =>
         val inputString = CharStreams.fromString(input)
 
         lexer.setInputStream(inputString)
         val tok: Token = lexer.nextToken()
-        tok.getType should be(expected)
+        tok.getType shouldBe expectedType
+        tok.getText shouldBe input
       }
     }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowLexerSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowLexerSpec.scala
@@ -9,8 +9,9 @@ class SnowLexerSpec extends AnyWordSpec with Matchers with TableDrivenPropertyCh
 
   private val lexer = new SnowflakeLexer(null)
 
+  // TODO: Expand this test to cover all token types, and maybe all tokens
   "Snowflake Lexer" should {
-    "parse string literals" in {
+    "parse string literals and ids" in {
 
       val testInput = Table(
         ("input", "expected"), // Headers

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlLexerSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlLexerSpec.scala
@@ -16,7 +16,6 @@ class TSqlLexerSpec extends AnyWordSpec with Matchers with TableDrivenPropertyCh
       val testInput = Table(
         ("input", "expected"), // Headers
         (""""quoted""id"""", TSqlLexer.DOUBLE_QUOTE_ID),
-        (" \"quote\"\"andunquote\"\"\"", TSqlLexer.DOUBLE_QUOTE_ID),
         ("\"quote\"\"andunquote\"\"\"", TSqlLexer.DOUBLE_QUOTE_ID),
         ("'hello'", TSqlLexer.STRING))
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlLexerSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlLexerSpec.scala
@@ -15,7 +15,7 @@ class TSqlLexerSpec extends AnyWordSpec with Matchers with TableDrivenPropertyCh
 
       val testInput = Table(
         ("input", "expected"), // Headers
-        (""""quoted""id""", TSqlLexer.DOUBLE_QUOTE_ID),
+        (""""quoted""id"""", TSqlLexer.DOUBLE_QUOTE_ID),
         (" \"quote\"\"andunquote\"\"\"", TSqlLexer.DOUBLE_QUOTE_ID),
         ("\"quote\"\"andunquote\"\"\"", TSqlLexer.DOUBLE_QUOTE_ID),
         ("'hello'", TSqlLexer.STRING))
@@ -25,7 +25,8 @@ class TSqlLexerSpec extends AnyWordSpec with Matchers with TableDrivenPropertyCh
 
         lexer.setInputStream(inputString)
         val tok: Token = lexer.nextToken()
-        tok.getType should be(expected)
+        tok.getType shouldBe expected
+        tok.getText shouldBe input
       }
     }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlLexerSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlLexerSpec.scala
@@ -1,0 +1,33 @@
+package com.databricks.labs.remorph.parsers.tsql
+
+import org.antlr.v4.runtime.{CharStreams, Token}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.wordspec.AnyWordSpec
+
+class TSqlLexerSpec extends AnyWordSpec with Matchers with TableDrivenPropertyChecks {
+
+  private val lexer = new TSqlLexer(null)
+
+  "TSqlLexer" should {
+    "parse string literals" in {
+
+      val testInput = Table(
+        ("input", "expected"), // Headers
+        (""""quoted""id""", TSqlLexer.DOUBLE_QUOTE_ID),
+        (" \"quote\"\"andunquote\"\"\"", TSqlLexer.DOUBLE_QUOTE_ID),
+        ("\"quote\"\"andunquote\"\"\"", TSqlLexer.DOUBLE_QUOTE_ID),
+        ("'hello'", TSqlLexer.STRING))
+
+      forAll(testInput) { (input: String, expected: Int) =>
+        val inputString = CharStreams.fromString(input)
+
+        lexer.setInputStream(inputString)
+        val tok: Token = lexer.nextToken()
+        tok.getType should be(expected)
+      }
+    }
+
+  }
+
+}

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlLexerSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlLexerSpec.scala
@@ -9,8 +9,9 @@ class TSqlLexerSpec extends AnyWordSpec with Matchers with TableDrivenPropertyCh
 
   private val lexer = new TSqlLexer(null)
 
+  // TODO: Expand this test to cover all token types, and maybe all tokens
   "TSqlLexer" should {
-    "parse string literals" in {
+    "parse string literals and ids" in {
 
       val testInput = Table(
         ("input", "expected"), // Headers


### PR DESCRIPTION
Adds lexer test Specs for both TSql and Snowflake lexers.

Here we clean up a lot of things in both lexers:

  - Quoted ID does not span multiple lines
  - Quoted ID correctly matches embedded "", though it is inadvisable.
     *Note* that the lexer preserves the text as it is in the source including the ""
  - STRING accepts escaped characters and not just ''
  - A single ' as a token is removed and the grammar rules that tried to use
    them have been removed or corrected
  - Attempts to lex URIs and enforce the normative spec lexicaly and syntactically
     have been removed.
  - Incorrect attempts to distinguish (incorrectly) storage options have been removed
     *Note* that we will soon remove all the keywords that are over-specified in the lexer and parser
     in favor of a keyword checking helper used when building the IR.
  - Configuration for antlr-maven-plugin is changed to not generate Listeners we do not use
  - Configuration for antlr-maven-plugin is changed to treat warnings as errors so that we do not check
    in parser grammar that cannot parse.
  