### PR TITLE
TSQL: Adds tests and support for SELECT OPTION(...) generation

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/ExpressionGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/ExpressionGenerator.scala
@@ -64,7 +64,7 @@ class ExpressionGenerator(val callMapper: ir.CallMapper = new ir.CallMapper())
     }
 
     val boolOptions = opts.boolFlags.map { case (key, value) =>
-      s"     ${key} = ${if (value) { "ON" }
+      s"     ${key} ${if (value) { "ON" }
         else { "OFF" }}\n"
     }.mkString
     val boolStr = if (boolOptions.nonEmpty) {
@@ -74,7 +74,7 @@ class ExpressionGenerator(val callMapper: ir.CallMapper = new ir.CallMapper())
     }
 
     val autoOptions = opts.autoFlags.map { key =>
-      s"     ${key}\n"
+      s"     ${key} AUTO\n"
     }.mkString
     val autoStr = if (autoOptions.nonEmpty) {
       s"    Auto options:\n\n${autoOptions}\n"

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -38,9 +38,11 @@ class TSqlRelationBuilder extends TSqlParserBaseVisitor[ir.LogicalPlan] {
 
     // We visit the OptionClause because in the future, we may be able to glean information from it
     // as an aid to migration, however the clause is not used in the AST or translation.
-    Option(ctx.optionClause).map(_.accept(expressionBuilder))
-
-    ctx.queryExpression.accept(this)
+    val query = ctx.queryExpression.accept(this)
+    Option(ctx.optionClause) match {
+      case Some(optionClause) => ir.WithOptions(query, optionClause.accept(expressionBuilder))
+      case None => query
+    }
   }
 
   override def visitQuerySpecification(ctx: TSqlParser.QuerySpecificationContext): ir.LogicalPlan = {

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
@@ -28,8 +28,8 @@ class ExpressionGeneratorTest extends AnyWordSpec with GeneratorTestCommon[ir.Ex
       |
       |    Boolean options:
       |
-      |     FLAME = OFF
-      |     QUICKLY = ON
+      |     FLAME OFF
+      |     QUICKLY ON
       |
       |
       | */

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -662,7 +662,14 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             SOMETHINGELSE OFF,
             SOMEOTHER AUTO,
             SOMEstrOpt = 'STRINGOPTION')""",
-      expectedAst = Batch(Seq(Project(namedTable("t"), Seq(Star(None))))))
+      expectedAst = Batch(
+        Seq(WithOptions(
+          Project(namedTable("t"), Seq(Star(None))),
+          Options(
+            Map("MAXRECURSION" -> Literal(short = Some(10)), "OPTIMIZE" -> Column(None, Id("FOR", true))),
+            Map("SOMESTROPT" -> "STRINGOPTION"),
+            Map("SOMETHING" -> true, "SOMETHINGELSE" -> false),
+            List("SOMEOTHER"))))))
   }
 
   "parse and collect table hints for named table select statements in all variants" in {


### PR DESCRIPTION
Here, we add code generation support for TSQL `SELECT ... OPTION(...)` clause. 

Any query hints supplied with a SELECT statement are now generated as comments in the output code, in case they may be useful in assessing query performance after remorph transpilation. As in the following sample:

```tsql
SELECT * FROM t
            OPTION (
            MAXRECURSION 10,
            SOMETHING ON,
            SOMETHINGELSE OFF,
            SOMEOTHER AUTO,
            SOMEstrOpt = 'STRINGOPTION')
```

Transpiles to:

```sql
/*
   The following statement was originally given the following OPTIONS:

    Expression options:

     MAXRECURSION = 10

    String options:

     SOMESTROPT = 'STRINGOPTION'

    Boolean options:

     SOMETHING ON
     SOMETHINGELSE OFF

    Auto options:

     SOMEOTHER AUTO


 */
SELECT * FROM t
```