### PR TITLE
Fix LEFT and RIGHT JOIN syntax in Snowflake ANTLR grammar

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -3011,7 +3011,6 @@ nonReservedWords
     | LAST_NAME
     | LAST_QUERY_ID
     | LEAD
-    | LEFT
     | LENGTH
     | LOCAL
     | MAX_CONCURRENCY_LEVEL
@@ -3042,7 +3041,6 @@ nonReservedWords
     | RESPECT
     | RESTRICT
     | RESULT
-    | RIGHT
     | RLIKE
     | ROLE
     | ROLLUP

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
@@ -62,8 +62,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         expectedAst = Project(simpleJoinAst, Seq(simplyNamedColumn("a"))))
     }
 
-    // TODO: fix the grammar (LEFT gets parsed as an alias rather than a join_type)
-    "translate a query with a LEFT JOIN" ignore {
+    "translate a query with a LEFT JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x LEFT JOIN table_y",
         expectedAst = Project(simpleJoinAst.copy(join_type = LeftOuterJoin), Seq(simplyNamedColumn("a"))))
@@ -75,8 +74,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         expectedAst = Project(simpleJoinAst.copy(join_type = LeftOuterJoin), Seq(simplyNamedColumn("a"))))
     }
 
-    // TODO: fix the grammar (RIGHT gets parsed as an alias rather than a join_type)
-    "translate a query with a RIGHT JOIN" ignore {
+    "translate a query with a RIGHT JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x RIGHT JOIN table_y",
         expectedAst = Project(simpleJoinAst.copy(join_type = RightOuterJoin), Seq(simplyNamedColumn("a"))))

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -517,7 +517,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Project(
             Limit(
               NamedTable("Employees", Map(), is_streaming = false),
-              Literal(integer = Some(10)),
+              Literal(short = Some(10)),
               is_percentage = false,
               with_ties = false),
             Seq(Star(None))))))
@@ -529,7 +529,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Project(
             Limit(
               NamedTable("Employees", Map(), is_streaming = false),
-              Literal(integer = Some(10)),
+              Literal(short = Some(10)),
               is_percentage = true,
               with_ties = false),
             Seq(Star(None))))))
@@ -541,7 +541,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Project(
             Limit(
               NamedTable("Employees", Map(), is_streaming = false),
-              Literal(integer = Some(10)),
+              Literal(short = Some(10)),
               is_percentage = true,
               with_ties = true),
             Seq(Star(None))))))
@@ -557,7 +557,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               NamedTable("Employees", Map(), is_streaming = false),
               Seq(SortOrder(simplyNamedColumn("Salary"), AscendingSortDirection, SortNullsUnspecified)),
               is_global = false),
-            Literal(integer = Some(10))),
+            Literal(short = Some(10))),
           Seq(Star(None))))))
 
     example(
@@ -570,8 +570,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 NamedTable("Employees", Map(), is_streaming = false),
                 Seq(SortOrder(simplyNamedColumn("Salary"), AscendingSortDirection, SortNullsUnspecified)),
                 is_global = false),
-              Literal(integer = Some(10))),
-            Literal(integer = Some(5))),
+              Literal(short = Some(10))),
+            Literal(short = Some(5))),
           Seq(Star(None))))))
   }
 
@@ -586,7 +586,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 NamedTable("Employees", Map(), is_streaming = false),
                 Seq(SortOrder(simplyNamedColumn("Salary"), AscendingSortDirection, SortNullsUnspecified)),
                 is_global = false),
-              Literal(integer = Some(10))),
+              Literal(short = Some(10))),
             List(),
             all_columns_as_keys = true,
             within_watermark = false),
@@ -603,8 +603,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                   NamedTable("Employees", Map(), is_streaming = false),
                   List(SortOrder(Column(None, Id("Salary")), AscendingSortDirection, SortNullsUnspecified)),
                   is_global = false),
-                Literal(integer = Some(10))),
-              Literal(integer = Some(5))),
+                Literal(short = Some(10))),
+              Literal(short = Some(5))),
             List(),
             all_columns_as_keys = true,
             within_watermark = false),


### PR DESCRIPTION
The keywords LEFT and RIGHT were being allowed as identifiers in the grammar. They are in fact hard keywords and must be [escaped] to be used as column names. 

However, SQL parsers are often hand crafted and can do special checks in context. Should we encounter an input set that uses LEFT or RIGHT as a column name without escaping, we can implement semantic predicates (which are generally avoided), as so (note, that this is for illustration purposes, and would actually be a call to a member function where we can explore the lookahead more exactly):

```antlr
asAlias: { !(_input.LA(1) == LEFT && _input.LA(2) == OUTER) }? AS? alias ;
```