### PR TITLE
Changes in Final reconcile output for column category 

### DIFF
--- a/src/databricks/labs/remorph/reconcile/recon_capture.py
+++ b/src/databricks/labs/remorph/reconcile/recon_capture.py
@@ -108,7 +108,8 @@ def generate_final_reconcile_output(
     ELSE NULL END AS ROW, 
     CASE WHEN lower(MAIN.report_type) in ('all', 'data') THEN
     CASE 
-        WHEN METRICS.recon_metrics.column_comparison.absolute_mismatch = 0 AND METRICS.recon_metrics.column_comparison.threshold_mismatch = 0 AND METRICS.recon_metrics.column_comparison.mismatch_columns = '' THEN TRUE 
+        WHEN (METRICS.run_metrics.status = true) or 
+         (METRICS.recon_metrics.column_comparison.absolute_mismatch = 0 AND METRICS.recon_metrics.column_comparison.threshold_mismatch = 0 AND METRICS.recon_metrics.column_comparison.mismatch_columns = '') THEN TRUE 
         ELSE FALSE 
     END 
     ELSE NULL END AS COLUMN, 


### PR DESCRIPTION
Changes in the Final reconcile output for column category give priority to status over absolute mismatch since the table threshold for the mismatch is introduced