### PR TITLE
TSQL: Implement TSQL UPDATE/DELETE statements

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -1600,13 +1600,11 @@ mergeMatched: UPDATE SET updateElem (COMMA updateElem)* | DELETE
 mergeNotMatched: INSERT (LPAREN columnNameList RPAREN)? ( tableValueConstructor | DEFAULT VALUES)
     ;
 
-deleteStatement
-    : withExpression? DELETE (TOP LPAREN expression RPAREN PERCENT? | TOP INT)? FROM? deleteStatementFrom withTableHints? outputClause? (
-        FROM tableSources
-    )? (WHERE ( searchCondition | CURRENT OF ( GLOBAL? cursorName | cursorVar = LOCAL_ID)))? forClause? optionClause? SEMI?
+deleteStatement: withExpression? delete
     ;
 
-deleteStatementFrom: ddlObject | rowsetFunctionLimited | tableVar = LOCAL_ID
+delete
+    : DELETE topClause? FROM? ddlObject withTableHints? outputClause? (FROM tableSources)? updateWhereClause? optionClause? SEMI?
     ;
 
 insertStatement: withExpression? insert

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -1594,7 +1594,7 @@ whenMatches
     | ( WHEN NOT MATCHED BY SOURCE (AND searchCondition)? THEN mergeMatched)+
     ;
 
-mergeMatched: UPDATE SET updateElemMerge (COMMA updateElemMerge)* | DELETE
+mergeMatched: UPDATE SET updateElem (COMMA updateElem)* | DELETE
     ;
 
 mergeNotMatched: INSERT (LPAREN columnNameList RPAREN)? ( tableValueConstructor | DEFAULT VALUES)
@@ -1631,13 +1631,17 @@ selectStatementStandalone: withExpression? selectStatement
 selectStatement: queryExpression forClause? optionClause? SEMI?
     ;
 
-updateStatement
-    : withExpression? UPDATE (TOP LPAREN expression RPAREN PERCENT?)? (
-        ddlObject
-        | rowsetFunctionLimited
-    ) withTableHints? SET updateElem (COMMA updateElem)* outputClause? (FROM tableSources)? (
-        WHERE (searchCondition | CURRENT OF ( GLOBAL? cursorName | cursorVar = LOCAL_ID))
-    )? forClause? optionClause? SEMI?
+updateStatement: withExpression? update
+    ;
+
+update
+    : UPDATE topClause? ddlObject withTableHints? SET updateElem (COMMA updateElem)* outputClause? (
+        FROM tableSources
+    )? updateWhereClause? optionClause? SEMI?
+    ;
+
+updateWhereClause
+    : WHERE (searchCondition | CURRENT OF ( GLOBAL? cursorName | cursorVar = LOCAL_ID))
     ;
 
 outputClause
@@ -2865,14 +2869,18 @@ commonTableExpression: id (LPAREN columnNameList RPAREN)? AS LPAREN selectStatem
     ;
 
 updateElem
-    : LOCAL_ID EQ fullColumnName (EQ | assignmentOperator) expression
-    | (fullColumnName | LOCAL_ID) (EQ | assignmentOperator) expression
-    | udtColumnName = id DOT methodName = id LPAREN expressionList RPAREN
-    ;
-
-updateElemMerge
-    : (fullColumnName | LOCAL_ID) (EQ | assignmentOperator) expression
-    | udtColumnName = id DOT methodName = id LPAREN expressionList RPAREN
+    : (l1 = LOCAL_ID EQ)? (fullColumnName | l2 = LOCAL_ID) op = (
+        EQ
+        | PE
+        | ME
+        | SE
+        | DE
+        | MEA
+        | AND_ASSIGN
+        | XOR_ASSIGN
+        | OR_ASSIGN
+    ) expression                             # updateElemCol
+    | id DOT id LPAREN expressionList RPAREN # updateElemUdt
     ;
 
 searchCondition

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -1583,9 +1583,12 @@ messageStatement
     )
     ;
 
-mergeStatement
-    : withExpression? MERGE (TOP LPAREN expression RPAREN PERCENT?)? INTO? ddlObject withTableHints? asTableAlias? USING tableSources ON
-        searchCondition whenMatches+ outputClause? optionClause? SEMI
+mergeStatement: withExpression? merge
+    ;
+
+merge
+    : MERGE topClause? INTO? ddlObject withTableHints? asTableAlias? USING tableSources ON searchCondition whenMatches+ outputClause? optionClause?
+        SEMI
     ;
 
 whenMatches

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -405,27 +405,13 @@ case class UpdateTable(
   override def output: Seq[Attribute] = target.output
 }
 
