### PR TITLE
Improve coverage test success rate around snowflake's conversion functions

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/ExpressionGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/ExpressionGenerator.scala
@@ -39,6 +39,7 @@ class ExpressionGenerator(val callMapper: ir.CallMapper = new ir.CallMapper())
       case d: ir.Distinct => distinct(ctx, d)
       case s: ir.Star => star(ctx, s)
       case c: ir.Cast => cast(ctx, c)
+      case t: ir.TryCast => tryCast(ctx, t)
       case col: ir.Column => column(ctx, col)
       case _: ir.DeleteAction => "DELETE"
       case ia: ir.InsertAction => insertAction(ctx, ia)
@@ -237,6 +238,8 @@ class ExpressionGenerator(val callMapper: ir.CallMapper = new ir.CallMapper())
         case r: ir.RLike => rlike(ctx, r)
         case r: ir.RegExpExtract => regexpExtract(ctx, r)
         case t: ir.TimestampDiff => timestampDiff(ctx, t)
+        case i: ir.IsNull => postfix(ctx, i)
+        case i: ir.IsNotNull => postfix(ctx, i)
         case t: ir.TimestampAdd => timestampAdd(ctx, t)
         case e: ir.Extract => extract(ctx, e)
         case i: ir.In => in(ctx, i)
