### PR TITLE
TSQL: Improve parser and lexer parsing level coverage ready for CREATE TABLE

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
@@ -842,7 +842,9 @@ DUMMY:
     'DUMMY'
 ; //Dummy is not a keyword but rules reference it in unfinished grammar - need to get rid
 
-SPACE        : [ \t\r\n\u000c\u0085\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000]+                -> skip;
+SPACE:
+    [ \t\r\n\u000c\u0085\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000]+ -> skip
+;
 
 SQL_COMMENT    : '/*' (SQL_COMMENT | .)*? '*/' -> channel(HIDDEN);
 LINE_COMMENT   : '--' ~[\r\n]*                 -> channel(HIDDEN);

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
@@ -842,7 +842,7 @@ DUMMY:
     'DUMMY'
 ; //Dummy is not a keyword but rules reference it in unfinished grammar - need to get rid
 
-SPACE: [ \t\r\n]+ -> skip;
+SPACE        : [ \t\r\n\u000c\u0085\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000]+                -> skip;
 
 SQL_COMMENT    : '/*' (SQL_COMMENT | .)*? '*/' -> channel(HIDDEN);
 LINE_COMMENT   : '--' ~[\r\n]*                 -> channel(HIDDEN);

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -835,7 +835,6 @@ SWITCH                                      : 'SWITCH';
 SYMMETRIC                                   : 'SYMMETRIC';
 SYNCHRONOUS_COMMIT                          : 'SYNCHRONOUS_COMMIT';
 SYNONYM                                     : 'SYNONYM';
-SYS                                         : 'SYS';
 SYSTEM                                      : 'SYSTEM';
 SYSTEM_USER                                 : 'SYSTEM_USER';
 TABLE                                       : 'TABLE';

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -834,6 +834,7 @@ SWITCH                                      : 'SWITCH';
 SYMMETRIC                                   : 'SYMMETRIC';
 SYNCHRONOUS_COMMIT                          : 'SYNCHRONOUS_COMMIT';
 SYNONYM                                     : 'SYNONYM';
+SYS                                         : 'SYS';
 SYSTEM                                      : 'SYSTEM';
 SYSTEM_USER                                 : 'SYSTEM_USER';
 TABLE                                       : 'TABLE';
@@ -938,7 +939,7 @@ DOLLAR_ACTION: '$ACTION';
 // Functions starting with double at signs
 AAPSEUDO: '@@' ID;
 
-SPACE        : [ \t\r\n]+                -> skip;
+SPACE        : [ \t\r\n\u000c\u0085\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000]+                -> skip;
 COMMENT      : '/*' (COMMENT | .)*? '*/' -> channel(HIDDEN);
 LINE_COMMENT : '--' ~[\r\n]*             -> channel(HIDDEN);
 

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -939,7 +939,9 @@ DOLLAR_ACTION: '$ACTION';
 // Functions starting with double at signs
 AAPSEUDO: '@@' ID;
 
-SPACE        : [ \t\r\n\u000c\u0085\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000]+                -> skip;
+SPACE:
+    [ \t\r\n\u000c\u0085\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000]+ -> skip
+;
 COMMENT      : '/*' (COMMENT | .)*? '*/' -> channel(HIDDEN);
 LINE_COMMENT : '--' ~[\r\n]*             -> channel(HIDDEN);
 

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -645,6 +645,7 @@ PROVIDER_KEY_NAME                           : 'PROVIDER_KEY_NAME';
 PUBLIC                                      : 'PUBLIC';
 PYTHON                                      : 'PYTHON';
 QUERY                                       : 'QUERY';
+QUERY_STORE                                 : 'QUERY_STORE';
 QUEUE                                       : 'QUEUE';
 QUEUE_DELAY                                 : 'QUEUE_DELAY';
 QUOTED_IDENTIFIER                           : 'QUOTED_IDENTIFIER';

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlLexer.g4
@@ -933,6 +933,9 @@ XMLSCHEMA                                   : 'XMLSCHEMA';
 XSINIL                                      : 'XSINIL';
 ZONE                                        : 'ZONE';
 
