### PR TITLE
Add Oracle ojdbc8 dependent library during reconcile Installation

### DIFF
--- a/src/databricks/labs/remorph/helpers/deployment.py
+++ b/src/databricks/labs/remorph/helpers/deployment.py
@@ -133,7 +133,11 @@ class JobDeployer:
         }
 
     def _job_recon_task(self, jobs_task: Task) -> Task:
-        libraries = [compute.Library(pypi=compute.PythonPyPiLibrary("databricks-labs-remorph"))]
+        # TODO: fetch a version list for `ojdbc8` and use the second latest version instead of hardcoding
+        libraries = [
+            compute.Library(pypi=compute.PythonPyPiLibrary("databricks-labs-remorph")),
+            compute.Library(maven=compute.MavenLibrary("com.oracle.database.jdbc:ojdbc8:23.4.0.24.05")),
+        ]
         return dataclasses.replace(
             jobs_task,
             libraries=libraries,

--- a/src/databricks/labs/remorph/reconcile/connectors/jdbc_reader.py
+++ b/src/databricks/labs/remorph/reconcile/connectors/jdbc_reader.py
@@ -8,10 +8,11 @@ class JDBCReaderMixin:
 
     # TODO update the url
     def _get_jdbc_reader(self, query, jdbc_url, driver):
+        driver_class = {"oracle": "oracle.jdbc.driver.OracleDriver"}
         return (
             self._spark.read.format("jdbc")
             .option("url", jdbc_url)
-            .option("driver", driver)
+            .option("driver", driver_class.get(driver, driver))
             .option("dbtable", f"({query}) tmp")
         )
 


### PR DESCRIPTION
As part of the `reconcile` process, we may need to pull the data from the `Oracle` Data source for `reconciliation` between `Oracle` and `Databricks`. It requires `ojdbc8.jar` on the CLASSPATH.

This PR handles:
-  the installation of `com.oracle.database.jdbc:ojdbc8:23.4.0.24.05` jar as a dependent library in the `Remorph_Reconciliation_Job` Workflow.
- Updated the driver class to `oracle.jdbc.driver.OracleDriver` instead of `oracle` in `JDBCReaderMixin`


