### PR TITLE
Support translation of TSQL INGORE NULLS clause in windowing functions

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -3127,7 +3127,7 @@ expr
     | expr predicatePartial                     # exprPredicate
     | DISTINCT expr                             # exprDistinct
     //Should be latest rule as it's nearly a catch all
-    | primitiveExpression                       # exprPrimitive
+    | primitiveExpression # exprPrimitive
     ;
 
 withinGroup: WITHIN GROUP L_PAREN orderByClause R_PAREN
@@ -3151,9 +3151,7 @@ jsonPathElem: ID | DOUBLE_QUOTE_ID
 iffExpr: IFF L_PAREN searchCondition COMMA expr COMMA expr R_PAREN
     ;
 
-castExpr
-    : castOp = (TRY_CAST | CAST) L_PAREN expr AS dataType R_PAREN
-    | INTERVAL expr
+castExpr: castOp = (TRY_CAST | CAST) L_PAREN expr AS dataType R_PAREN | INTERVAL expr
     ;
 
 jsonLiteral: LCB kvPair (COMMA kvPair)* RCB | LCB RCB
@@ -3227,15 +3225,10 @@ windowFrameExtent: BETWEEN windowFrameBound AND windowFrameBound
 windowFrameBound: UNBOUNDED (PRECEDING | FOLLOWING) | num (PRECEDING | FOLLOWING) | CURRENT ROW
     ;
 
-functionCall
-    : builtinFunction
-    | standardFunction
-    | rankingWindowedFunction
-    | aggregateFunction
+functionCall: builtinFunction | standardFunction | rankingWindowedFunction | aggregateFunction
     ;
 
-builtinFunction
-    : EXTRACT L_PAREN part = (STRING | ID) FROM expr R_PAREN  # builtinExtract
+builtinFunction: EXTRACT L_PAREN part = (STRING | ID) FROM expr R_PAREN # builtinExtract
     ;
 
 standardFunction: id L_PAREN exprList? R_PAREN

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -3093,11 +3093,9 @@ expressionElem: columnAlias EQ expression | expression asColumnAlias?
     ;
 
 selectListElem
-    : (
-        asterisk
-        | LOCAL_ID op = (PE | ME | SE | DE | MEA | AND_ASSIGN | XOR_ASSIGN | OR_ASSIGN | EQ) expression
-        | expressionElem
-    ) ((IGNORE | RESPECT) NULLS)?
+    : asterisk
+    | LOCAL_ID op = (PE | ME | SE | DE | MEA | AND_ASSIGN | XOR_ASSIGN | OR_ASSIGN | EQ) expression
+    | expressionElem
     ;
 
 tableSources: source += tableSource (COMMA source += tableSource)*
@@ -3339,8 +3337,11 @@ expressionList: exp += expression (COMMA exp += expression)*
 withinGroup: WITHIN GROUP LPAREN orderByClause RPAREN
     ;
 
+// The ((IGNORE | RESPECT) NULLS)? is strictly speaking, not part of the OVER clause
+// but trails certain windowing functions such as LAG and LEAD. However, all such functions
+// must use the OVER clause, so it is included here to make build the IR simpler.
 overClause
-    : OVER LPAREN (PARTITION BY expression (COMMA expression)*)? orderByClause? rowOrRangeClause? RPAREN
+    : ((IGNORE | RESPECT) NULLS)? OVER LPAREN (PARTITION BY expression (COMMA expression)*)? orderByClause? rowOrRangeClause? RPAREN
     ;
 
 rowOrRangeClause: (ROWS | RANGE) windowFrameExtent

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
@@ -248,6 +248,20 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
         Seq(simplyNamedColumn("department_id")),
         Seq(ir.SortOrder(simplyNamedColumn("employee_id"), ir.DescendingSortDirection, ir.SortNullsUnspecified)),
         None))
+
+    example(
+      query = """
+    LEAD(salary, 1) IGNORE NULLS OVER (PARTITION BY department_id ORDER BY employee_id DESC)
+  """,
+      _.expression(),
+      ir.Window(
+        ir.CallFunction(
+          "LEAD",
+          Seq(simplyNamedColumn("salary"), ir.Literal(integer = Some(1)), ir.Literal(boolean = Some(true)))),
+        Seq(simplyNamedColumn("department_id")),
+        Seq(ir.SortOrder(simplyNamedColumn("employee_id"), ir.DescendingSortDirection, ir.SortNullsUnspecified)),
+        None))
+
   }
 
   "translate 'functions' with non-standard syntax" in {


### PR DESCRIPTION
Certain TSQL windowing functions, requiring an OVER clause, allow the specification of `IGNORE NULLS` or `RESPECT NULLS`, which influences their behavior. For instance:

```tsql
SELECT LEAD(column_name) IGNORE NULLS OVER (ORDER BY other_column)
```

The equivalent functions in Databricks SQL take an optional trailing boolean parameter, which indicates whether the function should ignore trailing nulls. 

Here we append the boolean option to the Databricks windowing functions, when the IGNORE NULLS clause is specified, RESPECT NULLS being the default case.