### PR TITLE
TSQL: Support generic FOR options

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -3610,7 +3610,6 @@ keyword
     | FIRST
     | FMTONLY
     | FOLLOWING
-    | FOR
     | FORCE
     | FORCE_FAILOVER_ALLOW_DATA_LOSS
     | FORCE_SERVICE_ALLOW_DATA_LOSS
@@ -4136,6 +4135,7 @@ optionList: genericOption (COMMA genericOption)*
  * KEYWORD = VALUE KB        - Some sort of size value, where KB can be various things so is parsed as any id()
  * KEYWORD (=)? DEFAULT      - A fairly redundant option, but sometimes people want to be explicit
  * KEYWORD (=)? AUTO         - The option is set to AUTO, which occurs in a few places
+ * somthing FOR something    - The option is a special case such as OPTIMIZE FOR UNKNOWN
  * DEFAULT                   - The option is set to the default value but is not named
  * ON                        - The option is on but is not named (will get just id)
  * OFF                       - The option is off but is not named (will get just id)
@@ -4149,6 +4149,7 @@ genericOption
         | OFF            // Simple OFF     - don't resolve with expression
         | AUTO           // Simple AUTO    - don't resolve with expression
         | STRING         // String value   - don't resolve with expression
+        | FOR id         // FOR id         - don't resolve with expression - special case
         | expression id? // Catch all for less explicit options, sometimes with extra keywords
     )?
     ;

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/OptionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/OptionBuilder.scala
@@ -32,6 +32,11 @@ class OptionBuilder(expressionBuilder: TSqlExpressionBuilder) {
       case c if c.OFF() != null => OptionOff(id)
       case c if c.AUTO() != null => OptionAuto(id)
       case c if c.STRING() != null => OptionString(id, c.STRING().getText)
+
+      // FOR cannot be allowed as an id as it clashes with the FOR clause in SELECT et al. So
+      // we special case it here and elide the FOR. It handles just a few things such as OPTIMIZE FOR UNKNOWN,
+      // which becomes "OPTIMIZE", Id(UNKNOWN)
+      case c if c.FOR() != null => OptionExpression(id, expressionBuilder.visitId(c.id(1)), None)
       case c if c.expression() != null =>
         val supplement = if (c.id(1) != null) Some(ctx.id(1).getText) else None
         OptionExpression(id, c.expression().accept(expressionBuilder), supplement)

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -517,7 +517,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Project(
             Limit(
               NamedTable("Employees", Map(), is_streaming = false),
-              Literal(integer = Some(10)),
+              Literal(short = Some(10)),
               is_percentage = false,
               with_ties = false),
             Seq(Star(None))))))
@@ -529,7 +529,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Project(
             Limit(
               NamedTable("Employees", Map(), is_streaming = false),
-              Literal(integer = Some(10)),
+              Literal(short = Some(10)),
               is_percentage = true,
               with_ties = false),
             Seq(Star(None))))))
@@ -541,7 +541,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Project(
             Limit(
               NamedTable("Employees", Map(), is_streaming = false),
-              Literal(integer = Some(10)),
+              Literal(short = Some(10)),
               is_percentage = true,
               with_ties = true),
             Seq(Star(None))))))
@@ -557,7 +557,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               NamedTable("Employees", Map(), is_streaming = false),
               Seq(SortOrder(simplyNamedColumn("Salary"), AscendingSortDirection, SortNullsUnspecified)),
               is_global = false),
-            Literal(integer = Some(10))),
+            Literal(short = Some(10))),
           Seq(Star(None))))))
 
     example(
@@ -570,8 +570,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 NamedTable("Employees", Map(), is_streaming = false),
                 Seq(SortOrder(simplyNamedColumn("Salary"), AscendingSortDirection, SortNullsUnspecified)),
                 is_global = false),
-              Literal(integer = Some(10))),
-            Literal(integer = Some(5))),
+              Literal(short = Some(10))),
+            Literal(short = Some(5))),
           Seq(Star(None))))))
   }
 
@@ -586,7 +586,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 NamedTable("Employees", Map(), is_streaming = false),
                 Seq(SortOrder(simplyNamedColumn("Salary"), AscendingSortDirection, SortNullsUnspecified)),
                 is_global = false),
-              Literal(integer = Some(10))),
+              Literal(short = Some(10))),
             List(),
             all_columns_as_keys = true,
             within_watermark = false),
@@ -603,8 +603,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                   NamedTable("Employees", Map(), is_streaming = false),
                   List(SortOrder(Column(None, Id("Salary")), AscendingSortDirection, SortNullsUnspecified)),
                   is_global = false),
-                Literal(integer = Some(10))),
-              Literal(integer = Some(5))),
+                Literal(short = Some(10))),
+              Literal(short = Some(5))),
             List(),
             all_columns_as_keys = true,
             within_watermark = false),


### PR DESCRIPTION
Some TSQL option clauses use the keyword FOR, which is not allowed to be used as an identifier without escaping it using the standard syntax `[FOR]` as it would be seen as a table alias in a `SELECT` statement. Hence it must be catered for explicitly in the generic option syntax. 

For example:

```tsql
SELECT * FROM t FOR XML RAW
            OPTION (
                OPTIMIZE FOR UNKNOWN
            )
```

In the example, the first `FOR` would be seen as an alias for table `t` if it were allowed to be a keyword usable directly as an Identifier.

Here, we expand the ANTLR rule for parsing generically formed options, such that options containing `FOR` are correctly parsed as options.