@@ -330,9 +333,21 @@ class ExpressionGenerator(val callMapper: ir.CallMapper = new ir.CallMapper())
   }
 
   private def cast(ctx: GeneratorContext, cast: ir.Cast): String = {
-    val expr = expression(ctx, cast.expr)
-    val dataType = DataTypeGenerator.generateDataType(ctx, cast.dataType)
-    s"CAST($expr AS $dataType)"
+    castLike(ctx, "CAST", cast.expr, cast.dataType)
+  }
+
+  private def tryCast(ctx: GeneratorContext, tryCast: ir.TryCast): String = {
+    castLike(ctx, "TRY_CAST", tryCast.expr, tryCast.dataType)
+  }
+
+  private def castLike(
+      ctx: GeneratorContext,
+      prettyName: String,
+      expr: ir.Expression,
+      dataType: ir.DataType): String = {
+    val e = expression(ctx, expr)
+    val dt = DataTypeGenerator.generateDataType(ctx, dataType)
+    s"$prettyName($e AS $dt)"
   }
 
   private def dot(ctx: GeneratorContext, dot: ir.Dot): String = {
@@ -428,6 +443,11 @@ class ExpressionGenerator(val callMapper: ir.CallMapper = new ir.CallMapper())
   private def extract(ctx: GeneratorContext, e: ir.Extract): String = {
     s"EXTRACT(${expression(ctx, e.left)} FROM ${expression(ctx, e.right)})"
   }
+
+  private def postfix(ctx: GeneratorContext, unaryFunc: ir.Unary with ir.Fn): String = {
+    s"${expression(ctx, unaryFunc.child)} ${unaryFunc.prettyName}"
+  }
+
   private def orNull(option: Option[String]): String = option.getOrElse("NULL")
 
   private def singleQuote(s: String): String = s"'$s'"

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/ExpressionGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/ExpressionGenerator.scala
@@ -238,8 +238,6 @@ class ExpressionGenerator(val callMapper: ir.CallMapper = new ir.CallMapper())
         case r: ir.RLike => rlike(ctx, r)
         case r: ir.RegExpExtract => regexpExtract(ctx, r)
         case t: ir.TimestampDiff => timestampDiff(ctx, t)
-        case i: ir.IsNull => postfix(ctx, i)
-        case i: ir.IsNotNull => postfix(ctx, i)
         case t: ir.TimestampAdd => timestampAdd(ctx, t)
         case e: ir.Extract => extract(ctx, e)
         case i: ir.In => in(ctx, i)
@@ -442,10 +440,6 @@ class ExpressionGenerator(val callMapper: ir.CallMapper = new ir.CallMapper())
 
   private def extract(ctx: GeneratorContext, e: ir.Extract): String = {
     s"EXTRACT(${expression(ctx, e.left)} FROM ${expression(ctx, e.right)})"
-  }
-
-  private def postfix(ctx: GeneratorContext, unaryFunc: ir.Unary with ir.Fn): String = {
-    s"${expression(ctx, unaryFunc.child)} ${unaryFunc.prettyName}"
   }
 
   private def orNull(option: Option[String]): String = option.getOrElse("NULL")

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/expressions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/expressions.scala
@@ -100,7 +100,7 @@ case class AttributeReference(
   override def newInstance(): NamedExpression = copy(exprId = NamedExpression.newExprId)
 }
 
-abstract class Unary(child: Expression) extends Expression {
+abstract class Unary(val child: Expression) extends Expression {
   override def children: Seq[Expression] = Seq(child)
 }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/functions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/functions.scala
@@ -2325,7 +2325,6 @@ case class SchemaOfJson(left: Expression, right: Expression) extends Binary(left
 
 /** to_json(expr[, options]) - Returns a JSON string with a given struct value */
 case class StructsToJson(left: Expression, right: Option[Expression]) extends Expression with Fn {
-  override def children: Seq[Expression] = Seq(left) ++ right
   override def prettyName: String = "TO_JSON"
   override def children: Seq[Expression] = Seq(left) ++ right.toSeq
   override def dataType: DataType = UnresolvedType

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/functions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/functions.scala
@@ -1478,16 +1478,6 @@ case class SparkVersion() extends LeafExpression with Fn {
 }
 
 /**
- * CASE WHEN expr1 THEN expr2 [WHEN expr3 THEN expr4]* [ELSE expr5] END - When `expr1` = true, returns `expr2`; else
- * when `expr3` = true, returns `expr4`; else returns `expr5`.
- */
-case class CaseWhen(branches: Seq[Expression], otherwise: Option[Expression] = None) extends Expression with Fn {
-  override def prettyName: String = "WHEN"
-  override def children: Seq[Expression] = branches ++ otherwise
-  override def dataType: DataType = UnresolvedType
-}
-
-/**
  * width_bucket(value, min_value, max_value, num_bucket) - Returns the bucket number to which `value` would be assigned
  * in an equiwidth histogram with `num_bucket` buckets, in the range `min_value` to `max_value`."
  */
@@ -2337,6 +2327,7 @@ case class SchemaOfJson(left: Expression, right: Expression) extends Binary(left
 case class StructsToJson(left: Expression, right: Option[Expression]) extends Expression with Fn {
   override def children: Seq[Expression] = Seq(left) ++ right
   override def prettyName: String = "TO_JSON"
+  override def children: Seq[Expression] = Seq(left) ++ right.toSeq
   override def dataType: DataType = UnresolvedType
 }
 
@@ -2486,4 +2477,12 @@ case class TimestampAdd(unit: String, quantity: Expression, timestamp: Expressio
   override def prettyName: String = "DATEADD"
   override def children: Seq[Expression] = Seq(quantity, timestamp)
   override def dataType: DataType = TimestampType
+}
+
+/**
+ * try_cast(sourceExpr AS targetType) - Returns the value of sourceExpr cast to data type targetType if possible, or
+ * NULL if not possible.
+ */
+case class TryCast(expr: Expression, override val dataType: DataType) extends Expression {
+  override def children: Seq[Expression] = Seq(expr)
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/literals.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/literals.scala
@@ -21,6 +21,8 @@ object Literal {
       value.values.toSeq)))
   def apply(values: Seq[Expression]): Literal =
     Literal(array = Some(ArrayExpr(values.headOption.map(_.dataType).getOrElse(UnresolvedType), values)))
+
+  val NULL: Literal = Literal(nullType = Some(NullType))
 }
 
 case class Literal(

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/relations.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/relations.scala
@@ -106,10 +106,10 @@ case object NullsFirst extends NullOrdering("NULLS FIRST")
 case object NullsLast extends NullOrdering("NULLS LAST")
 
 case class SortOrder(
-    child: Expression,
+    expr: Expression,
     direction: SortDirection = UnspecifiedSortDirection,
     nullOrdering: NullOrdering = SortNullsUnspecified)
-    extends Unary(child) {
+    extends Unary(expr) {
   override def dataType: DataType = child.dataType
 }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -442,7 +442,7 @@ class SnowflakeExpressionBuilder()
       case c if c.likeExpression() != null => buildLikeExpression(c.likeExpression(), expression)
       case c if c.IS() != null =>
         val isNull: ir.Expression = ir.IsNull(expression)
-        Option(c.nullNotNull().NOT()).fold(isNull)(_ => ir.Not(isNull))
+        Option(c.nullNotNull().NOT()).fold(isNull)(_ => ir.IsNotNull(expression))
     }
     Option(ctx.NOT()).fold(predicate)(_ => ir.Not(predicate))
   }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -284,7 +284,11 @@ class SnowflakeExpressionBuilder()
     case c if c.castOp != null =>
       val expression = c.expr().accept(this)
       val dataType = typeBuilder.buildDataType(c.dataType())
-      ir.Cast(expression, dataType, returnNullOnError = c.TRY_CAST() != null)
+      ctx.castOp.getType match {
+        case CAST => ir.Cast(expression, dataType)
+        case TRY_CAST => ir.TryCast(expression, dataType)
+      }
+
     case c if c.INTERVAL() != null =>
       ir.Cast(c.expr().accept(this), ir.IntervalType)
   }

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
@@ -742,11 +742,11 @@ class ExpressionGeneratorTest
     }
 
     "ISNOTNULL(a)" in {
-      ir.CallFunction("ISNOTNULL", Seq(ir.UnresolvedAttribute("a"))) generates "ISNOTNULL(a)"
+      ir.CallFunction("ISNOTNULL", Seq(ir.UnresolvedAttribute("a"))) generates "a IS NOT NULL"
     }
 
     "ISNULL(a)" in {
-      ir.CallFunction("ISNULL", Seq(ir.UnresolvedAttribute("a"))) generates "ISNULL(a)"
+      ir.CallFunction("ISNULL", Seq(ir.UnresolvedAttribute("a"))) generates "a IS NULL"
     }
 
     "JAVA_METHOD(a, b)" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
@@ -742,11 +742,11 @@ class ExpressionGeneratorTest
     }
 
     "ISNOTNULL(a)" in {
-      ir.CallFunction("ISNOTNULL", Seq(ir.UnresolvedAttribute("a"))) generates "a IS NOT NULL"
+      ir.CallFunction("ISNOTNULL", Seq(ir.UnresolvedAttribute("a"))) generates "ISNOTNULL(a)"
     }
 
     "ISNULL(a)" in {
-      ir.CallFunction("ISNULL", Seq(ir.UnresolvedAttribute("a"))) generates "a IS NULL"
+      ir.CallFunction("ISNULL", Seq(ir.UnresolvedAttribute("a"))) generates "ISNULL(a)"
     }
 
     "JAVA_METHOD(a, b)" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
