### PR TITLE
TSQL: Remove redundant tokens from TSQL lexer

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -129,7 +129,6 @@ AUTO_UPDATE_STATISTICS                      : 'AUTO_UPDATE_STATISTICS';
 AUTO_UPDATE_STATISTICS_ASYNC                : 'AUTO_UPDATE_STATISTICS_ASYNC';
 AVAILABILITY                                : 'AVAILABILITY';
 AVAILABILITY_MODE                           : 'AVAILABILITY_MODE';
-BACKSLASH                                   : '\\';
 BACKUP                                      : 'BACKUP';
 BACKUP_CLONEDB                              : 'BACKUP_CLONEDB';
 BACKUP_PRIORITY                             : 'BACKUP_PRIORITY';
@@ -461,7 +460,6 @@ LISTENER                                    : 'LISTENER';
 LISTENER_IP                                 : 'LISTENER_IP';
 LISTENER_PORT                               : 'LISTENER_PORT';
 LISTENER_URL                                : 'LISTENER_URL';
-LOAD                                        : 'LOAD';
 LOB_COMPACTION                              : 'LOB_COMPACTION';
 LOCAL                                       : 'LOCAL';
 LOCAL_SERVICE_NAME                          : 'LOCAL_SERVICE_NAME';
@@ -935,7 +933,6 @@ WITHOUT_ARRAY_WRAPPER                       : 'WITHOUT_ARRAY_WRAPPER';
 WITNESS                                     : 'WITNESS';
 WORK                                        : 'WORK';
 WORKLOAD                                    : 'WORKLOAD';
-WRITETEXT                                   : 'WRITETEXT';
 XACT_ABORT                                  : 'XACT_ABORT';
 XLOCK                                       : 'XLOCK';
 XML                                         : 'XML';
@@ -949,8 +946,7 @@ ZONE                                        : 'ZONE';
 SP_EXECUTESQL: 'SP_EXECUTESQL';
 
 //Combinations that cannot be used as IDs
-DISK_DRIVE    : [A-Z][:];
-DOLLAR_ACTION : '$ACTION';
+DOLLAR_ACTION: '$ACTION';
 
 // Functions starting with double at signs
 AACURSOR_ROWS     : '@@CURSOR_ROWS';

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -796,8 +796,7 @@ alterCryptographicProvider
     )?
     ;
 
-createCryptographicProvider
-    : CREATE CRYPTOGRAPHIC PROVIDER providerName = id FROM FILE EQ pathOf_DLL = STRING
+createCryptographicProvider: CREATE CRYPTOGRAPHIC PROVIDER id FROM FILE EQ STRING
     ;
 
 createEndpoint


### PR DESCRIPTION
Removes token definitions that were left in the lexer but are no longer used in the TSQL parser.