### PR TITLE
TSQL:  Implement TOP, FETCH and OFFSET clauses for TSQL SELECT

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -3349,7 +3349,7 @@ columnPosition: num
 allDistinct: ALL | DISTINCT
     ;
 
-topClause: TOP num
+topClause: TOP expr
     ;
 
 intoClause: INTO varList
@@ -3559,11 +3559,7 @@ orderItem: expr (ASC | DESC)? (NULLS ( FIRST | LAST))?
 orderByClause: ORDER BY orderItem (COMMA orderItem)*
     ;
 
-rowRows: ROW | ROWS
-    ;
-
-firstNext: FIRST | NEXT
-    ;
-
-limitClause: LIMIT num (OFFSET num)? | (OFFSET num)? rowRows? FETCH firstNext? num rowRows? ONLY?
+limitClause
+    : LIMIT expr (OFFSET expr)?
+    | (OFFSET expr)? (ROW | ROWS)? FETCH (FIRST | NEXT)? expr (ROW | ROWS)? ONLY?
     ;

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -3016,15 +3016,7 @@ whereClause: WHERE searchCondition
 havingClause: HAVING searchCondition
     ;
 
-topClause: TOP (topPercent | topCount) (WITH TIES)?
-    ;
-
-topPercent
-    : percentConstant = (REAL | FLOAT | INT) PERCENT
-    | LPAREN topperExpression = expression RPAREN PERCENT
-    ;
-
-topCount: countConstant = INT | LPAREN topcountExpression = expression RPAREN
+topClause: TOP ( expression | LPAREN expression RPAREN) PERCENT? (WITH TIES)?
     ;
 
 orderByClause: ORDER BY orderByExpression (COMMA orderByExpression)*
@@ -3032,9 +3024,7 @@ orderByClause: ORDER BY orderByExpression (COMMA orderByExpression)*
 
 selectOrderByClause
     : orderByClause (
-        OFFSET expression or = (ROW | ROWS) (
-            FETCH (FIRST | NEXT) expression fr = (ROW | ROWS) ONLY
-        )?
+        OFFSET expression (ROW | ROWS) (FETCH (FIRST | NEXT) expression (ROW | ROWS) ONLY)?
     )?
     ;
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/relations.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/relations.scala
@@ -61,9 +61,10 @@ case class SetOperation(
     allow_missing_columns: Boolean)
     extends RelationCommon {}
 
-case class Limit(input: Relation, limit: Int) extends RelationCommon {}
+case class Limit(input: Relation, limit: Expression, is_percentage: Boolean = false, with_ties: Boolean = false)
+    extends RelationCommon {}
 
-case class Offset(input: Relation, offset: Int) extends RelationCommon {}
+case class Offset(input: Relation, offset: Expression) extends RelationCommon {}
 
 case class Tail(input: Relation, limit: Int) extends RelationCommon {}
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
@@ -35,14 +35,14 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] w
   private def buildLimitOffset(ctx: LimitClauseContext, input: ir.Relation): ir.Relation = {
     Option(ctx).fold(input) { c =>
       if (c.LIMIT() != null) {
-        val limit = ir.Limit(input, ctx.num(0).getText.toInt)
+        val limit = ir.Limit(input, ctx.expr(0).accept(expressionBuilder))
         if (c.OFFSET() != null) {
-          ir.Offset(limit, ctx.num(1).getText.toInt)
+          ir.Offset(limit, ctx.expr(1).accept(expressionBuilder))
         } else {
           limit
         }
       } else {
-        ir.Offset(input, ctx.num(0).getText.toInt)
+        ir.Offset(input, ctx.expr(0).accept(expressionBuilder))
       }
     }
   }
@@ -63,7 +63,7 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.Relation] w
 
   private def buildTop(ctxOpt: Option[TopClauseContext], input: ir.Relation): ir.Relation =
     ctxOpt.fold(input) { top =>
-      ir.Limit(input, top.num().getText.toInt)
+      ir.Limit(input, top.expr().accept(expressionBuilder))
     }
 
   override def visitSelectOptionalClauses(ctx: SelectOptionalClausesContext): ir.Relation = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -49,11 +49,20 @@ class TSqlRelationBuilder extends TSqlParserBaseVisitor[ir.Relation] {
     // Note that ALL is the default so we don't need to check for it
     ctx match {
       case c if c.DISTINCT() != null =>
-        buildDistinct(select, columns)
+        ir.Project(buildTop(Option(ctx.topClause()), buildDistinct(select, columns)), columns)
       case _ =>
-        ir.Project(select, columns)
+        ir.Project(buildTop(Option(ctx.topClause()), select), columns)
     }
   }
+
+  private def buildTop(ctxOpt: Option[TSqlParser.TopClauseContext], input: ir.Relation): ir.Relation =
+    ctxOpt.fold(input) { top =>
+      ir.Limit(
+        input,
+        top.expression().accept(expressionBuilder),
+        is_percentage = top.PERCENT() != null,
+        with_ties = top.TIES() != null)
+    }
 
   override def visitSelectOptionalClauses(ctx: SelectOptionalClausesContext): ir.Relation = {
     val from = Option(ctx.fromClause()).map(_.accept(this)).getOrElse(ir.NoTable())
@@ -83,19 +92,31 @@ class TSqlRelationBuilder extends TSqlParserBaseVisitor[ir.Relation] {
     }
   }
 
