### PR TITLE
feat: Implement freetext function visitor, simplify grammar

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -3239,17 +3239,14 @@ partitionFunction
     ;
 
 freetextFunction
-    : (CONTAINSTABLE | FREETEXTTABLE) LPAREN tableName COMMA (
-        fullColumnName
-        | LPAREN fullColumnName (COMMA fullColumnName)* RPAREN
-        | STAR
-    ) COMMA expression (COMMA LANGUAGE expression)? (COMMA expression)? RPAREN
-    | (SEMANTICSIMILARITYTABLE | SEMANTICKEYPHRASETABLE) LPAREN tableName COMMA (
-        fullColumnName
-        | LPAREN fullColumnName (COMMA fullColumnName)* RPAREN
-        | STAR
-    ) COMMA expression RPAREN
-    | SEMANTICSIMILARITYDETAILSTABLE LPAREN tableName COMMA fullColumnName COMMA expression COMMA fullColumnName COMMA expression RPAREN
+    : f=(SEMANTICSIMILARITYDETAILSTABLE | SEMANTICSIMILARITYTABLE | SEMANTICKEYPHRASETABLE | CONTAINSTABLE | FREETEXTTABLE)
+    LPAREN expression
+         COMMA (
+            expression
+            | LPAREN expressionList RPAREN
+            | STAR
+        ) COMMA expression (COMMA LANGUAGE expression)? (COMMA expression)?
+    RPAREN
     ;
 
 freetextPredicate

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -3235,7 +3235,7 @@ funcId: id | FORMAT | LEFT | RIGHT | REPLACE | CONCAT
     ;
 
 partitionFunction
-    : (database = id DOT)? DOLLAR_PARTITION DOT funcName = id LPAREN expression RPAREN
+    : (id DOT)? DOLLAR_PARTITION DOT id LPAREN expression RPAREN
     ;
 
 freetextFunction

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -433,6 +433,12 @@ class TSqlExpressionBuilder() extends TSqlParserBaseVisitor[ir.Expression] with 
     functionBuilder.buildFunction(ctx.f.getText, List.empty)
   }
 
