### PR TITLE
TSQL: Remove the SIGN fragment from numerical tokens

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -952,13 +952,11 @@ STRING options {
     caseInsensitive = false;
 }: 'N'? '\'' ('\\' . | '\'\'' | ~['])* '\'';
 
-fragment SIGN: [+-];
-
-INT   : SIGN? DEC_DIGIT+;
-HEX   : SIGN? '0' 'X' HEX_DIGIT*;
-FLOAT : SIGN? DEC_DOT_DEC;
-REAL  : SIGN? (INT | DEC_DOT_DEC) ('E' [+-]? DEC_DIGIT+);
-MONEY : SIGN? '$' (INT | FLOAT);
+INT   : DEC_DIGIT+;
+HEX   : '0' 'X' HEX_DIGIT*;
+FLOAT : DEC_DOT_DEC;
+REAL  : (INT | DEC_DOT_DEC) ('E' [+-]? DEC_DIGIT+);
+MONEY : '$' (INT | FLOAT);
 
 EQ         : '=';
 GT         : '>';

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -279,13 +279,13 @@ class TSqlExpressionBuilder() extends TSqlParserBaseVisitor[ir.Expression] with 
     }
 
   private def buildPrimitive(con: Token): ir.Expression = con.getType match {
-    case c if c == DEFAULT => ir.Default()
-    case c if c == LOCAL_ID => ir.Identifier(con.getText, isQuoted = false)
-    case c if c == STRING => ir.Literal(string = Some(removeQuotes(con.getText)))
-    case c if c == NULL_ => ir.Literal(nullType = Some(ir.NullType()))
-    case c if c == HEX => ir.Literal(string = Some(con.getText)) // Preserve format
-    case c if c == MONEY => ir.Money(ir.Literal(string = Some(con.getText)))
-    case _ => convertNumeric(con.getText)
+    case DEFAULT => ir.Default()
+    case LOCAL_ID => ir.Identifier(con.getText, isQuoted = false)
+    case STRING => ir.Literal(string = Some(removeQuotes(con.getText)))
+    case NULL_ => ir.Literal(nullType = Some(ir.NullType()))
+    case HEX => ir.Literal(string = Some(con.getText)) // Preserve format
+    case MONEY => ir.Money(ir.Literal(string = Some(con.getText)))
+    case INT | REAL | FLOAT => convertNumeric(con.getText)
   }
 
   // TODO: Maybe start sharing such things between all the parsers?

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -17,8 +17,8 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
     "translate literals" in {
       example("null", _.expression(), ir.Literal(nullType = Some(ir.NullType())))
       example("1", _.expression(), ir.Literal(short = Some(1)))
-      example("-1", _.expression(), ir.Literal(short = Some(-1)))
-      example("+1", _.expression(), ir.Literal(short = Some(1)))
+      example("-1", _.expression(), ir.UMinus(ir.Literal(short = Some(1))))
+      example("+1", _.expression(), ir.UPlus(ir.Literal(short = Some(1))))
       example("1.1", _.expression(), ir.Literal(float = Some(1.1f)))
       example("'foo'", _.expression(), ir.Literal(string = Some("foo")))
     }
@@ -39,7 +39,9 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
 
     "translate simple numeric binary expressions" in {
       example("1 + 2", _.expression(), ir.Add(ir.Literal(short = Some(1)), ir.Literal(short = Some(2))))
+      example("1 +2", _.expression(), ir.Add(ir.Literal(short = Some(1)), ir.Literal(short = Some(2))))
       example("1 - 2", _.expression(), ir.Subtract(ir.Literal(short = Some(1)), ir.Literal(short = Some(2))))
+      example("1 -2", _.expression(), ir.Subtract(ir.Literal(short = Some(1)), ir.Literal(short = Some(2))))
       example("1 * 2", _.expression(), ir.Multiply(ir.Literal(short = Some(1)), ir.Literal(short = Some(2))))
       example("1 / 2", _.expression(), ir.Divide(ir.Literal(short = Some(1)), ir.Literal(short = Some(2))))
       example("1 % 2", _.expression(), ir.Mod(ir.Literal(short = Some(1)), ir.Literal(short = Some(2))))
@@ -96,7 +98,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
       example(
         "1 + -++-2",
         _.expression(),
-        ir.Add(ir.Literal(short = Some(1)), ir.UMinus(ir.UPlus(ir.UPlus(ir.Literal(short = Some(-2)))))))
+        ir.Add(ir.Literal(short = Some(1)), ir.UMinus(ir.UPlus(ir.UPlus(ir.UMinus(ir.Literal(short = Some(2))))))))
       example(
         "1 + ~ 2 * 3",
         _.expression(),
@@ -106,13 +108,17 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
       example(
         "1 + -2 * 3",
         _.expression(),
-        ir.Add(ir.Literal(short = Some(1)), ir.Multiply(ir.Literal(short = Some(-2)), ir.Literal(short = Some(3)))))
+        ir.Add(
+          ir.Literal(short = Some(1)),
+          ir.Multiply(ir.UMinus(ir.Literal(short = Some(2))), ir.Literal(short = Some(3)))))
       example(
         "1 + -2 * 3 + 7 & 66",
         _.expression(),
         ir.BitwiseAnd(
           ir.Add(
-            ir.Add(ir.Literal(short = Some(1)), ir.Multiply(ir.Literal(short = Some(-2)), ir.Literal(short = Some(3)))),
+            ir.Add(
+              ir.Literal(short = Some(1)),
+              ir.Multiply(ir.UMinus(ir.Literal(short = Some(2))), ir.Literal(short = Some(3)))),
             ir.Literal(short = Some(7))),
           ir.Literal(short = Some(66))))
       example(
@@ -120,7 +126,9 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
         _.expression(),
         ir.BitwiseXor(
           ir.Add(
-            ir.Add(ir.Literal(short = Some(1)), ir.Multiply(ir.Literal(short = Some(-2)), ir.Literal(short = Some(3)))),
+            ir.Add(
+              ir.Literal(short = Some(1)),
+              ir.Multiply(ir.UMinus(ir.Literal(short = Some(2))), ir.Literal(short = Some(3)))),
             ir.Literal(short = Some(7))),
           ir.Literal(short = Some(66))))
       example(
@@ -128,7 +136,9 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
         _.expression(),
         ir.BitwiseOr(
           ir.Add(
-            ir.Add(ir.Literal(short = Some(1)), ir.Multiply(ir.Literal(short = Some(-2)), ir.Literal(short = Some(3)))),
+            ir.Add(
+              ir.Literal(short = Some(1)),
+              ir.Multiply(ir.UMinus(ir.Literal(short = Some(2))), ir.Literal(short = Some(3)))),
             ir.Literal(short = Some(7))),
           ir.Literal(short = Some(66))))
       example(
@@ -136,7 +146,9 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
         _.expression(),
         ir.Add(
           ir.Add(
-            ir.Add(ir.Literal(short = Some(1)), ir.Multiply(ir.Literal(short = Some(-2)), ir.Literal(short = Some(3)))),
+            ir.Add(
+              ir.Literal(short = Some(1)),
+              ir.Multiply(ir.UMinus(ir.Literal(short = Some(2))), ir.Literal(short = Some(3)))),
             ir.Literal(short = Some(7))),
           ir.BitwiseNot(ir.Literal(short = Some(66)))))
       example(
@@ -149,7 +161,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
                 ir.Add(
                   ir.Add(
                     ir.Literal(short = Some(1)),
-                    ir.Multiply(ir.Literal(short = Some(-2)), ir.Literal(short = Some(3)))),
+                    ir.Multiply(ir.UMinus(ir.Literal(short = Some(2))), ir.Literal(short = Some(3)))),
                   ir.Literal(short = Some(7))),
                 ir.Literal(short = Some(1980))),
               ir.Literal(string = Some("leeds1"))),


### PR DESCRIPTION
Fixes #546 

The proposed solution isn't completely satisfying though, as it makes it impossible to parse negative literals out of TSQL input: the input string `-2` is now parsed as `UMinus(Literal(2))` (instead of simply `Literal(-2)`). While being a mere inconvenience (it just delegates the handling of `UPlus` and `UMinus` to downstream processes), the fact that Snowflake grammar is able to parse `-2` as `Literal(-2)` indicates that there might be a better solution to this problem. So I suggest we keep #546 open even if we merge this PR, so that @jimidle can later come back to it and find a better solution.