### PR TITLE
fix: Change order of search for "" in quoted lexer rule.

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
@@ -1126,7 +1126,7 @@ LINE_COMMENT   : '--' ~[\r\n]*                 -> channel(HIDDEN);
 LINE_COMMENT_2 : '//' ~[\r\n]*                 -> channel(HIDDEN);
 
 // TODO: ID can be not only Latin.
-DOUBLE_QUOTE_ID    : '"' (~[\r\n"] | '"''"')+ '"';
+DOUBLE_QUOTE_ID    :  '"' ('""' | ~[\r\n"] )* '"';
 DOUBLE_QUOTE_BLANK : '""';
 
 ID  : [A-Z_] [A-Z0-9_@$]*;

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
@@ -1134,7 +1134,7 @@ ID2 : DOLLAR [A-Z_] [A-Z0-9_]*;
 
 DBL_DOLLAR: '$$' (~'$' | '\\$' | '$' ~'$')*? '$$';
 
-STRING: '\'' (~['] | '\\' .) * '\'';
+STRING: '\'' ('\\' . | '\'\'' | ~['])* '\'';
 
 DECIMAL : DEC_DIGIT+;
 FLOAT   : DEC_DOT_DEC;

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -979,7 +979,7 @@ TEMP_ID            : '#' ([A-Z_$@#0-9] | FullWidthLetter)*;
 ID                 : ( [A-Z_#] | FullWidthLetter) ( [A-Z_#$@0-9] | FullWidthLetter)*;
 STRING options {
     caseInsensitive = false;
-}      : 'N'? '\'' (~['] | '\\' .)* '\'';
+}      : 'N'? '\'' ('\\' . | '\'\'' | ~['])* '\'';
 
 fragment SIGN: [+-];
 

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -971,7 +971,7 @@ COMMENT      : '/*' (COMMENT | .)*? '*/' -> channel(HIDDEN);
 LINE_COMMENT : '--' ~[\r\n]*             -> channel(HIDDEN);
 
 // TODO: ID can be not only Latin.
-DOUBLE_QUOTE_ID    : '"' (~[\r\n"] | '"''"')+ '"';
+DOUBLE_QUOTE_ID    : '"' ('""' | ~[\r\n"] )* '"';
 SQUARE_BRACKET_ID  : '[' (~']' | ']' ']')* ']';
 LOCAL_ID           : '@' ([A-Z_$@#0-9] | FullWidthLetter)*;
 TEMP_ID            : '#' ([A-Z_$@#0-9] | FullWidthLetter)*;

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowLexerSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowLexerSpec.scala
@@ -15,9 +15,13 @@ class SnowLexerSpec extends AnyWordSpec with Matchers with TableDrivenPropertyCh
 
       val testInput = Table(
         ("input", "expected"), // Headers
+
+        ("'And it''s raining'", SnowflakeLexer.STRING),
+        ("""'Tab\oir'""", SnowflakeLexer.STRING),
+        ("""'Tab\'oir'""", SnowflakeLexer.STRING),
+        ("'hello'", SnowflakeLexer.STRING),
         (""""quoted""id"""", SnowflakeLexer.DOUBLE_QUOTE_ID),
-        ("\"quote\"\"andunquote\"\"\"", SnowflakeLexer.DOUBLE_QUOTE_ID),
-        ("'hello'", SnowflakeLexer.STRING))
+        ("\"quote\"\"andunquote\"\"\"", SnowflakeLexer.DOUBLE_QUOTE_ID))
 
       forAll(testInput) { (input: String, expectedType: Int) =>
         val inputString = CharStreams.fromString(input)

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlLexerSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlLexerSpec.scala
@@ -15,9 +15,13 @@ class TSqlLexerSpec extends AnyWordSpec with Matchers with TableDrivenPropertyCh
 
       val testInput = Table(
         ("input", "expected"), // Headers
+
+        ("'And it''s raining'", TSqlLexer.STRING),
+        ("""'Tab\oir'""", TSqlLexer.STRING),
+        ("""'Tab\'oir'""", TSqlLexer.STRING),
+        ("'hello'", TSqlLexer.STRING),
         (""""quoted""id"""", TSqlLexer.DOUBLE_QUOTE_ID),
-        ("\"quote\"\"andunquote\"\"\"", TSqlLexer.DOUBLE_QUOTE_ID),
-        ("'hello'", TSqlLexer.STRING))
+        ("\"quote\"\"andunquote\"\"\"", TSqlLexer.DOUBLE_QUOTE_ID))
 
       forAll(testInput) { (input: String, expected: Int) =>
         val inputString = CharStreams.fromString(input)


### PR DESCRIPTION
As the lexer uses an NFA, it will match the first alt when either could match. I will leave the " in the alt explicit.