+// Specials for graph nodes
+NODEID: '$NODE_ID';
+
 //Combinations that cannot be used as IDs
 DOLLAR_ACTION: '$ACTION';
 

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -842,15 +842,10 @@ eventSessionPredicateLeaf
     ;
 
 createExternalDataSource
-    : CREATE EXTERNAL DATA SOURCE id
-      WITH LPAREN
-        (COMMA? (  genericOption | connectionOptions))*
-        RPAREN
-        SEMI?
+    : CREATE EXTERNAL DATA SOURCE id WITH LPAREN (COMMA? ( genericOption | connectionOptions))* RPAREN SEMI?
     ;
 
-connectionOptions
-    :  id EQ STRING (COMMA STRING)*
+connectionOptions: id EQ STRING (COMMA STRING)*
     ;
 
 alterExternalDataSource
@@ -1477,18 +1472,16 @@ delete
     : DELETE topClause? FROM? ddlObject withTableHints? outputClause? (FROM tableSources)? updateWhereClause? optionClause? SEMI?
     ;
 
-bulkStatement: BULK INSERT dotIdentifier
-FROM STRING
-( WITH LPAREN bulkInsertOption (COMMA? bulkInsertOption)* RPAREN )?
+bulkStatement
+    : BULK INSERT dotIdentifier FROM STRING (
+        WITH LPAREN bulkInsertOption (COMMA? bulkInsertOption)* RPAREN
+    )?
     ;
 
-bulkInsertOption:
-    ORDER LPAREN bulkInsertCol (COMMA bulkInsertCol)* RPAREN
-       | genericOption
+bulkInsertOption: ORDER LPAREN bulkInsertCol (COMMA bulkInsertCol)* RPAREN | genericOption
     ;
 
-bulkInsertCol:
-    id (ASC |DESC)?
+bulkInsertCol: id (ASC | DESC)?
     ;
 
 insertStatement: withExpression? insert
@@ -1539,13 +1532,11 @@ createDatabase
         ON (PRIMARY? databaseFileSpec ( COMMA databaseFileSpec)*)? (
             id /* LOG */ ON databaseFileSpec (COMMA databaseFileSpec)*
         )?
-    )? (COLLATE id)? (WITH createDatabaseOption (COMMA createDatabaseOption)*)?
-    SEMI?
+    )? (COLLATE id)? (WITH createDatabaseOption (COMMA createDatabaseOption)*)? SEMI?
     ;
 
 createDatabaseScopedCredential
-    : CREATE DATABASE SCOPED CREDENTIAL id
-            WITH IDENTITY EQ STRING (COMMA SECRET EQ STRING)? SEMI?
+    : CREATE DATABASE SCOPED CREDENTIAL id WITH IDENTITY EQ STRING (COMMA SECRET EQ STRING)? SEMI?
     ;
 
 createDatabaseOption
@@ -1758,27 +1749,22 @@ createTable: CREATE (createExternal | createInternal)
 createInternal
     : TABLE tableName (
         LPAREN columnDefTableConstraints (COMMA? tableIndices)* COMMA? RPAREN (LOCK simpleId)?
-    )?
-    tableOptions?  // This sequence looks strange but alloes CTAS and normal CREATE TABLE to be parsed
-    createTableAs?
-    tableOptions?
-    (ON id | DEFAULT | onPartitionOrFilegroup)? (
+    )? tableOptions? // This sequence looks strange but alloes CTAS and normal CREATE TABLE to be parsed
+    createTableAs? tableOptions? (ON id | DEFAULT | onPartitionOrFilegroup)? (
         TEXTIMAGE_ON id
         | DEFAULT
     )? SEMI?
     ;
-
-distributionOption: DISTRIBUTION EQ distributionType ;
 
 createExternal
     : EXTERNAL TABLE tableName (LPAREN columnDefTableConstraints RPAREN)? WITH LPAREN optionList RPAREN AS selectStatementStandalone SEMI?
     ;
 
 createTableAs