-case class UpdateTable(
-    target: Relation,
-    source: Option[Relation],
-    set: Seq[Expression],
-    where: Option[Expression],
-    output: Option[Relation],
-    options: Option[Expression])
-    extends Modification {}
-
-case class DeleteFromTable(
-    target: Relation,
-    source: Option[Relation],
-    where: Option[Expression],
-    output: Option[Relation],
-    options: Option[Expression])
-    extends Modification {}
-
 case class MergeTables(
-    target: Relation,
-    source: Option[Relation],
+    target: LogicalPlan,
+    source: Option[LogicalPlan],
     conditions: Option[Expression],
-    output: Option[Relation],
+    outputRelation: Option[LogicalPlan],
     options: Option[Expression])
-    extends Modification {}
+    extends Modification {
+  override def children: Seq[LogicalPlan] = Seq(target, source.getOrElse(NoopNode), outputRelation.getOrElse(NoopNode))
+  override def output: Seq[Attribute] = target.output
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -407,9 +407,16 @@ case class UpdateTable(
 
 case class UpdateTable(
     target: Relation,
-    top: Relation,
-    source: Relation,
+    source: Option[Relation],
     set: Seq[Expression],
+    where: Option[Expression],
+    output: Option[Relation],
+    options: Option[Expression])
+    extends Modification {}
+
+case class DeleteFromTable(
+    target: Relation,
+    source: Option[Relation],
     where: Option[Expression],
     output: Option[Relation],
     options: Option[Expression])

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -421,3 +421,11 @@ case class DeleteFromTable(
     output: Option[Relation],
     options: Option[Expression])
     extends Modification {}
+
+case class MergeTables(
+    target: Relation,
+    source: Option[Relation],
+    conditions: Option[Expression],
+    output: Option[Relation],
+    options: Option[Expression])
+    extends Modification {}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/extensions.scala
@@ -404,3 +404,13 @@ case class UpdateTable(
   override def children: Seq[LogicalPlan] = Seq(target, source.getOrElse(NoopNode), outputRelation.getOrElse(NoopNode))
   override def output: Seq[Attribute] = target.output
 }
+
+case class UpdateTable(
+    target: Relation,
+    top: Relation,
+    source: Relation,
+    set: Seq[Expression],
+    where: Option[Expression],
+    output: Option[Relation],
+    options: Option[Expression])
+    extends Modification {}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlErrorStrategy.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlErrorStrategy.scala
@@ -243,6 +243,15 @@ object TSqlErrorStrategy {
     "joinSubqueryTableSubqueryExpression" -> "JOIN subquery table subquery expression",
     "joinSubqueryTableSubqueryOperator" -> "JOIN subquery table subquery operator",
     "joinSubqueryTableSubqueryTable" -> "JOIN subquery table subquery table",
+    "updateStatement" -> "UPDATE statement",
+    "update" -> "UPDATE statement",
+    "topClause" -> "TOP clause",
+    "ddlObject" -> "TABLE object",
+    "withTableHints" -> "WITH table hints",
+    "updateElem" -> "UPDATE element specification",
+    "outputClause" -> "OUTPUT clause",
+    "updateWhereClause" -> "WHERE clause",
+    "optionClause" -> "OPTION clause",
 
     // Etc
     "tableSource" -> "table source",

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -31,6 +31,26 @@ class TSqlExpressionBuilder() extends TSqlParserBaseVisitor[ir.Expression] with 
     ir.Options(opts.expressionOpts, opts.stringOpts, opts.boolFlags, opts.autoFlags)
   }
 
+  override def visitUpdateElemCol(ctx: TSqlParser.UpdateElemColContext): ir.Expression = {
+    val value = ctx.expression().accept(this)
+    val target1 = Option(ctx.l2)
+      .map(_.getText)
+      .getOrElse(ctx.fullColumnName().accept(this).asInstanceOf[ir.Identifier].name)
+    val a1 = buildAssign(ir.Identifier(target1, isQuoted = false), value, ctx.op)
+    Option(ctx.l1).map(l1 => ir.Assign(ir.Identifier(l1.getText, isQuoted = false), a1)).getOrElse(a1)
+  }
+
+  override def visitUpdateElemUdt(ctx: TSqlParser.UpdateElemUdtContext): ir.Expression = {
+    val args = ctx.expressionList().expression().asScala.map(_.accept(this))
+    val fName = ctx.id(0).getText + "." + ctx.id(1).getText
+    functionBuilder.buildFunction(fName, args)
+  }
+
+  override def visitUpdateWhereClause(ctx: UpdateWhereClauseContext): ir.Expression = {
+    ctx.searchCondition().accept(this)
+    // TODO: TSQL also supports updates via cursor traversal, which is not supported in Databricks SQL - lint error?
+  }
+
   /**
    * Build a local variable assignment from a column source
    *
@@ -40,18 +60,22 @@ class TSqlExpressionBuilder() extends TSqlParserBaseVisitor[ir.Expression] with 
   private def buildLocalAssign(ctx: TSqlParser.SelectListElemContext): ir.Expression = {
     val localId = ir.Identifier(ctx.LOCAL_ID().getText, isQuoted = false)
     val expression = ctx.expression().accept(this)
-    ctx.op.getType match {
-      case EQ => ir.Assign(localId, expression)
-      case PE => ir.Assign(localId, ir.Add(localId, expression))
-      case ME => ir.Assign(localId, ir.Subtract(localId, expression))
-      case SE => ir.Assign(localId, ir.Multiply(localId, expression))
-      case DE => ir.Assign(localId, ir.Divide(localId, expression))
-      case MEA => ir.Assign(localId, ir.Mod(localId, expression))
-      case AND_ASSIGN => ir.Assign(localId, ir.BitwiseAnd(localId, expression))
-      case OR_ASSIGN => ir.Assign(localId, ir.BitwiseOr(localId, expression))
-      case XOR_ASSIGN => ir.Assign(localId, ir.BitwiseXor(localId, expression))
+    buildAssign(localId, expression, ctx.op)
+  }
+
+  private def buildAssign(target: ir.Expression, value: ir.Expression, op: Token): ir.Expression = {
+    op.getType match {
+      case EQ => ir.Assign(target, value)
+      case PE => ir.Assign(target, ir.Add(target, value))
+      case ME => ir.Assign(target, ir.Subtract(target, value))
+      case SE => ir.Assign(target, ir.Multiply(target, value))
+      case DE => ir.Assign(target, ir.Divide(target, value))
+      case MEA => ir.Assign(target, ir.Mod(target, value))
+      case AND_ASSIGN => ir.Assign(target, ir.BitwiseAnd(target, value))
+      case OR_ASSIGN => ir.Assign(target, ir.BitwiseOr(target, value))
+      case XOR_ASSIGN => ir.Assign(target, ir.BitwiseXor(target, value))
       // We can only reach here if the grammar is changed to add more operators and this function is not updated
-      case _ => ir.UnresolvedExpression(ctx.getText) // Handle unexpected operation types
+      case _ => ir.UnresolvedExpression(op.getText) // Handle unexpected operation types
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -244,6 +244,40 @@ class TSqlRelationBuilder extends TSqlParserBaseVisitor[ir.LogicalPlan] {
     ctx.expressionList().expression().asScala.map(_.accept(expressionBuilder))
   }
 
+  override def visitMergeStatement(ctx: MergeStatementContext): ir.LogicalPlan = {
+    val merge = ctx.merge().accept(this)
+    Option(ctx.withExpression())
+      .map { withExpression =>
+        val ctes = withExpression.commonTableExpression().asScala.map(_.accept(this))
+        ir.WithCTE(ctes, merge)
+      }
+      .getOrElse(merge)
+  }
+
+  override def visitMerge(ctx: MergeContext): ir.LogicalPlan = {
+    // TODO: Ran out of time to implement the rest of the MERGE statement
+
+//    val target = ctx.ddlObject().accept(this)
+//    val hints = buildTableHints(Option(ctx.withTableHints()))
+//    val finalTarget = if (hints.nonEmpty) {
+//      ir.TableWithHints(target, hints)
+//    } else {
+//      target
+//    }
+//
+//    val output = Option(ctx.outputClause()).map(_.accept(this))
+//    val condition = ctx.searchCondition().accept(expressionBuilder)
+//    val tableSourcesOption = Option(ctx.tableSources()).map(_.tableSource().asScala.map(_.accept(this)))
+//    val sourceRelation = tableSourcesOption.map {
+//      case Seq(tableSource) => tableSource
+//      case sources =>
+//        sources.reduce(
+//          ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
+//    }
+
+    ir.UnresolvedRelation(ctx.getText)
+  }
+
   override def visitUpdateStatement(ctx: UpdateStatementContext): ir.LogicalPlan = {
     val update = ctx.update().accept(this)
     Option(ctx.withExpression())

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
@@ -33,7 +33,7 @@ class ExpressionGeneratorTest extends AnyWordSpec with Matchers with MockitoSuga
 
       generate(ir.Literal(date = Some(1721757801000L))) shouldBe "\"2024-07-23\""
 
-      generate(ir.Literal(timestamp = Some(1721757801000L))) shouldBe "\"2024-07-23 12:03:21.000\""
+      generate(ir.Literal(timestamp = Some(1721757801000L))) shouldBe "\"2024-07-23 18:03:21.000\""
     }
 
     "arrays" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
@@ -33,7 +33,7 @@ class ExpressionGeneratorTest extends AnyWordSpec with Matchers with MockitoSuga
 
       generate(ir.Literal(date = Some(1721757801000L))) shouldBe "\"2024-07-23\""
 
-      generate(ir.Literal(timestamp = Some(1721757801000L))) shouldBe "\"2024-07-23 18:03:21.000\""
+      generate(ir.Literal(timestamp = Some(1721757801000L))) shouldBe "\"2024-07-23 12:03:21.000\""
     }
 
     "arrays" in {


### PR DESCRIPTION
Here we add support for the TSQL update statement in all syntactical forms, including support for UDF column transformations. The DELETE statement is also implemented here as they share many common clauses.