-  // TODO: COLLATE in OrderBy expression
-  // TODO: OFFSET and FETCH in selectOrderByClause
   private def buildOrderBy(ctx: SelectOrderByClauseContext, input: ir.Relation): ir.Relation = {
     Option(ctx).fold(input) { c =>
       val sortOrders = c.orderByClause().orderByExpression().asScala.map { orderItem =>
-        val expression = orderItem.expression(0).accept(expressionBuilder) // expression(1) is COLLATE
+        val expression = orderItem.expression(0).accept(expressionBuilder)
+        // orderItem.expression(1) is COLLATE - we will not support that, but should either add a comment in the
+        // translated source or raise some kind of linting alert.
         if (orderItem.DESC() == null) {
           ir.SortOrder(expression, ir.AscendingSortDirection, ir.SortNullsUnspecified)
         } else {
           ir.SortOrder(expression, ir.DescendingSortDirection, ir.SortNullsUnspecified)
         }
       }
-      ir.Sort(input = input, order = sortOrders, is_global = false)
+      val sorted = ir.Sort(input = input, order = sortOrders, is_global = false)
+
+      // Having created the IR for ORDER BY, we now need to apply any OFFSET, and then any FETCH
+      if (ctx.OFFSET() != null) {
+        val offset = ir.Offset(sorted, ctx.expression(0).accept(expressionBuilder))
+        if (ctx.FETCH() != null) {
+          ir.Limit(offset, ctx.expression(1).accept(expressionBuilder))
+        } else {
+          offset
+        }
+      } else {
+        sorted
+      }
     }
   }
 
@@ -116,9 +137,7 @@ class TSqlRelationBuilder extends TSqlParserBaseVisitor[ir.Relation] {
       case ir.Alias(_, a, _) => a
       // Note that the ir.Star(None) is not matched so that we set all_columns_as_keys to true
     }.flatten
-    ir.Project(
-      ir.Deduplicate(from, columnNames, all_columns_as_keys = columnNames.isEmpty, within_watermark = false),
-      columns)
+    ir.Deduplicate(from, columnNames, all_columns_as_keys = columnNames.isEmpty, within_watermark = false),
   }
 
   override def visitTableName(ctx: TableNameContext): ir.NamedTable = {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
@@ -225,15 +225,21 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
     "translate queries with LIMIT and OFFSET" in {
       singleQueryExample(
         query = "SELECT a FROM b LIMIT 5",
-        expectedAst = Project(Limit(NamedTable("b", Map.empty, is_streaming = false), 5), Seq(simplyNamedColumn("a"))))
+        expectedAst = Project(
+          Limit(NamedTable("b", Map.empty, is_streaming = false), Literal(short = Some(5))),
+          Seq(simplyNamedColumn("a"))))
       singleQueryExample(
         query = "SELECT a FROM b LIMIT 5 OFFSET 10",
-        expectedAst =
-          Project(Offset(Limit(NamedTable("b", Map.empty, is_streaming = false), 5), 10), Seq(simplyNamedColumn("a"))))
+        expectedAst = Project(
+          Offset(
+            Limit(NamedTable("b", Map.empty, is_streaming = false), Literal(short = Some(5))),
+            Literal(short = Some(10))),
+          Seq(simplyNamedColumn("a"))))
       singleQueryExample(
         query = "SELECT a FROM b OFFSET 10 FETCH FIRST 42",
-        expectedAst =
-          Project(Offset(NamedTable("b", Map.empty, is_streaming = false), 10), Seq(simplyNamedColumn("a"))))
+        expectedAst = Project(
+          Offset(NamedTable("b", Map.empty, is_streaming = false), Literal(short = Some(10))),
+          Seq(simplyNamedColumn("a"))))
     }
     "translate a query with PIVOT" in {
       singleQueryExample(

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
@@ -257,13 +257,15 @@ class SnowflakeRelationBuilderSpec
       example(
         "SELECT TOP 42 a FROM t",
         _.selectStatement(),
-        Project(Limit(namedTable("t"), 42), Seq(simplyNamedColumn("a"))))
+        Project(Limit(namedTable("t"), Literal(short = Some(42))), Seq(simplyNamedColumn("a"))))
 
       example(
         "SELECT DISTINCT TOP 42 a FROM t",
         _.selectStatement(),
         Project(
-          Limit(Deduplicate(namedTable("t"), Seq(Id("a")), all_columns_as_keys = false, within_watermark = false), 42),
+          Limit(
+            Deduplicate(namedTable("t"), Seq(Id("a")), all_columns_as_keys = false, within_watermark = false),
+            Literal(short = Some(42))),
           Seq(simplyNamedColumn("a"))))
     }
 


### PR DESCRIPTION
TSQL select implements the LIMIT clause via the TOP clause, which also allows phrases such as:

```tsql
SELECT TOP 10 PERCENT
```


TSQL limiting clauses such as FETCH and NEXT also allow expressions rather than just NUMERIC, as well as returning more than the TOP N in an ORDER BY clause if more rows than the last row match the ORDER BY list. Hence the IR has changed to accoomodate expression, `WITH TIES` and whether the expression represents a PERCENT or a straight scalar.