+  override def visitHierarchyidStaticMethod(ctx: HierarchyidStaticMethodContext): ir.Expression = {
+    // Databricks SQL does not support HIERARCHYID functions, so there is no point in trying to convert these
+    // functions. We do need to generate IR that indicates that this is a function that is not supported.
+    functionBuilder.buildFunction("HIERARCHYID", List.empty)
+  }
+
   // format: off
   /**
    * Check if the ABSENT ON NULL clause is present in the JSON clause. The behavior is as follows:

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -392,6 +392,11 @@ class TSqlExpressionBuilder() extends TSqlParserBaseVisitor[ir.Expression] with 
     ctx.expression().accept(this)
   }
 
+  override def visitPartitionFunction(ctx: PartitionFunctionContext): ir.Expression = {
+    // $$PARTITION is not supported in Databricks SQL, so we will report it is not supported
+    functionBuilder.buildFunction(s"$$PARTITION", List.empty)
+  }
+
   /**
    * Handles the NEXT VALUE FOR function in SQL Server, which has a special syntax.
    *

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -422,6 +422,12 @@ class TSqlExpressionBuilder() extends TSqlParserBaseVisitor[ir.Expression] with 
     buildJsonObject(namedStruct, absentOnNull)
   }
 
+  override def visitFreetextFunction(ctx: FreetextFunctionContext): ir.Expression = {
+    // Databricks SQL does not support FREETEXT functions, so there is no point in trying to convert these
+    // functions. We do need to generate IR that indicates that this is a function that is not supported.
+    functionBuilder.buildFunction(ctx.f.getText, List.empty)
+  }
+
   // format: off
   /**
    * Check if the ABSENT ON NULL clause is present in the JSON clause. The behavior is as follows:

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionBuilder.scala
@@ -5,6 +5,7 @@ import com.databricks.labs.remorph.parsers.{FunctionBuilder, FunctionDefinition,
 class TSqlFunctionBuilder extends FunctionBuilder with StringConverter {
 
   private val tSqlFunctionDefinitionPf: PartialFunction[String, FunctionDefinition] = {
+    case """$PARTITION""" => FunctionDefinition.notConvertible(0)
     case "@@CURSOR_ROWS" => FunctionDefinition.notConvertible(0)
     case "@@DBTS" => FunctionDefinition.notConvertible(0)
     case "@@FETCH_STATUS" => FunctionDefinition.notConvertible(0)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionBuilder.scala
@@ -27,6 +27,7 @@ class TSqlFunctionBuilder extends FunctionBuilder with StringConverter {
     case "CUBE" => FunctionDefinition.standard(1, Int.MaxValue) // Snowflake hard codes this
     case "FREETEXTTABLE" => FunctionDefinition.notConvertible(0)
     case "GET_BIT" => FunctionDefinition.standard(2).withConversionStrategy(rename)
+    case "HIERARCHYID" => FunctionDefinition.notConvertible(0)
     case "ISNULL" => FunctionDefinition.standard(2).withConversionStrategy(rename)
     case "LEFT_SHIFT" => FunctionDefinition.standard(2).withConversionStrategy(rename)
     case "MODIFY" => FunctionDefinition.xml(1)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionBuilder.scala
@@ -22,7 +22,9 @@ class TSqlFunctionBuilder extends FunctionBuilder with StringConverter {
     case "@@TEXTSIZE" => FunctionDefinition.notConvertible(0)
     case "@@VERSION" => FunctionDefinition.notConvertible(0)
     case "COLLATIONPROPERTY" => FunctionDefinition.notConvertible(2)
+    case "CONTAINSTABLE" => FunctionDefinition.notConvertible(0)
     case "CUBE" => FunctionDefinition.standard(1, Int.MaxValue) // Snowflake hard codes this
+    case "FREETEXTTABLE" => FunctionDefinition.notConvertible(0)
     case "GET_BIT" => FunctionDefinition.standard(2).withConversionStrategy(rename)
     case "ISNULL" => FunctionDefinition.standard(2).withConversionStrategy(rename)
     case "LEFT_SHIFT" => FunctionDefinition.standard(2).withConversionStrategy(rename)
@@ -30,6 +32,9 @@ class TSqlFunctionBuilder extends FunctionBuilder with StringConverter {
     case "NEXTVALUEFOR" => FunctionDefinition.standard(1).withConversionStrategy(nextValueFor)
     case "RIGHT_SHIFT" => FunctionDefinition.standard(2).withConversionStrategy(rename)
     case "ROLLUP" => FunctionDefinition.standard(1, Int.MaxValue) // Snowflake hard codes this
+    case "SEMANTICKEYPHRASETABLE" => FunctionDefinition.notConvertible(0)
+    case "SEMANTICSIMILARITYDETAILSTABLE" => FunctionDefinition.notConvertible(0)
+    case "SEMANTICSSIMILARITYTABLE" => FunctionDefinition.notConvertible(0)
     case "SET_BIT" => FunctionDefinition.standard(2, 3).withConversionStrategy(rename)
   }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionBuilderSpec.scala
@@ -17,6 +17,7 @@ class TSqlFunctionBuilderSpec extends AnyFlatSpec with Matchers with TableDriven
       ("functionName", "expectedArity"), // Header
 
       // TSql specific
+      (s"$$PARTITION", Some(FunctionDefinition.notConvertible(0))),
       ("@@CURSOR_ROWS", Some(FunctionDefinition.notConvertible(0))),
       ("@@DBTS", Some(FunctionDefinition.notConvertible(0))),
       ("@@FETCH_STATUS", Some(FunctionDefinition.notConvertible(0))),

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionBuilderSpec.scala
@@ -37,6 +37,7 @@ class TSqlFunctionBuilderSpec extends AnyFlatSpec with Matchers with TableDriven
       ("COLLATIONPROPERTY", Some(FunctionDefinition.notConvertible(2))),
       ("CONTAINSTABLE", Some(FunctionDefinition.notConvertible(0))),
       ("FREETEXTTABLE", Some(FunctionDefinition.notConvertible(0))),
+      ("HIERARCHYID", Some(FunctionDefinition.notConvertible(0))),
       ("MODIFY", Some(FunctionDefinition.xml(1))),
       ("SEMANTICKEYPHRASETABLE", Some(FunctionDefinition.notConvertible(0))),
       ("SEMANTICSIMILARITYDETAILSTABLE", Some(FunctionDefinition.notConvertible(0))),

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionBuilderSpec.scala
@@ -1,10 +1,9 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.FunctionDefinition
+import com.databricks.labs.remorph.parsers.{FunctionDefinition, intermediate => ir}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
 
 class TSqlFunctionBuilderSpec extends AnyFlatSpec with Matchers with TableDrivenPropertyChecks {
 
@@ -35,7 +34,12 @@ class TSqlFunctionBuilderSpec extends AnyFlatSpec with Matchers with TableDriven
       ("@@TEXTSIZE", Some(FunctionDefinition.notConvertible(0))),
       ("@@VERSION", Some(FunctionDefinition.notConvertible(0))),
       ("COLLATIONPROPERTY", Some(FunctionDefinition.notConvertible(2))),
-      ("MODIFY", Some(FunctionDefinition.xml(1))))
+      ("CONTAINSTABLE", Some(FunctionDefinition.notConvertible(0))),
+      ("FREETEXTTABLE", Some(FunctionDefinition.notConvertible(0))),
+      ("MODIFY", Some(FunctionDefinition.xml(1))),
+      ("SEMANTICKEYPHRASETABLE", Some(FunctionDefinition.notConvertible(0))),
+      ("SEMANTICSIMILARITYDETAILSTABLE", Some(FunctionDefinition.notConvertible(0))),
+      ("SEMANTICSSIMILARITYTABLE", Some(FunctionDefinition.notConvertible(0))))
 
     forAll(functions) { (functionName: String, expectedArity: Option[FunctionDefinition]) =>
       functionBuilder.functionDefinition(functionName) shouldEqual expectedArity

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
@@ -337,4 +337,11 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
   "translate functions using ALL" in {
     example(query = "COUNT(ALL goals)", _.expression(), ir.CallFunction("COUNT", Seq(simplyNamedColumn("goals"))))
   }
+
+  "translate freetext functions as unconvertible" in {
+    example(
+      query = "FREETEXTTABLE(table, col, 'search')",
+      _.expression(),
+      ir.UnresolvedFunction("FREETEXTTABLE", List.empty, is_distinct = false, is_user_defined_function = false))
+  }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
@@ -344,4 +344,11 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
       _.expression(),
       ir.UnresolvedFunction("FREETEXTTABLE", List.empty, is_distinct = false, is_user_defined_function = false))
   }
+
+  "translate $PARTITION functions as unconvertible" in {
+    example(
+      query = "$PARTITION.partitionFunction(col)",
+      _.expression(),
+      ir.UnresolvedFunction("$PARTITION", List.empty, is_distinct = false, is_user_defined_function = false))
+  }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
@@ -338,17 +338,24 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
     example(query = "COUNT(ALL goals)", _.expression(), ir.CallFunction("COUNT", Seq(simplyNamedColumn("goals"))))
   }
 
-  "translate freetext functions as unconvertible" in {
+  "translate freetext functions as inconvertible" in {
     example(
       query = "FREETEXTTABLE(table, col, 'search')",
       _.expression(),
       ir.UnresolvedFunction("FREETEXTTABLE", List.empty, is_distinct = false, is_user_defined_function = false))
   }
 
-  "translate $PARTITION functions as unconvertible" in {
+  "translate $PARTITION functions as inconvertible" in {
     example(
       query = "$PARTITION.partitionFunction(col)",
       _.expression(),
       ir.UnresolvedFunction("$PARTITION", List.empty, is_distinct = false, is_user_defined_function = false))
+  }
+
+  "translate HIERARCHYID static method as inconvertible" in {
+    example(
+      query = "HIERARCHYID::Parse('1/2/3')",
+      _.expression(),
+      ir.UnresolvedFunction("HIERARCHYID", List.empty, is_distinct = false, is_user_defined_function = false))
   }
 }


### PR DESCRIPTION
Freetext functions, $PARTITION and HIERARCHYID functions are unsupported in Databricks SQL, but we must still support generation of IR to indicate this. We also  therefore prevent errors when visiting functionCall.

Here we complete handling of all TSQL functions from a parsing and IR generating point of view. There are likely to be many conversions of functions and flagging of unsupported functions as the coverage tests are expanded to support them.

Progresses: #275 
Closes: #357