@@ -65,7 +65,7 @@ class SnowflakeExprSpec extends AnyWordSpec with SnowflakeParserTestCommon with 
 
     "translate cast expressions" in {
       example("CAST (column_1 AS BOOLEAN)", Cast(Id("column_1"), BooleanType))
-      example("TRY_CAST (column_1 AS BOOLEAN)", Cast(Id("column_1"), BooleanType, returnNullOnError = true))
+      example("TRY_CAST (column_1 AS BOOLEAN)", TryCast(Id("column_1"), BooleanType))
       example("TO_TIMESTAMP(1234567890)", CallFunction("TO_TIMESTAMP", Seq(Literal(integer = Some(1234567890)))))
       example("TIME('00:00:00')", CallFunction("TO_TIME", Seq(Literal(string = Some("00:00:00")))))
       example("TO_TIME(column_1)", CallFunction("TO_TIME", Seq(Id("column_1"))))

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
@@ -161,7 +161,7 @@ class SnowflakeExprSpec extends AnyWordSpec with SnowflakeParserTestCommon with 
 
     "translate IS [NOT] NULL expressions" in {
       exprAndPredicateExample("col1 IS NULL", IsNull(Id("col1")))
-      exprAndPredicateExample("col1 IS NOT NULL", Not(IsNull(Id("col1"))))
+      exprAndPredicateExample("col1 IS NOT NULL", IsNotNull(Id("col1")))
     }
 
     "translate DISTINCT expressions" in {

--- a/src/databricks/labs/remorph/snow/databricks.py
+++ b/src/databricks/labs/remorph/snow/databricks.py
@@ -177,7 +177,7 @@ def _to_boolean(self: org_databricks.Databricks.Generator, expression: local_exp
                WHEN LOWER({this}) IN ('false', 'f', 'no', 'n', 'off', '0') THEN FALSE
                ELSE RAISE_ERROR('Boolean value of x is not recognized by TO_BOOLEAN')
                END
-       WHEN ISNOTNULL(TRY_CAST({this} AS DOUBLE)) THEN
+       WHEN TRY_CAST({this} AS DOUBLE) IS NOT NULL THEN
            CASE
                WHEN ISNAN(CAST({this} AS DOUBLE)) OR CAST({this} AS DOUBLE) = DOUBLE('infinity') THEN
                     RAISE_ERROR('Invalid parameter type for TO_BOOLEAN')

--- a/tests/resources/functional/snowflake/arrays/test_arrayagg_6.sql
+++ b/tests/resources/functional/snowflake/arrays/test_arrayagg_6.sql
@@ -3,5 +3,5 @@ SELECT ARRAY_AGG(col2) WITHIN GROUP (ORDER BY col2 DESC) FROM test_table;
 
 -- databricks sql:
 SELECT
-  SORT_ARRAY(ARRAY_AGG(col2), FALSE)
+  SORT_ARRAY(ARRAY_AGG(col2), false)
 FROM test_table;

--- a/tests/resources/functional/snowflake/ddl/lateral_struct/test_lateral_struct_12.sql
+++ b/tests/resources/functional/snowflake/ddl/lateral_struct/test_lateral_struct_12.sql
@@ -4,7 +4,7 @@ SELECT
   verticals.value AS value
 FROM
   sample_data,
-  LATERAL FLATTEN(input => array_column, OUTER => TRUE ) AS verticals;
+  LATERAL FLATTEN(input => array_column, OUTER => true ) AS verticals;
 
 -- databricks sql:
 SELECT

--- a/tests/resources/functional/snowflake/ddl/lateral_struct/test_lateral_struct_3.sql
+++ b/tests/resources/functional/snowflake/ddl/lateral_struct/test_lateral_struct_3.sql
@@ -6,7 +6,7 @@ SELECT
   i.value:prop::FLOAT as prop,
   candidates
 FROM dwh.vw  d,
-LATERAL FLATTEN (INPUT => d.impressions, OUTER => TRUE) i
+LATERAL FLATTEN (INPUT => d.impressions, OUTER => true) i
 WHERE event_date = '{start_date}' and event_name in ('store.replacements_view');
 
 -- databricks sql:

--- a/tests/resources/functional/snowflake/ddl/lateral_struct/test_lateral_struct_9.sql
+++ b/tests/resources/functional/snowflake/ddl/lateral_struct/test_lateral_struct_9.sql
@@ -25,7 +25,7 @@ SELECT
 FROM SNOWFLAKE.DATA_SHARING_USAGE.LISTING_ACCESS_HISTORY AS lah
 LATERAL VIEW EXPLODE(lah.listing_objects_accessed) AS los
 LATERAL VIEW EXPLODE(los.value.columns) AS cols
-WHERE TRUE AND CAST(los.value.objectDomain AS STRING) IN ('Table', 'View') AND
+WHERE true AND CAST(los.value.objectDomain AS STRING) IN ('Table', 'View') AND
 query_date BETWEEN '2022-03-01' AND '2022-04-30' AND
 CAST(los.value.objectName AS STRING) = 'DATABASE_NAME.SCHEMA_NAME.TABLE_NAME' AND
 lah.consumer_account_locator = 'CONSUMER_ACCOUNT_LOCATOR' GROUP BY 1, 2, 3;

--- a/tests/resources/functional/snowflake/functions/conversion/is_integer_1.sql
+++ b/tests/resources/functional/snowflake/functions/conversion/is_integer_1.sql
@@ -6,6 +6,6 @@ SELECT
 
       CASE
          WHEN col IS NULL THEN NULL
-         WHEN col RLIKE '^-?[0-9]+$' AND TRY_CAST(col AS INT) IS NOT NULL THEN TRUE
-         ELSE FALSE
-         END
+         WHEN col RLIKE '^-?[0-9]+$' AND TRY_CAST(col AS INT) IS NOT NULL THEN true
+         ELSE false
+         END;

--- a/tests/resources/functional/snowflake/functions/conversion/to_boolean/test_to_boolean_1.sql
+++ b/tests/resources/functional/snowflake/functions/conversion/to_boolean/test_to_boolean_1.sql
@@ -1,3 +1,4 @@
+
 -- snowflake sql:
 select TO_BOOLEAN(col1);
 
@@ -9,15 +10,15 @@ SELECT
      WHEN TYPEOF(col1) = 'boolean' THEN BOOLEAN(col1)
      WHEN TYPEOF(col1) = 'string' THEN
          CASE
-             WHEN LOWER(col1) IN ('true', 't', 'yes', 'y', 'on', '1') THEN TRUE
-             WHEN LOWER(col1) IN ('false', 'f', 'no', 'n', 'off', '0') THEN FALSE
+             WHEN LOWER(col1) IN ('true', 't', 'yes', 'y', 'on', '1') THEN true
+             WHEN LOWER(col1) IN ('false', 'f', 'no', 'n', 'off', '0') THEN false
              ELSE RAISE_ERROR('Boolean value of x is not recognized by TO_BOOLEAN')
              END
-     WHEN ISNOTNULL(TRY_CAST(col1 AS DOUBLE)) THEN
+     WHEN TRY_CAST(col1 AS DOUBLE) IS NOT NULL THEN
          CASE
              WHEN ISNAN(CAST(col1 AS DOUBLE)) OR CAST(col1 AS DOUBLE) = DOUBLE('infinity') THEN
                   RAISE_ERROR('Invalid parameter type for TO_BOOLEAN')
              ELSE CAST(col1 AS DOUBLE) != 0.0
              END
      ELSE RAISE_ERROR('Invalid parameter type for TO_BOOLEAN')
-     END
+     END;

--- a/tests/resources/functional/snowflake/functions/conversion/to_boolean/test_try_to_boolean_1.sql
+++ b/tests/resources/functional/snowflake/functions/conversion/to_boolean/test_try_to_boolean_1.sql
@@ -9,15 +9,15 @@ SELECT
        WHEN TYPEOF(1) = 'boolean' THEN BOOLEAN(1)
        WHEN TYPEOF(1) = 'string' THEN
            CASE
-               WHEN LOWER(1) IN ('true', 't', 'yes', 'y', 'on', '1') THEN TRUE
-               WHEN LOWER(1) IN ('false', 'f', 'no', 'n', 'off', '0') THEN FALSE
+               WHEN LOWER(1) IN ('true', 't', 'yes', 'y', 'on', '1') THEN true
+               WHEN LOWER(1) IN ('false', 'f', 'no', 'n', 'off', '0') THEN false
                ELSE RAISE_ERROR('Boolean value of x is not recognized by TO_BOOLEAN')
                END
-       WHEN ISNOTNULL(TRY_CAST(1 AS DOUBLE)) THEN
+       WHEN TRY_CAST(1 AS DOUBLE) IS NOT NULL THEN
            CASE
                WHEN ISNAN(CAST(1 AS DOUBLE)) OR CAST(1 AS DOUBLE) = DOUBLE('infinity') THEN
                     RAISE_ERROR('Invalid parameter type for TO_BOOLEAN')
                ELSE CAST(1 AS DOUBLE) != 0.0
                END
        ELSE NULL
-       END
+       END;

--- a/tests/resources/functional/snowflake/test_skip_unsupported_operations/test_skip_unsupported_operations_11.sql
+++ b/tests/resources/functional/snowflake/test_skip_unsupported_operations/test_skip_unsupported_operations_11.sql
@@ -12,7 +12,7 @@ SELECT DISTINCT
   WHERE dst.mto_flag = 1
       AND dst.customer_type IN ('Consumer')
       AND dd.STORE_ID IN (SELECT store_id FROM foo.bar.cng_stores_stage)
-      AND dd.is_test = FALSE
+      AND dd.is_test = false
       AND dst.origin IN ('Chat')
       AND dd_agent_id IS NOT NULL
   AND dst.CREATED_DATE > current_date - 7
@@ -38,7 +38,7 @@ SELECT DISTINCT
         store_id
       FROM foo.bar.cng_stores_stage
     )
-    AND dd.is_test = FALSE
+    AND dd.is_test = false
     AND dst.origin IN ('Chat')
     AND NOT dd_agent_id IS NULL
     AND dst.CREATED_DATE > CURRENT_DATE - 7


### PR DESCRIPTION
Two tests are still failing, those related to the translation of Snowflake's  `TO_TIMESTAMP` function. 

To fix these I figured that we first need to agree on:
- how we convert the provided time format. For instance, remorph-py converts `yyyy-MM-dd` to `yyyy-MM-d`. Both format have the same effect (in the sense that in DB SQL, `TO_TIME(x, 'yyyy-MM-dd')` and `TO_TIME(x, 'yyyy-MM-d')` yield the same result), but are syntactically different. Are we sure this conversion is necessary?
- how do we infer the format string (that is required by `TO_TIME`) when none is provided to `TO_TIMESTAMP` ?