### PR TITLE
[internal] added JVM command proxy in development mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ spark-warehouse/
 remorph_transpile/
 /linter/gen/
 /linter/src/main/antlr4/library/gen/
+.databricks-login.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,30 @@ issues without relying on external systems. Focus on testing the edge cases of t
 things may fail. See [this example](https://github.com/databricks/databricks-sdk-py/pull/295) as a reference of an extensive
 unit test coverage suite and the clear difference between _unit tests_ and _integration tests_.
 
+## JVM Proxy
+
+In order to use this, you have to install `remorph` on any workspace via `databricks labs install .`, 
+so that `.databricks-login.json` file gets created with the following contents:
+
+```
+{
+  "workspace_profile": "labs-azure-tool",
+  "cluster_id": "0708-200540-wcwi4i9e"
+}
+```
+
+then run `make dev-cli` to collect classpath information. And then invoke commands, 
+like `databricks labs remorph debug-script --name file`. Add `--debug` flag to recompile project each run.
+
+Example output is:
+```text
+databricks labs remorph debug-script --name foo
+21:57:42  INFO [databricks.sdk] Using Azure CLI authentication with AAD tokens
+21:57:42  WARN [databricks.sdk] azure_workspace_resource_id field not provided. It is recommended to specify this field in the Databricks configuration to avoid authentication errors.
+Debugging script...
+Map(log_level -> disabled, name -> foo)
+```
+
 ## Local Setup
 
 This section provides a step-by-step guide to set up and start working on the project. These steps will help you set up your project environment and dependencies for efficient development.

--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,6 @@ antlr-coverage: build_core_jar
 
 antlr-lint:
 	mvn compile -DskipTests exec:java -pl linter --file pom.xml -Dexec.args="-i core/src/main/antlr4 -o .venv/linter/grammar -c true"
+
+dev-cli:
+	mvn -f core/pom.xml dependency:build-classpath -Dmdep.outputFile=target/classpath.txt

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,6 +23,7 @@
     <sql-formatter.version>2.0.5</sql-formatter.version>
     <scala-logging.version>3.9.5</scala-logging.version>
     <databricks-sdk-java.version>0.27.1</databricks-sdk-java.version>
+    <ujson.version>4.0.0</ujson.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -95,6 +96,12 @@
       <artifactId>pprint_${scala.binary.version}</artifactId>
       <version>0.8.1</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.lihaoyi</groupId>
+      <artifactId>ujson_${scala.binary.version}</artifactId>
+      <version>${ujson.version}</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.github.vertical-blank</groupId>

--- a/core/src/main/scala/com/databricks/labs/remorph/Main.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/Main.scala
@@ -1,5 +1,22 @@
 package com.databricks.labs.remorph
 
+case class Payload(command: String, flags: Map[String, String])
+
 object Main extends App {
-  // noop
+  // scalastyle:off println
+  route match {
+    case Payload("debug-script", args) =>
+      println("Debugging script...")
+      println(args)
+    case Payload(command, _) =>
+      println(s"Unknown command: $command")
+  }
+
+  // parse json from the last CLI argument
+  private def route: Payload = {
+    val payload = ujson.read(args.last).obj
+    val command = payload("command").str
+    val flags = payload("flags").obj.mapValues(_.str).toMap
+    Payload(command, flags)
+  }
 }

--- a/labs.yml
+++ b/labs.yml
@@ -53,3 +53,8 @@ commands:
         description: Directory to store the generated lineage file
   - name: configure-secrets
     description: Utility to setup Scope and Secrets on Databricks Workspace
+  - name: debug-script
+    description: "[INTERNAL] Debug Script"
+    flags:
+      - name: name
+        description: Filename to debug

--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -10,6 +10,7 @@ from databricks.labs.remorph.reconcile.runner import ReconcileRunner
 from databricks.labs.remorph.lineage import lineage_generator
 from databricks.labs.remorph.transpiler.execute import morph
 from databricks.labs.remorph.reconcile.execute import RECONCILE_OPERATION_NAME, AGG_RECONCILE_OPERATION_NAME
+from databricks.labs.remorph.jvmproxy import proxy_command
 
 from databricks.sdk import WorkspaceClient
 
@@ -21,6 +22,9 @@ DIALECTS = {name for name, dialect in SQLGLOT_DIALECTS.items()}
 
 def raise_validation_exception(msg: str) -> Exception:
     raise ValueError(msg)
+
+
+proxy_command(remorph, "debug-script")
 
 
 @remorph.command

--- a/src/databricks/labs/remorph/jvmproxy.py
+++ b/src/databricks/labs/remorph/jvmproxy.py
@@ -1,0 +1,55 @@
+import logging
+import os
+import sys
+import subprocess
+
+from databricks.labs.blueprint.entrypoint import find_project_root
+from databricks.labs.blueprint.cli import App
+
+
+def proxy_command(app: App, command: str):
+    def fn(**_):
+        proxy = JvmProxy()
+        proxy.run()
+
+    fn.__name__ = command
+    fn.__doc__ = f"Proxy to run {command} in JVM"
+    app.command(fn)
+
+
+class JvmProxy:
+    def __init__(self):
+        self._root = find_project_root(__file__)
+        databricks_logger = logging.getLogger("databricks")
+        self._debug = databricks_logger.level == logging.DEBUG
+
+    def _recompile(self):
+        subprocess.run(
+            ["mvn", "compile", "-f", f'{self._root}/pom.xml'],
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            check=True,
+        )
+
+    def run(self):
+        if self._debug:
+            self._recompile()
+        classpath = self._root / 'core/target/classpath.txt'
+        classes = self._root / 'core/target/scala-2.12/classes'
+        # TODO: use the os-specific path separator
+        args = [
+            "java",
+            "--class-path",
+            f'{classes.as_posix()}:{classpath.read_text()}',
+            "com.databricks.labs.remorph.Main",
+            sys.argv[1],
+        ]
+        with subprocess.Popen(
+            args,
+            stdin=sys.stdin,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            env=os.environ.copy(),
+            text=True,
+        ) as process:
+            return process.wait()


### PR DESCRIPTION
This PR adds basic functionality to proxy commands into JVM subprocess through Python. Later on it'll be implemented in the Databricks CLI itself. In order to use this, you have to install `remorph` on any workspace via `databricks labs install .`, so that `.databricks-login.json` file gets created with the following contents:

```
{
  "workspace_profile": "labs-azure-tool",
  "cluster_id": "0708-200540-wcwi4i9e"
}
```

then run `make dev-cli` to collect classpath information. And then invoke commands, like `databricks labs remorph debug-script --name file`. Add `--debug` flag to recompile project each run.