-    : AS selectStatementStandalone       # ctas
-    | AS FILETABLE WITH lparenOptionList # ctasFiletable
-    | AS (NODE | EDGE)                   # ctasGraph
-    | AS /* CLONE */ id OF dotIdentifier (AT_KEYWORD STRING)?        # ctasClone
+    : AS selectStatementStandalone                            # ctas
+    | AS FILETABLE WITH lparenOptionList                      # ctasFiletable
+    | AS (NODE | EDGE)                                        # ctasGraph
+    | AS /* CLONE */ id OF dotIdentifier (AT_KEYWORD STRING)? # ctasClone
     ;
 
 tableIndices
@@ -1965,16 +1951,13 @@ autoOption
     ;
 
 changeTrackingOption
-    : CHANGE_TRACKING (EQ (
-        OFF
-        | ON)
+    : CHANGE_TRACKING (
+        EQ ( OFF | ON)
         | LPAREN (changeTrackingOpt ( COMMA changeTrackingOpt)*) RPAREN
     )
     ;
 
-changeTrackingOpt
-    : AUTO_CLEANUP EQ onOff
-    | CHANGE_RETENTION EQ INT ( DAYS | HOURS | MINUTES)
+changeTrackingOpt: AUTO_CLEANUP EQ onOff | CHANGE_RETENTION EQ INT ( DAYS | HOURS | MINUTES)
     ;
 
 containmentOption: CONTAINMENT EQ (NONE | PARTIAL)
@@ -2187,17 +2170,14 @@ cursorStatement
     ;
 
 backupDatabase
-    : BACKUP DATABASE id
-        (READ_WRITE_FILEGROUPS (COMMA optionList)?)?
-        optionList?
-        (TO optionList)
-        (MIRROR TO optionList)?
-     (WITH (
-        ENCRYPTION LPAREN ALGORITHM EQ genericOption COMMA SERVER CERTIFICATE EQ genericOption RPAREN
-        | optionList
+    : BACKUP DATABASE id (READ_WRITE_FILEGROUPS (COMMA optionList)?)? optionList? (TO optionList) (
+        MIRROR TO optionList
+    )? (
+        WITH (
+            ENCRYPTION LPAREN ALGORITHM EQ genericOption COMMA SERVER CERTIFICATE EQ genericOption RPAREN
+            | optionList
         )
-    )?
-    SEMI?
+    )? SEMI?
     ;
 
 backupLog: BACKUP id /* LOG */ id TO optionList (MIRROR TO optionList)? ( WITH optionList)?

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -1939,6 +1939,14 @@ databaseOptionspec
     | targetRecoveryTimeOption
     | termination
     | genericOption
+    | queryStoreOption
+    ;
+
+queryStoreOption
+    : QUERY_STORE (OFF (LPAREN /* FORCED */ id RPAREN)? | ON (LPAREN queryStoreElementOpt RPAREN)?)
+    ;
+
+queryStoreElementOpt:
     ;
 
 autoOption

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -42,7 +42,7 @@ options {
 tSqlFile: batch? EOF
     ;
 
-batch: SEMI* executeBodyBatch? (sqlClauses+ SEMI*)+
+batch: SEMI* executeBodyBatch? SEMI* (sqlClauses+ SEMI*)+
     ;
 
 // TODO: Properly sort out SEMI colons, which have been haphazzardly added in some

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -42,7 +42,7 @@ options {
 tSqlFile: batch? EOF
     ;
 
-batch: SEMI* ( ( sqlClauses SEMI*)+ | executeBodyBatch goStatement? SEMI*)
+batch: SEMI* executeBodyBatch? (sqlClauses+ SEMI*)+
     ;
 
 // TODO: Properly sort out SEMI colons, which have been haphazzardly added in some
@@ -2810,7 +2810,6 @@ predicate
     : EXISTS LPAREN subquery RPAREN
     | freetextPredicate
     | expression comparisonOperator expression
-    | expression ME expression
     | expression comparisonOperator (ALL | SOME | ANY) LPAREN subquery RPAREN
     | expression NOT* BETWEEN expression AND expression
     | expression NOT* IN LPAREN (subquery | expressionList) RPAREN
@@ -2992,8 +2991,8 @@ fullColumnNameList: column += fullColumnName (COMMA column += fullColumnName)*
     ;
 
 rowsetFunction
-    : (OPENROWSET LPAREN STRING COMMA STRING COMMA STRING RPAREN)
-    | (OPENROWSET LPAREN BULK STRING COMMA ( bulkOption (COMMA bulkOption)* | id) RPAREN)
+    : (OPENROWSET LPAREN STRING COMMA ((STRING SEMI STRING SEMI STRING) | STRING) (COMMA (dotIdentifier | STRING)) RPAREN)
+    | (OPENROWSET LPAREN BULK STRING COMMA ( id EQ STRING COMMA optionList? | id) RPAREN)
     ;
 
 bulkOption: id EQ bulkOptionValue = (INT | STRING)

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -2999,9 +2999,6 @@ rowsetFunction
     | (OPENROWSET LPAREN BULK STRING COMMA ( id EQ STRING COMMA optionList? | id) RPAREN)
     ;
 
-bulkOption: id EQ bulkOptionValue = (INT | STRING)
-    ;
-
 derivedTable: subquery | tableValueConstructor | LPAREN tableValueConstructor RPAREN
     ;
 

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -2991,7 +2991,11 @@ fullColumnNameList: column += fullColumnName (COMMA column += fullColumnName)*
     ;
 
 rowsetFunction
-    : (OPENROWSET LPAREN STRING COMMA ((STRING SEMI STRING SEMI STRING) | STRING) (COMMA (dotIdentifier | STRING)) RPAREN)
+    : (
+        OPENROWSET LPAREN STRING COMMA ((STRING SEMI STRING SEMI STRING) | STRING) (
+            COMMA (dotIdentifier | STRING)
+        ) RPAREN
+    )
     | (OPENROWSET LPAREN BULK STRING COMMA ( id EQ STRING COMMA optionList? | id) RPAREN)
     ;
 

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -1938,15 +1938,23 @@ databaseOptionspec
     | sqlOption
     | targetRecoveryTimeOption
     | termination
-    | genericOption
     | queryStoreOption
+    | genericOption
     ;
 
 queryStoreOption
-    : QUERY_STORE (OFF (LPAREN /* FORCED */ id RPAREN)? | ON (LPAREN queryStoreElementOpt RPAREN)?)
+    : QUERY_STORE (
+        EQ (
+            OFF (LPAREN /* FORCED */ id RPAREN)?
+            | ON (LPAREN queryStoreElementOpt (COMMA queryStoreElementOpt)* RPAREN)?
+        )
+        | LPAREN queryStoreElementOpt RPAREN
+        | ALL
+        | id
+    )
     ;
 
-queryStoreElementOpt:
+queryStoreElementOpt: id EQ LPAREN optionList RPAREN | genericOption
     ;
 
 autoOption

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -42,7 +42,7 @@ options {
 tSqlFile: batch? EOF
     ;
 
-batch: executeBodyBatch? (sqlClauses SEMI*)+
+batch: SEMI* executeBodyBatch? SEMI* (sqlClauses SEMI*)+
     ;
 
 // TODO: Properly sort out SEMI colons, which have been haphazzardly added in some
@@ -2911,12 +2911,12 @@ tableSourceItem: tsiElement (asTableAlias columnAliasList?)? withTableHints?
     ;
 
 tsiElement
-    : (SYS DOT)? tableName       # tsiNamedTable
+    : tableName                  # tsiNamedTable
     | rowsetFunction             # tsiRowsetFunction
     | LPAREN derivedTable RPAREN # tsiDerivedTable
     | changeTable                # tsiChangeTable
     | nodesMethod                # tsiNodesMethod
-    | (SYS DOT)? functionCall    # tsiFunctionCall
+    | (id DOT)? functionCall     # tsiFunctionCall
     | LOCAL_ID                   # tsiLocalId
     | LOCAL_ID DOT functionCall  # tsiLocalIdFunctionCall
     | openXml                    # tsiOpenXml
@@ -3008,7 +3008,7 @@ functionValues: f = ( AAPSEUDO | SESSION_USER | SYSTEM_USER | USER)
 
 // Standard functions that are built in but take standard syntax, or are
 // some user function etc
-standardFunction: funcId LPAREN (expression (COMMA expression)*)? RPAREN
+standardFunction: (id DOT)? funcId LPAREN (expression (COMMA expression)*)? RPAREN
     ;
 
 funcId: id | FORMAT | LEFT | RIGHT | REPLACE | CONCAT
@@ -3209,7 +3209,7 @@ sendConversation
     )? SEMI?
     ;
 
-dataType: dataTypeIdentity | id (LPAREN (INT | MAX) (COMMA INT)? RPAREN)?
+dataType: dataTypeIdentity | XML LPAREN id RPAREN | id (LPAREN (INT | MAX) (COMMA INT)? RPAREN)?
     ;
 
 dataTypeIdentity: id IDENTITY (LPAREN INT COMMA INT RPAREN)?

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -258,21 +258,34 @@ class TSqlExpressionBuilder() extends TSqlParserBaseVisitor[ir.Expression] with 
   override def visitScPrec(ctx: TSqlParser.ScPrecContext): ir.Expression = ctx.searchCondition.accept(this)
 
   override def visitPredicate(ctx: TSqlParser.PredicateContext): ir.Expression = {
-    ctx.expression().size() match {
-      case 1 => ctx.expression(0).accept(this)
+
+    ctx match {
+      case e if e.EXISTS() != null => ir.UnresolvedExpression(ctx.getText) // TODO: build EXISTS
+      case f if f.freetextPredicate() != null => ir.UnresolvedExpression(ctx.getText) // TODO: build FREETEXT
+      case i if i.IN() != null => ir.UnresolvedExpression(ctx.getText) // TODO: build IN
+      case asa if asa.subquery() != null => ir.UnresolvedExpression(ctx.getText) // TODO: build = ALL/SOM/ANY subquery
+      case l if l.LIKE() != null => ir.UnresolvedExpression(ctx.getText) // TODO: build LIKE
+      case i if i.IS() != null => ir.UnresolvedExpression(ctx.getText) // TODO: build IS
       case _ =>
-        val left = ctx.expression(0).accept(this)
-        val right = ctx.expression(1).accept(this)
-        ctx.comparisonOperator match {
-          case op if op.LT != null && op.EQ != null => ir.LessThanOrEqual(left, right)
-          case op if op.GT != null && op.EQ != null => ir.GreaterThanOrEqual(left, right)
-          case op if op.LT != null && op.GT != null => ir.NotEquals(left, right)
-          case op if op.BANG != null && op.GT != null => ir.LessThanOrEqual(left, right)
-          case op if op.BANG != null && op.LT != null => ir.GreaterThanOrEqual(left, right)
-          case op if op.BANG != null && op.EQ != null => ir.NotEquals(left, right)
-          case op if op.EQ != null => ir.Equals(left, right)
-          case op if op.GT != null => ir.GreaterThan(left, right)
-          case op if op.LT != null => ir.LessThan(left, right)
+        ctx.expression().size() match {
+          // Single expression as a predicate
+          case 1 => ctx.expression(0).accept(this)
+
+          // Binary logical operators
+          case _ =>
+            val left = ctx.expression(0).accept(this)
+            val right = ctx.expression(1).accept(this)
+            ctx.comparisonOperator match {
+              case op if op.LT != null && op.EQ != null => ir.LessThanOrEqual(left, right)
+              case op if op.GT != null && op.EQ != null => ir.GreaterThanOrEqual(left, right)
+              case op if op.LT != null && op.GT != null => ir.NotEquals(left, right)
+              case op if op.BANG != null && op.GT != null => ir.LessThanOrEqual(left, right)
+              case op if op.BANG != null && op.LT != null => ir.GreaterThanOrEqual(left, right)
+              case op if op.BANG != null && op.EQ != null => ir.NotEquals(left, right)
+              case op if op.EQ != null => ir.Equals(left, right)
+              case op if op.GT != null => ir.GreaterThan(left, right)
+              case op if op.LT != null => ir.LessThan(left, right)
+            }
         }
     }
   }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -448,7 +448,7 @@ class TSqlRelationBuilder extends TSqlParserBaseVisitor[ir.LogicalPlan] {
 
   override def visitOutputClause(ctx: OutputClauseContext): ir.LogicalPlan = {
     val outputs = ctx.outputDmlListElem().asScala.map(_.accept(expressionBuilder))
-    val target = ctx.ddlObject().accept(this)
+    val target = Option(ctx.ddlObject()).map(_.accept(this))
     val columns =
       Option(ctx.columnNameList())
         .map(_.id().asScala.map(id => ir.Column(None, expressionBuilder.visitId(id))))

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/relations.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/relations.scala
@@ -1,14 +1,15 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.intermediate.{Attribute, AttributeReference, Column, Command, Expression, Id, LeafNode, LogicalPlan, RelationCommon, StringType}
+import com.databricks.labs.remorph.parsers.intermediate._
 
 case class DerivedRows(rows: Seq[Seq[Expression]]) extends LeafNode {
   override def output: Seq[Attribute] = rows.flatten.map(e => AttributeReference(e.toString, e.dataType))
 }
 
-case class Output(target: LogicalPlan, outputs: Seq[Expression], columns: Option[Seq[Column]]) extends RelationCommon {
+case class Output(target: Option[LogicalPlan], outputs: Seq[Expression], columns: Option[Seq[Column]])
+    extends RelationCommon {
   override def output: Seq[Attribute] = outputs.map(e => AttributeReference(e.toString, e.dataType))
-  override def children: Seq[LogicalPlan] = Seq(target)
+  override def children: Seq[LogicalPlan] = Seq(target.getOrElse(NoopNode))
 }
 
 case class WithOutputClause(input: LogicalPlan, target: LogicalPlan) extends RelationCommon {

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/TSqlToDatabricksTranspiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/TSqlToDatabricksTranspiler.scala
@@ -17,26 +17,16 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
   private val generator = new LogicalPlanGenerator(new ExpressionGenerator(new TSqlCallMapper()))
 
   override def parse(input: String): ir.LogicalPlan = {
-    val inputString = CharStreams.fromString(input)
-    val lexer = new TSqlLexer(inputString)
-    val tokenStream = new CommonTokenStream(lexer)
-    val parser = new TSqlParser(tokenStream)
-    parser.setErrorHandler(new TSqlErrorStrategy)
-    val errListener = new ProductionErrorCollector(input, "-- test string --")
-    parser.removeErrorListeners()
-    parser.addErrorListener(errListener)
-    val tree = parser.tSqlFile()
-    if (errListener.errorCount > 0) {
-
-      // scalastyle:off println
-      println("==============================")
-      println(input)
-      println("------------------------------")
-      errListener.formatErrors.foreach(println)
-      println("------------------------------")
-      // scalastyle:on println
-    }
-    astBuilder.visit(tree)
+      val inputString = CharStreams.fromString(input)
+      val lexer = new TSqlLexer(inputString)
+      val tokenStream = new CommonTokenStream(lexer)
+      val parser = new TSqlParser(tokenStream)
+      parser.setErrorHandler(new TSqlErrorStrategy)
+      val errListener = new ProductionErrorCollector(input, "-- test string --")
+      parser.removeErrorListeners()
+      parser.addErrorListener(errListener)
+      val tree = parser.tSqlFile()
+      astBuilder.visit(tree)
   }
 
   override def optimize(logicalPlan: ir.LogicalPlan): ir.LogicalPlan = optimizer.apply(logicalPlan)

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/TSqlToDatabricksTranspiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/TSqlToDatabricksTranspiler.scala
@@ -17,16 +17,16 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
   private val generator = new LogicalPlanGenerator(new ExpressionGenerator(new TSqlCallMapper()))
 
   override def parse(input: String): ir.LogicalPlan = {
-      val inputString = CharStreams.fromString(input)
-      val lexer = new TSqlLexer(inputString)
-      val tokenStream = new CommonTokenStream(lexer)
-      val parser = new TSqlParser(tokenStream)
-      parser.setErrorHandler(new TSqlErrorStrategy)
-      val errListener = new ProductionErrorCollector(input, "-- test string --")
-      parser.removeErrorListeners()
-      parser.addErrorListener(errListener)
-      val tree = parser.tSqlFile()
-      astBuilder.visit(tree)
+    val inputString = CharStreams.fromString(input)
+    val lexer = new TSqlLexer(inputString)
+    val tokenStream = new CommonTokenStream(lexer)
+    val parser = new TSqlParser(tokenStream)
+    parser.setErrorHandler(new TSqlErrorStrategy)
+    val errListener = new ProductionErrorCollector(input, "-- test string --")
+    parser.removeErrorListeners()
+    parser.addErrorListener(errListener)
+    val tree = parser.tSqlFile()
+    astBuilder.visit(tree)
   }
 
   override def optimize(logicalPlan: ir.LogicalPlan): ir.LogicalPlan = optimizer.apply(logicalPlan)

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/TSqlToDatabricksTranspiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/TSqlToDatabricksTranspiler.scala
@@ -26,6 +26,16 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
     parser.removeErrorListeners()
     parser.addErrorListener(errListener)
     val tree = parser.tSqlFile()
+    if (errListener.errorCount > 0) {
+
+      // scalastyle:off println
+      println("==============================")
+      println(input)
+      println("------------------------------")
+      errListener.formatErrors.foreach(println)
+      println("------------------------------")
+      // scalastyle:on println
+    }
     astBuilder.visit(tree)
   }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -799,7 +799,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             Assign(Column(None, Id("b")), Literal(short = Some(2)))),
           None,
           Some(tsql.Output(
-           Some( NamedTable("Inserted", Map(), is_streaming = false)),
+            Some(NamedTable("Inserted", Map(), is_streaming = false)),
             Seq(
               Alias(Column(Some(ObjectReference(Id("INSERTED"))), Id("a")), Seq(Id("a_lias")), None),
               Column(Some(ObjectReference(Id("INSERTED"))), Id("b"))),

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -728,7 +728,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Some(List(Id("a"), Id("b"))),
           DerivedRows(List(List(Literal(short = Some(1)), Literal(short = Some(2))))),
           Some(tsql.Output(
-            namedTable("Inserted"),
+            Some(namedTable("Inserted")),
             List(
               Alias(Column(Some(ObjectReference(Id("INSERTED"))), Id("a")), Seq(Id("a_lias")), None),
               Column(Some(ObjectReference(Id("INSERTED"))), Id("b"))),
@@ -799,7 +799,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             Assign(Column(None, Id("b")), Literal(short = Some(2)))),
           None,
           Some(tsql.Output(
-            NamedTable("Inserted", Map(), is_streaming = false),
+           Some( NamedTable("Inserted", Map(), is_streaming = false)),
             Seq(
               Alias(Column(Some(ObjectReference(Id("INSERTED"))), Id("a")), Seq(Id("a_lias")), None),
               Column(Some(ObjectReference(Id("INSERTED"))), Id("b"))),
@@ -852,7 +852,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           None,
           None,
           Some(tsql.Output(
-            NamedTable("Deleted", Map(), is_streaming = false),
+            Some(NamedTable("Deleted", Map(), is_streaming = false)),
             Seq(
               Alias(Column(Some(ObjectReference(Id("DELETED"))), Id("a")), Seq(Id("a_lias")), None),
               Column(Some(ObjectReference(Id("DELETED"))), Id("b"))),

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -460,39 +460,6 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               simplyNamedColumn("colxcount")))))))
   }
 
-  "parse genericOptions correctly" in {
-    // NOTE that we are using the BACKUP DATABASE command to test the generic options as it is the
-    // simplest command that has generic options.
-    example(
-      query = "BACKUP DATABASE mydb TO DISK = 'disk' WITH mount = auto, verbose = default",
-      expectedAst = Batch(Seq(BackupDatabase("mydb", Seq("disk"), Map.empty, Seq("MOUNT"), Map.empty))))
-
-    example(
-      query = "BACKUP DATABASE mydb TO DISK = 'disk1', DISK = 'disk2' WITH mount = auto, verbose = default",
-      expectedAst = Batch(Seq(BackupDatabase("mydb", Seq("disk2", "disk1"), Map.empty, Seq("MOUNT"), Map.empty))))
-
-    example(
-      query = "BACKUP DATABASE mydb TO DISK = 'disk1' WITH audit = ON, desCription = 'backup1', FILE_SNAPSHOT OFF",
-      expectedAst = Batch(
-        Seq(
-          BackupDatabase("mydb", Seq("disk1"), Map("AUDIT" -> true, "FILE_SNAPSHOT" -> false), List.empty, Map.empty))))
-
-    example(
-      query = "BACKUP DATABASE mydb TO DISK = 'disk1' WITH ON, OFF, AUTO, DEFAULT",
-      expectedAst =
-        Batch(Seq(BackupDatabase("mydb", Seq("disk1"), Map("ON" -> true, "OFF" -> false), Seq("AUTO"), Map.empty))))
-
-    example(
-      query = "BACKUP DATABASE mydb TO DISK 'd1' WITH COPY_ONLY, limit = 77 KB",
-      expectedAst = Batch(
-        Seq(
-          BackupDatabase(
-            "mydb",
-            Seq("d1"),
-            Map("COPY_ONLY" -> true),
-            List.empty,
-            Map("LIMIT" -> Literal(short = Some(77)))))))
-  }
 
   "translate a SELECT with a TOP clause" should {
     "use LIMIT" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -460,7 +460,6 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               simplyNamedColumn("colxcount")))))))
   }
 
-
   "translate a SELECT with a TOP clause" should {
     "use LIMIT" in {
       example(

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlErrorStategySpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlErrorStategySpec.scala
@@ -32,14 +32,12 @@ class TSqlErrorStategySpec extends AnyWordSpec with TSqlParserTestCommon with Ma
       checkError(
         query = "*",
         errContains = "unexpected extra input '*' while parsing a T-SQL batch\n" +
-          "expecting one of: End of batch, Identifier, Select Statement, Statement, '(', ';', 'RAW', 'WITH'")
+          "expecting one of: End of batch, Identifier, Select Statement, Statement, ")
 
       checkError(
         query = "SELECT * FROM",
         errContains = "'<EOF>' was unexpected while parsing a table source in a FROM clause " +
-          "in a SELECT statement\nexpecting one of: @Local, Identifier, '$', '$PARTITION', '(', '::', " +
-          "'CONTAINSTABLE', 'FREETEXTTABLE', 'LEFT', 'OPENROWSET', 'OPENXML', 'RAW'...\nFile: -- test " +
-          "string --, Line: 1, Token: <EOF>\nSELECT * FROM")
+          "in a SELECT statement\nexpecting one of:")
     }
   }
 }


### PR DESCRIPTION
More preparation for CREATE and associated DML.

Also fixes the TSQL visitor so that (almost) all paths to a visitor that do not have ir production coverage no longer cause exceptions but instead produce UnresolvedXXX, which greatly improves parser coverage as AST production problems are currently counted against the parser as a whole and are not separated from syntactical success vs IR production success.

```
OUTPUT_DIR=.venv/antlr-coverage hatch run python src/databricks/labs/remorph/coverage/local_report.py
remorph-core -> Snow: 91.75% parsed (3572/3893), 64.22% transpiled (2500/3893)
remorph-core -> Tsql: 96.58% parsed (3643/3772), 58.30% transpiled (2199/3772)
```