### PR TITLE
Improve remorph-core coverage report, add a dry-run github workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -182,6 +182,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          cache: 'pip'
+          cache-dependency-path: '**/pyproject.toml'
+          python-version: 3.10.x
+
+      - name: Install hatch
+        run: pip install hatch==$HATCH_VERSION
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: 11
+          cache: 'maven'
+
       - name: Create dummy test file
         run: echo "SELECT * FROM t;" >> dummy_test.sql
         shell: bash

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -171,3 +171,26 @@ jobs:
           name: remorph-coverage-results
           path: coverage/target/coverage-result.json
 
+  coverage-tests-with-make:
+    runs-on: ubuntu-latest
+    env:
+      INPUT_DIR: .
+      OUTPUT_DIR: ./test-reports
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create dummy test file
+        run: echo "SELECT * FROM t;" >> dummy_test.sql
+        shell: bash
+
+      - name: Dry run coverage tests with make
+        run: make dialect_coverage_report
+
+      - name: Verify report file
+        if: ${{ hashFiles('./test-reports/') == '' }}
+        run: |
+          echo "No file produced in tests-reports/"
+          exit 1

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/ErrorCollector.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/ErrorCollector.scala
@@ -87,7 +87,8 @@ class ProductionErrorCollector(sourceCode: String, fileName: String) extends Err
         (errorPosition, errorLine.take(windowWidth - clipMark.length) + clipMark)
       case (true, true) =>
         val start = errorPosition - roomForContext
-        val clippedLineWithoutClipMarks = errorLine.substring(start, start + windowWidth)
+        val clippedLineWithoutClipMarks =
+          errorLine.substring(start, Math.min(start + windowWidth, errorLine.length - 1))
         (
           roomForContext,
           clipMark + clippedLineWithoutClipMarks.substring(

--- a/coverage/src/main/scala/com/databricks/labs/remorph/coverage/Main.scala
+++ b/coverage/src/main/scala/com/databricks/labs/remorph/coverage/Main.scala
@@ -68,12 +68,13 @@ object Main {
           timestamp = now.toString,
           source_dialect = sourceDialect,
           target_dialect = targetDialect,
-          file = test.inputFile.toString)
+          file = os.Path(test.inputFile).relativeTo(sourceDir).toString)
         val report = runner.runQuery(inputQuery, expectedTranslation)
         val reportEntryJson = ReportEntry(header, report).asJson
         os.write.append(outputFilePath, ujson.write(reportEntryJson, indent = -1) + "\n")
       }
     }
+    println(s"Successfully produced coverage report in $outputFilePath")
   }
 
   def main(args: Array[String]): Unit = ParserForMethods(this).runOrExit(args)

--- a/coverage/src/main/scala/com/databricks/labs/remorph/coverage/ReportEntry.scala
+++ b/coverage/src/main/scala/com/databricks/labs/remorph/coverage/ReportEntry.scala
@@ -15,7 +15,7 @@ case class ReportEntryReport(
     transpiled: Int = 0, // 1 for success, 0 for failure
     transpiled_statements: Int = 0, // number of statements transpiled
     transpilation_error: Option[String] = None) {
-  def isSuccess: Boolean = parsed + transpiled == 2
+  def isSuccess: Boolean = parsing_error.isEmpty && transpilation_error.isEmpty
   def errorMessage: Option[String] = parsing_error.orElse(transpilation_error)
 }
 


### PR DESCRIPTION
Set `transpiled` to 0 are we do only parsing ATM, shorten errors and display relative paths to make the report smaller