### PR TITLE
TSQL: Implement grammar for CREATE DATABASE and CREATE DATABASE SCOPED OPTION

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -1655,11 +1655,37 @@ outputDmlListElem: (expression | asterisk) asColumnAlias?
     ;
 
 createDatabase
-    : CREATE DATABASE (database = id) (CONTAINMENT EQ ( NONE | PARTIAL))? (
-        ON PRIMARY? databaseFileSpec ( COMMA databaseFileSpec)*
-    )? (id /* LOG */ ON databaseFileSpec (COMMA databaseFileSpec)*)? (COLLATE collationName = id)? (
+    : CREATE DATABASE id (CONTAINMENT EQ ( NONE | PARTIAL))?
+    (
+        ON (
+            (PRIMARY? databaseFileSpec ( COMMA databaseFileSpec)*)?
+            (id /* LOG */ ON databaseFileSpec (COMMA databaseFileSpec)*)?
+        )
+    )?
+    (COLLATE collationName = id)?
+    (
         WITH createDatabaseOption (COMMA createDatabaseOption)*
     )?
+    ;
+
+createDatabaseScopedCredential
+    : CREATE DATABASE SCOPED CREDENTIAL id WITH IDENTITY EQ STRING (SECRET EQ STRING)?
+    ;
+
+createDatabaseOption
+    : FILESTREAM (databaseFilestreamOption (COMMA databaseFilestreamOption)*)
+    | genericOption
+    ;
+
+// TODO: Remove this after verifying translation options for Datrabricks SQL
+    nouse:
+     DEFAULT_LANGUAGE EQ ( id | STRING)
+    | DEFAULT_FULLTEXT_LANGUAGE EQ ( id | STRING)
+    | NESTED_TRIGGERS EQ ( OFF | ON)
+    | TRANSFORM_NOISE_WORDS EQ ( OFF | ON)
+    | TWO_DIGIT_YEAR_CUTOFF EQ INT
+    | DB_CHAINING ( OFF | ON)
+    | TRUSTWORTHY ( OFF | ON)
     ;
 
 createIndex
@@ -3235,16 +3261,7 @@ windowFrameExtent: windowFrameBound | BETWEEN windowFrameBound AND windowFrameBo
 windowFrameBound: UNBOUNDED (PRECEDING | FOLLOWING) | INT (PRECEDING | FOLLOWING) | CURRENT ROW
     ;
 
-createDatabaseOption
-    : FILESTREAM (databaseFilestreamOption (COMMA databaseFilestreamOption)*)
-    | DEFAULT_LANGUAGE EQ ( id | STRING)
-    | DEFAULT_FULLTEXT_LANGUAGE EQ ( id | STRING)
-    | NESTED_TRIGGERS EQ ( OFF | ON)
-    | TRANSFORM_NOISE_WORDS EQ ( OFF | ON)
-    | TWO_DIGIT_YEAR_CUTOFF EQ INT
-    | DB_CHAINING ( OFF | ON)
-    | TRUSTWORTHY ( OFF | ON)
-    ;
+
 
 databaseFilestreamOption
     : LPAREN ((NON_TRANSACTED_ACCESS EQ ( OFF | READ_ONLY | FULL)) | ( DIRECTORY_NAME EQ STRING)) RPAREN

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -1656,11 +1656,9 @@ outputDmlListElem: (expression | asterisk) asColumnAlias?
 
 createDatabase
     : CREATE DATABASE id (CONTAINMENT EQ ( NONE | PARTIAL))? (
-        ON (
-            (PRIMARY? databaseFileSpec ( COMMA databaseFileSpec)*)? (
-                id /* LOG */ ON databaseFileSpec (COMMA databaseFileSpec)*
-            )?
-        )
+        ON (PRIMARY? databaseFileSpec ( COMMA databaseFileSpec)*)? (
+            id /* LOG */ ON databaseFileSpec (COMMA databaseFileSpec)*
+        )?
     )? (COLLATE collationName = id)? (WITH createDatabaseOption (COMMA createDatabaseOption)*)?
     ;
 

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -1655,17 +1655,13 @@ outputDmlListElem: (expression | asterisk) asColumnAlias?
     ;
 
 createDatabase
-    : CREATE DATABASE id (CONTAINMENT EQ ( NONE | PARTIAL))?
-    (
+    : CREATE DATABASE id (CONTAINMENT EQ ( NONE | PARTIAL))? (
         ON (
-            (PRIMARY? databaseFileSpec ( COMMA databaseFileSpec)*)?
-            (id /* LOG */ ON databaseFileSpec (COMMA databaseFileSpec)*)?
+            (PRIMARY? databaseFileSpec ( COMMA databaseFileSpec)*)? (
+                id /* LOG */ ON databaseFileSpec (COMMA databaseFileSpec)*
+            )?
         )
-    )?
-    (COLLATE collationName = id)?
-    (
-        WITH createDatabaseOption (COMMA createDatabaseOption)*
-    )?
+    )? (COLLATE collationName = id)? (WITH createDatabaseOption (COMMA createDatabaseOption)*)?
     ;
 
 createDatabaseScopedCredential
@@ -1678,8 +1674,8 @@ createDatabaseOption
     ;
 
 // TODO: Remove this after verifying translation options for Datrabricks SQL
-    nouse:
-     DEFAULT_LANGUAGE EQ ( id | STRING)
+nouse
+    : DEFAULT_LANGUAGE EQ (id | STRING)
     | DEFAULT_FULLTEXT_LANGUAGE EQ ( id | STRING)
     | NESTED_TRIGGERS EQ ( OFF | ON)
     | TRANSFORM_NOISE_WORDS EQ ( OFF | ON)
@@ -3260,8 +3256,6 @@ windowFrameExtent: windowFrameBound | BETWEEN windowFrameBound AND windowFrameBo
 
 windowFrameBound: UNBOUNDED (PRECEDING | FOLLOWING) | INT (PRECEDING | FOLLOWING) | CURRENT ROW
     ;
-
-
 
 databaseFilestreamOption
     : LPAREN ((NON_TRANSACTED_ACCESS EQ ( OFF | READ_ONLY | FULL)) | ( DIRECTORY_NAME EQ STRING)) RPAREN


### PR DESCRIPTION
The TSQL grammar for `CREATE DATABASE` and `CREATE DATABASE SCOPED OPTION` was not consistent with the TSQL documentation.  Here we correct the grammar errors.

While it was originally my intention to implement these all the way through to code gen, the DDL needs some serious work, and I would rather implement the grammar for it all in a series of grammar only PRs, then come back through and implement all the way to codegen in a subsequent set of PRs. The reason being that as each DDL statement is fixed at the grammar level, all the other DDL statements will gradually simplify at the same time and I do not wish to keep changing grammar then have to tweak previously defined code gen. 