### PR TITLE
TSQL: Implement remaining join pivot and apply operations

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -3127,7 +3127,7 @@ expr
     | expr predicatePartial                     # exprPredicate
     | DISTINCT expr                             # exprDistinct
     //Should be latest rule as it's nearly a catch all
-    | primitiveExpression                       # exprPrimitive
+    | primitiveExpression # exprPrimitive
     ;
 
 withinGroup: WITHIN GROUP L_PAREN orderByClause R_PAREN
@@ -3151,9 +3151,7 @@ jsonPathElem: ID | DOUBLE_QUOTE_ID
 iffExpr: IFF L_PAREN searchCondition COMMA expr COMMA expr R_PAREN
     ;
 
-castExpr
-    : castOp = (TRY_CAST | CAST) L_PAREN expr AS dataType R_PAREN
-    | INTERVAL expr
+castExpr: castOp = (TRY_CAST | CAST) L_PAREN expr AS dataType R_PAREN | INTERVAL expr
     ;
 
 jsonLiteral: LCB kvPair (COMMA kvPair)* RCB | LCB RCB
@@ -3227,15 +3225,10 @@ windowFrameExtent: BETWEEN windowFrameBound AND windowFrameBound
 windowFrameBound: UNBOUNDED (PRECEDING | FOLLOWING) | num (PRECEDING | FOLLOWING) | CURRENT ROW
     ;
 
-functionCall
-    : builtinFunction
-    | standardFunction
-    | rankingWindowedFunction
-    | aggregateFunction
+functionCall: builtinFunction | standardFunction | rankingWindowedFunction | aggregateFunction
     ;
 
-builtinFunction
-    : EXTRACT L_PAREN part = (STRING | ID) FROM expr R_PAREN  # builtinExtract
+builtinFunction: EXTRACT L_PAREN part = (STRING | ID) FROM expr R_PAREN # builtinExtract
     ;
 
 standardFunction: id L_PAREN exprList? R_PAREN

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -3146,7 +3146,7 @@ changeTableVersion
     : CHANGETABLE LPAREN VERSION versiontable = tableName COMMA pkColumns = fullColumnNameList COMMA pkValues = selectList RPAREN
     ;
 
-joinPart: joinOn | crossJoin | apply_ | pivot | unpivot
+joinPart: joinOn | crossJoin | apply | pivot | unpivot
     ;
 
 outerJoin: (LEFT | RIGHT | FULL) OUTER?
@@ -3162,7 +3162,7 @@ joinOn
 crossJoin: CROSS JOIN tableSourceItem
     ;
 
-apply_: applyStyle = (CROSS | OUTER) APPLY source = tableSourceItem
+apply: (CROSS | OUTER) APPLY tableSourceItem
     ;
 
 pivot: PIVOT pivotClause asTableAlias
@@ -3174,8 +3174,7 @@ unpivot: UNPIVOT unpivotClause asTableAlias
 pivotClause: LPAREN expression FOR fullColumnName IN columnAliasList RPAREN
     ;
 
-unpivotClause
-    : LPAREN unpivotExp = expression FOR fullColumnName IN LPAREN fullColumnNameList RPAREN RPAREN
+unpivotClause: LPAREN id FOR id IN LPAREN fullColumnNameList RPAREN RPAREN
     ;
 
 fullColumnNameList: column += fullColumnName (COMMA column += fullColumnName)*

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -189,3 +189,10 @@ case class BackupDatabase(
     extends Command {}
 
 case class ArrayAgg(values: Expression, sort: Seq[SortOrder]) extends Expression {}
+
+// TSQL has some join types that are not natively supported in Databricks SQL, but can possibly be emulated
+// using LATERAL VIEW and an explode function. Some things like functions are translatable at IR production
+// time, but complex joins are probably/possibly better done at the translation from IR as they are more involved
+// than some simple prescribed action.
+case object CrossApply extends JoinType
+case object OuterApply extends JoinType

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -15,7 +15,6 @@ class TSqlExpressionBuilder() extends TSqlParserBaseVisitor[ir.Expression] with 
 
   override def visitSelectListElem(ctx: TSqlParser.SelectListElemContext): ir.Expression = {
     ctx match {
-      // TODO: asterisk not fully handled
       case c if c.asterisk() != null => c.asterisk().accept(this)
       case c if c.LOCAL_ID() != null => buildLocalAssign(ctx)
       case c if c.expressionElem() != null => ctx.expressionElem().accept(this)


### PR DESCRIPTION
Here we implement:

 - CROSS JOIN (explicit)
 - CROSS APPLY
 - OUTER APPLY
 - PIVOT
 - UNPIVOT
 
The APPLY joins are peculiar to TSQL, but should be translatable to LEFT LATERAL or LEFT LATERAL VIEW with an explode function. This however is not going to be a simple translation in the manner of function to function translation, and so we will defer this to Databricks SQL generation, at least for now. 
     




