### PR TITLE
Added Translation Support for Non Ansi joins

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
@@ -914,4 +914,5 @@ fragment DEC_DIGIT   : [0-9];
 // This lexer rule is needed so that any unknown character in the lexicon does not
 // cause an incomprehensible error message. This rule will allow the parser to issue
 // somethign more meaningful and perform error recovery.
-BADCHAR: .;
+BADCHAR       : .;
+NON_ANSI_JOIN : '(''+'')';

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -3194,6 +3194,7 @@ dataType
 primitiveExpression
     : DEFAULT           # primExprDefault //?
     | id LSB num RSB    # primArrayAccess
+    | id NON_ANSI_JOIN     # primExprNonAnsiJoin
     | id LSB string RSB # primObjectAccess
     | id                # primExprColumn
     | literal           # primExprLiteral

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
@@ -6,6 +6,21 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
 
   protected val transpiler = new SnowflakeToDatabricksTranspiler
 
+  "Snowflake non ansi join" should{
+
+    "transpile non ansi join" in {
+      "SELECT T1.d, T2.c FROM T1, T2 WHERE T1.x = T2.x(+)" transpilesTo
+        s"""SELECT
+           |  T1.d,
+           |  T2.c
+           |FROM
+           |  T1
+           |  LEFT JOIN T2
+           |ON
+           |  T1.x = T2.x;""".stripMargin
+    }
+  }
+
   "Snowflake transpiler" should {
 
     "transpile queries" in {

--- a/src/databricks/labs/remorph/snow/snowflake.py
+++ b/src/databricks/labs/remorph/snow/snowflake.py
@@ -217,6 +217,7 @@ def _parse_tonumber(args: list) -> local_expression.ToNumber:
 class Snow(Snowflake):
     # Instantiate Snowflake Dialect
     snowflake = Snowflake()
+    snowflake.SUPPORTS_COLUMN_JOIN_MARKS = True
 
     class Tokenizer(Snowflake.Tokenizer):
 
@@ -228,7 +229,10 @@ class Snow(Snowflake):
             r"(?i)var\s+\w+\s+=\s+\w+?": TokenType.VAR,
         }
 
-        KEYWORDS = {**Snowflake.Tokenizer.KEYWORDS}
+        KEYWORDS = {
+            **Snowflake.Tokenizer.KEYWORDS,
+            "(+)": TokenType.JOIN_MARKER,
+        }
         # DEC is not a reserved keyword in Snowflake it can be used as table alias
         KEYWORDS.pop("DEC")
 

--- a/tests/resources/functional/snowflake/nonansi/test_non_ansi_join.sql
+++ b/tests/resources/functional/snowflake/nonansi/test_non_ansi_join.sql
@@ -1,0 +1,5 @@
+-- snowflake sql:
+SELECT T1.d, T2.c FROM T1, T2 WHERE T1.x = T2.x(+) and T2.y(+) > 5 and T1.z = 10
+
+-- databricks sql:
+SELECT T1.d, T2.c FROM T1 LEFT JOIN T2 ON T1.x = T2.x AND T2.y > 5 WHERE T1.z = 10


### PR DESCRIPTION
Adding support for non ansi join.
Non Ansi is a style of SQL join where the join condition is specified in the WHERE clause, and an outer join is indicated using the (+) operator.

Example:
input query : `SELECT  *  FROM   departments d, employees e WHERE  d.department_id(+) = e.department_id`
output query: `SELECT *  FROM   departments d RIGHT OUTER JOIN employees e ON  d.department_id = e.department_id`