### PR TITLE
[internal] Remove recursive dependency between logical plan and expression generators

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/generators/GeneratorContext.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/GeneratorContext.scala
@@ -1,23 +1,32 @@
 package com.databricks.labs.remorph.generators
 
+import com.databricks.labs.remorph.parsers.{intermediate => ir}
+
 case class GeneratorContext(
+    logical: Generator[ir.LogicalPlan, String],
     maxLineWidth: Int = 120,
     private val indent: Int = 0,
     private val layer: Int = 0,
     private val joins: Int = 0,
     wrapLiteral: Boolean = true) {
   def nest: GeneratorContext =
-    GeneratorContext(maxLineWidth = maxLineWidth, joins = joins, layer = layer, indent = indent + 1)
+    GeneratorContext(logical, maxLineWidth = maxLineWidth, joins = joins, layer = layer, indent = indent + 1)
 
   def ws: String = "  " * indent
 
   def subQuery: GeneratorContext =
-    GeneratorContext(maxLineWidth = maxLineWidth, joins = joins, layer = layer + 1, indent = indent + 1)
+    GeneratorContext(logical, maxLineWidth = maxLineWidth, joins = joins, layer = layer + 1, indent = indent + 1)
 
   def layerName: String = s"layer_$layer"
 
   def withRawLiteral: GeneratorContext =
-    GeneratorContext(maxLineWidth = maxLineWidth, joins = joins, indent = indent, layer = layer, wrapLiteral = false)
+    GeneratorContext(
+      logical,
+      maxLineWidth = maxLineWidth,
+      joins = joins,
+      indent = indent,
+      layer = layer,
+      wrapLiteral = false)
 
   def hasJoins: Boolean = joins > 0
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/ExpressionGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/ExpressionGenerator.scala
@@ -13,9 +13,6 @@ class ExpressionGenerator(val callMapper: ir.CallMapper = new ir.CallMapper())
   private val dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd")
   private val timeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneId.of("UTC"))
 
-  // LogicalPlan and Expression are mutually recursive (due to expressions such as EXISTS, IN, etc.)
-  private val logicalPlanGenerator = new LogicalPlanGenerator(this)
-
   override def generate(ctx: GeneratorContext, tree: ir.Expression): String = expression(ctx, tree)
 
   def expression(ctx: GeneratorContext, expr: ir.Expression): String = {
@@ -320,7 +317,7 @@ class ExpressionGenerator(val callMapper: ir.CallMapper = new ir.CallMapper())
   }
 
   private def scalarSubquery(ctx: GeneratorContext, subquery: ir.ScalarSubquery): String = {
-    logicalPlanGenerator.generate(ctx, subquery.relation)
+    ctx.logical.generate(ctx, subquery.relation)
   }
 
   private def window(ctx: GeneratorContext, window: ir.Window): String = {

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspiler.scala
@@ -27,6 +27,6 @@ class SnowflakeToDatabricksTranspiler extends BaseTranspiler {
   override def optimize(logicalPlan: ir.LogicalPlan): ir.LogicalPlan = logicalPlan
 
   override def generate(optimizedLogicalPlan: ir.LogicalPlan): String =
-    generator.generate(GeneratorContext(), optimizedLogicalPlan)
+    generator.generate(GeneratorContext(generator), optimizedLogicalPlan)
 
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/TSqlToDatabricksTranspiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/TSqlToDatabricksTranspiler.scala
@@ -28,6 +28,6 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
   override def optimize(logicalPlan: ir.LogicalPlan): ir.LogicalPlan = optimizer.apply(logicalPlan)
 
   override def generate(optimizedLogicalPlan: ir.LogicalPlan): String =
-    generator.generate(GeneratorContext(), optimizedLogicalPlan)
+    generator.generate(GeneratorContext(generator), optimizedLogicalPlan)
 
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/DataTypeGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/DataTypeGeneratorTest.scala
@@ -33,7 +33,8 @@ class DataTypeGeneratorTest extends AnyWordSpec with Matchers with TableDrivenPr
   "DataTypeGenerator" should {
     "generate proper SQL data types" in {
       forAll(translations) { (dt, expected) =>
-        DataTypeGenerator.generateDataType(GeneratorContext(), dt) shouldBe expected
+        val logical = new LogicalPlanGenerator(new ExpressionGenerator())
+        DataTypeGenerator.generateDataType(GeneratorContext(logical), dt) shouldBe expected
       }
     }
   }

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/GeneratorTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/GeneratorTestCommon.scala
@@ -12,11 +12,13 @@ trait GeneratorTestCommon[T <: ir.TreeNode[T]] extends Matchers {
 
   implicit class TestOps(t: T) {
     def generates(expectedOutput: String): Assertion = {
-      generator.generate(GeneratorContext(), t) shouldBe expectedOutput
+      val logical = new LogicalPlanGenerator(new ExpressionGenerator())
+      generator.generate(GeneratorContext(logical), t) shouldBe expectedOutput
     }
 
     def doesNotTranspile: Assertion = {
-      assertThrows[TranspileException](generator.generate(GeneratorContext(), t))
+      val logical = new LogicalPlanGenerator(new ExpressionGenerator())
+      assertThrows[TranspileException](generator.generate(GeneratorContext(logical), t))
     }
   }
 }


### PR DESCRIPTION
GeneratorContext is something that is explicitly passed down through entire chain, so let's use it to inject logical plan generator when we need it to generate subquery expressions.