### PR TITLE
Fix translation of Snowflake's join types

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -3391,8 +3391,7 @@ joinType: INNER | outerJoin
     ;
 
 joinClause
-    : joinType? JOIN objectRef ((ON predicate)? | (USING L_PAREN columnList R_PAREN)?)
-    //| joinType? JOIN objectRef (USING L_PAREN columnList R_PAREN)?
+    : joinType? JOIN objectRef ((ON predicate) | (USING L_PAREN columnList R_PAREN))?
     | NATURAL outerJoin? JOIN objectRef
     | CROSS JOIN objectRef
     ;

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
@@ -1,7 +1,6 @@
 package com.databricks.labs.remorph.generators.sql
 
 import com.databricks.labs.remorph.generators.{Generator, GeneratorContext}
-import com.databricks.labs.remorph.parsers.intermediate.{ExceptSetOp, IntersectSetOp, MergeIntoTable, UnionSetOp}
 import com.databricks.labs.remorph.parsers.{intermediate => ir}
 import com.databricks.labs.remorph.transpilers.TranspileException
 
@@ -54,21 +53,27 @@ class LogicalPlanGenerator(val expr: ExpressionGenerator, val explicitDistinct: 
   private def generateJoin(ctx: GeneratorContext, join: ir.Join): String = {
     val left = generate(ctx, join.left)
     val right = generate(ctx, join.right)
-    val joinType = join.join_type match {
-      case ir.InnerJoin => "INNER JOIN"
-      case ir.FullOuterJoin => "FULL OUTER JOIN"
-      case ir.LeftOuterJoin => "LEFT OUTER JOIN"
-      case ir.LeftSemiJoin => "LEFT SEMI JOIN"
-      case ir.LeftAntiJoin => "LEFT ANTI JOIN"
-      case ir.RightOuterJoin => "RIGHT OUTER JOIN"
-      case ir.CrossJoin => "JOIN"
-    }
-
+    val joinType = generateJoinType(join.join_type)
+    val joinClause = if (joinType.isEmpty) { "JOIN" }
+    else { joinType + " JOIN" }
     val conditionOpt = join.join_condition.map(expr.generate(ctx, _))
-    val spaceAndCondition = conditionOpt.map(" ON " + _).getOrElse("")
-    val using = join.using_columns.mkString(", ")
-    val spaceAndUsing = if (using.isEmpty) "" else s" USING ($using)"
-    s"$left $joinType $right$spaceAndCondition$spaceAndUsing"
+    val condition = conditionOpt.map("ON " + _).getOrElse("")
+    val usingColumns = join.using_columns.mkString(", ")
+    val using = if (usingColumns.isEmpty) "" else s"USING ($usingColumns)"
+    Seq(left, joinClause, right, condition, using).filterNot(_.isEmpty).mkString(" ")
+  }
+
+  private def generateJoinType(joinType: ir.JoinType): String = joinType match {
+    case ir.InnerJoin => "INNER"
+    case ir.FullOuterJoin => "FULL OUTER"
+    case ir.LeftOuterJoin => "LEFT OUTER"
+    case ir.LeftSemiJoin => "LEFT SEMI"
+    case ir.LeftAntiJoin => "LEFT ANTI"
+    case ir.RightOuterJoin => "RIGHT OUTER"
+    case ir.CrossJoin => "CROSS"
+    case ir.NaturalJoin(ir.UnspecifiedJoin) => "NATURAL"
+    case ir.NaturalJoin(jt) => s"NATURAL ${generateJoinType(jt)}"
+    case ir.UnspecifiedJoin => ""
   }
 
   private def setOperation(ctx: GeneratorContext, setOp: ir.SetOperation): String = {
@@ -79,16 +84,16 @@ class LogicalPlanGenerator(val expr: ExpressionGenerator, val explicitDistinct: 
       throw unknown(setOp)
     }
     val op = setOp.set_op_type match {
-      case UnionSetOp => "UNION"
-      case IntersectSetOp => "INTERSECT"
-      case ExceptSetOp => "EXCEPT"
+      case ir.UnionSetOp => "UNION"
+      case ir.IntersectSetOp => "INTERSECT"
+      case ir.ExceptSetOp => "EXCEPT"
       case _ => throw unknown(setOp)
     }
     val duplicates = if (setOp.is_all) " ALL" else if (explicitDistinct) " DISTINCT" else ""
     s"(${generate(ctx, setOp.left)}) $op$duplicates (${generate(ctx, setOp.right)})"
   }
 
-  private def generateMerge(ctx: GeneratorContext, mergeIntoTable: MergeIntoTable) = {
+  private def generateMerge(ctx: GeneratorContext, mergeIntoTable: ir.MergeIntoTable) = {
     val target = generate(ctx, mergeIntoTable.targetTable)
     val source = generate(ctx, mergeIntoTable.sourceTable)
     val condition = expr.generate(ctx, mergeIntoTable.mergeCondition)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/relations.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/relations.scala
@@ -367,6 +367,8 @@ case object LeftSemiJoin extends JoinType
 
 case object CrossJoin extends JoinType
 
+case class NaturalJoin(joinType: JoinType) extends JoinType
+
 case object UnspecifiedSetOp extends SetOpType
 
 case object IntersectSetOp extends SetOpType

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGeneratorTest.scala
@@ -145,7 +145,7 @@ class LogicalPlanGeneratorTest extends AnyWordSpec with GeneratorTestCommon[ir.L
 
   "Join" should {
     "transpile to JOIN" in {
-      crossJoin(namedTable("t1"), namedTable("t2")) generates "t1 JOIN t2"
+      crossJoin(namedTable("t1"), namedTable("t2")) generates "t1 CROSS JOIN t2"
 
       ir.Join(
         namedTable("t1"),
@@ -172,6 +172,14 @@ class LogicalPlanGeneratorTest extends AnyWordSpec with GeneratorTestCommon[ir.L
         ir.JoinDataType(
           is_left_struct = false,
           is_right_struct = false)) generates "t1 RIGHT OUTER JOIN t2 ON IS_DATE(c1) USING (c1, c2)"
+
+      ir.Join(
+        namedTable("t1"),
+        namedTable("t2"),
+        None,
+        ir.NaturalJoin(ir.LeftOuterJoin),
+        Seq(),
+        ir.JoinDataType(is_left_struct = false, is_right_struct = false)) generates "t1 NATURAL LEFT OUTER JOIN t2"
     }
   }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
@@ -50,7 +50,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         NamedTable("table_x", Map.empty, is_streaming = false),
         NamedTable("table_y", Map.empty, is_streaming = false),
         join_condition = None,
-        InnerJoin,
+        UnspecifiedJoin,
         using_columns = Seq(),
         JoinDataType(is_left_struct = false, is_right_struct = false))
 
@@ -58,6 +58,18 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
       singleQueryExample(
         query = "SELECT a FROM table_x JOIN table_y",
         expectedAst = Project(simpleJoinAst, Seq(simplyNamedColumn("a"))))
+    }
+
+    "translate a query with a INNER JOIN" in {
+      singleQueryExample(
+        query = "SELECT a FROM table_x INNER JOIN table_y",
+        expectedAst = Project(simpleJoinAst.copy(join_type = InnerJoin), Seq(simplyNamedColumn("a"))))
+    }
+
+    "translate a query with a CROSS JOIN" in {
+      singleQueryExample(
+        query = "SELECT a FROM table_x CROSS JOIN table_y",
+        expectedAst = Project(simpleJoinAst.copy(join_type = CrossJoin), Seq(simplyNamedColumn("a"))))
     }
 
     "translate a query with a LEFT JOIN" in {
@@ -88,6 +100,21 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
       singleQueryExample(
         query = "SELECT a FROM table_x FULL JOIN table_y",
         expectedAst = Project(simpleJoinAst.copy(join_type = FullOuterJoin), Seq(simplyNamedColumn("a"))))
+    }
+
+    "translate a query with a NATURAL JOIN" in {
+      singleQueryExample(
+        query = "SELECT a FROM table_x NATURAL JOIN table_y",
+        expectedAst =
+          Project(simpleJoinAst.copy(join_type = NaturalJoin(UnspecifiedJoin)), Seq(simplyNamedColumn("a"))))
+
+      singleQueryExample(
+        query = "SELECT a FROM table_x NATURAL LEFT JOIN table_y",
+        expectedAst = Project(simpleJoinAst.copy(join_type = NaturalJoin(LeftOuterJoin)), Seq(simplyNamedColumn("a"))))
+
+      singleQueryExample(
+        query = "SELECT a FROM table_x NATURAL RIGHT JOIN table_y",
+        expectedAst = Project(simpleJoinAst.copy(join_type = NaturalJoin(RightOuterJoin)), Seq(simplyNamedColumn("a"))))
     }
 
     "translate a query with a simple WHERE clause" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
@@ -321,7 +321,7 @@ class SnowflakeRelationBuilderSpec
       verify(outerJoin).LEFT()
       verify(outerJoin).RIGHT()
       verify(outerJoin).FULL()
-      verify(joinType, times(4)).outerJoin()
+      verify(joinType).outerJoin()
     }
   }
 }


### PR DESCRIPTION
Previously, `NATURAL` and `CROSS` joins were not properly handled, this change fixes it.