### PR TITLE
[internal] added query plan debugger and dependency injection baseline

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -95,7 +95,7 @@
       <groupId>com.lihaoyi</groupId>
       <artifactId>pprint_${scala.binary.version}</artifactId>
       <version>0.8.1</version>
-      <scope>test</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.lihaoyi</groupId>

--- a/core/src/main/scala/com/databricks/labs/remorph/ApplicationContext.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/ApplicationContext.scala
@@ -1,0 +1,22 @@
+package com.databricks.labs.remorph
+
+import com.databricks.labs.remorph.parsers.PlanParser
+import com.databricks.labs.remorph.parsers.snowflake.SnowflakePlanParser
+import com.databricks.labs.remorph.parsers.tsql.TSqlPlanParser
+import com.databricks.labs.remorph.queries.ExampleDebugger
+import com.databricks.sdk.WorkspaceClient
+import com.databricks.sdk.core.DatabricksConfig
+
+trait ApplicationContext {
+  def snowflakePlanParser: SnowflakePlanParser = new SnowflakePlanParser
+  def tsqlPlanParser: TSqlPlanParser = new TSqlPlanParser
+  def planParser(dialect: String): PlanParser[_] = dialect match {
+    case "snowflake" => snowflakePlanParser
+    case "tsql" => tsqlPlanParser
+    case _ => throw new IllegalArgumentException(s"Unsupported dialect: $dialect")
+  }
+  def connectConfig: DatabricksConfig = new DatabricksConfig()
+  def workspaceClient: WorkspaceClient = new WorkspaceClient(connectConfig)
+  def prettyPrinter[T](v: T): Unit = pprint.pprintln[T](v)
+  def exampleDebugger: ExampleDebugger = new ExampleDebugger(planParser, prettyPrinter)
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/Main.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/Main.scala
@@ -2,12 +2,13 @@ package com.databricks.labs.remorph
 
 case class Payload(command: String, flags: Map[String, String])
 
-object Main extends App {
+object Main extends App with ApplicationContext {
   // scalastyle:off println
   route match {
     case Payload("debug-script", args) =>
-      println("Debugging script...")
-      println(args)
+      exampleDebugger.debugExample(args("name"), args.get("dialect"))
+    case Payload("debug-me", _) =>
+      prettyPrinter(workspaceClient.currentUser().me())
     case Payload(command, _) =>
       println(s"Unknown command: $command")
   }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/PlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/PlanParser.scala
@@ -1,0 +1,19 @@
+package com.databricks.labs.remorph.parsers
+
+import com.databricks.labs.remorph.parsers.intermediate.LogicalPlan
+import org.antlr.v4.runtime.{CharStream, CharStreams, CommonTokenStream, Parser, TokenSource, TokenStream}
+
+trait PlanParser[P <: Parser] {
+  protected def createPlan(parser: P): LogicalPlan
+  protected def createParser(stream: TokenStream): P
+  protected def createLexer(input: CharStream): TokenSource
+  def parse(input: String): LogicalPlan = {
+    val inputString = CharStreams.fromString(input)
+    val tokenStream = new CommonTokenStream(createLexer(inputString))
+    val parser = createParser(tokenStream)
+    val errHandler = new ProductionErrorCollector(input, "-- test string --")
+    parser.removeErrorListeners()
+    parser.addErrorListener(errHandler)
+    createPlan(parser)
+  }
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakePlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakePlanParser.scala
@@ -1,0 +1,15 @@
+package com.databricks.labs.remorph.parsers.snowflake
+
+import com.databricks.labs.remorph.parsers.PlanParser
+import com.databricks.labs.remorph.parsers.intermediate.LogicalPlan
+import org.antlr.v4.runtime.{CharStream, TokenSource, TokenStream}
+
+class SnowflakePlanParser extends PlanParser[SnowflakeParser] {
+  private val astBuilder = new SnowflakeAstBuilder
+  override protected def createLexer(input: CharStream): TokenSource = new SnowflakeLexer(input)
+  override protected def createParser(stream: TokenStream): SnowflakeParser = new SnowflakeParser(stream)
+  override protected def createPlan(parser: SnowflakeParser): LogicalPlan = {
+    val tree = parser.snowflakeFile()
+    astBuilder.visit(tree)
+  }
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
@@ -1,0 +1,12 @@
+package com.databricks.labs.remorph.parsers.tsql
+
+import com.databricks.labs.remorph.parsers.PlanParser
+import com.databricks.labs.remorph.parsers.intermediate.LogicalPlan
+import org.antlr.v4.runtime.{CharStream, TokenSource, TokenStream}
+
+class TSqlPlanParser extends PlanParser[TSqlParser] {
+  private val astBuilder = new TSqlAstBuilder()
+  override protected def createPlan(parser: TSqlParser): LogicalPlan = astBuilder.visit(parser.tSqlFile())
+  override protected def createParser(stream: TokenStream): TSqlParser = new TSqlParser(stream)
+  override protected def createLexer(input: CharStream): TokenSource = new TSqlLexer(input)
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/queries/ExampleSource.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/queries/ExampleSource.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.coverage
+package com.databricks.labs.remorph.queries
 
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
@@ -7,7 +7,7 @@ import scala.collection.JavaConverters._
 
 case class AcceptanceTest(testName: String, inputFile: File)
 
-trait AcceptanceTestSource {
+trait ExampleSource {
   def listTests: Seq[AcceptanceTest]
 }
 
@@ -26,7 +26,7 @@ object NestedFiles {
   }
 }
 
-class NestedFiles(root: Path) extends AcceptanceTestSource {
+class NestedFiles(root: Path) extends ExampleSource {
   def listTests: Seq[AcceptanceTest] = {
     val files =
       Files

--- a/core/src/test/scala/com/databricks/labs/remorph/queries/ExampleDebuggerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/queries/ExampleDebuggerTest.scala
@@ -1,0 +1,26 @@
+package com.databricks.labs.remorph.queries
+
+import com.databricks.labs.remorph.parsers.PlanParser
+import com.databricks.labs.remorph.parsers.intermediate.NoopNode
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+
+class ExampleDebuggerTest extends AnyWordSpec with Matchers with MockitoSugar {
+  "ExampleDebugger" should {
+    "work" in {
+      val buf = new StringBuilder
+      val parser = mock[PlanParser[_]]
+      when(parser.parse(any[String])).thenReturn(NoopNode)
+
+      val debugger = new ExampleDebugger(_ => parser, x => buf.append(x))
+      val name = s"${NestedFiles.projectRoot}/tests/resources/functional/snowflake/nested_query_with_json_1.sql"
+
+      debugger.debugExample(name, None)
+
+      buf.toString() should equal("NoopNode$\n")
+    }
+  }
+}

--- a/coverage/src/main/scala/com/databricks/labs/remorph/coverage/Main.scala
+++ b/coverage/src/main/scala/com/databricks/labs/remorph/coverage/Main.scala
@@ -1,4 +1,5 @@
 package com.databricks.labs.remorph.coverage
+import com.databricks.labs.remorph.queries.{DialectNameCommentBasedQueryExtractor, NestedFiles, WholeFileQueryExtractor}
 import mainargs._
 
 import java.time.Instant

--- a/coverage/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
+++ b/coverage/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
@@ -1,6 +1,7 @@
 package com.databricks.labs.remorph.coverage
 
 import com.databricks.labs.remorph.parsers.ParseException
+import com.databricks.labs.remorph.queries.ExampleQuery
 import com.databricks.labs.remorph.transpilers.{Formatter, SnowflakeToDatabricksTranspiler, TSqlToDatabricksTranspiler, TranspileException}
 import com.databricks.labs.remorph.utils.Strings
 

--- a/coverage/src/test/scala/com/databricks/labs/remorph/coverage/AcceptanceTestRunner.scala
+++ b/coverage/src/test/scala/com/databricks/labs/remorph/coverage/AcceptanceTestRunner.scala
@@ -1,13 +1,11 @@
 package com.databricks.labs.remorph.coverage
 
+import com.databricks.labs.remorph.queries.{AcceptanceTest, ExampleSource, DialectNameCommentBasedQueryExtractor, NestedFiles, QueryExtractor}
 import org.scalatest.flatspec.AnyFlatSpec
 
 import java.nio.file.Paths
 
-case class AcceptanceTestConfig(
-    testFileSource: AcceptanceTestSource,
-    queryExtractor: QueryExtractor,
-    queryRunner: QueryRunner)
+case class AcceptanceTestConfig(testFileSource: ExampleSource, queryExtractor: QueryExtractor, queryRunner: QueryRunner)
 
 abstract class AcceptanceTestRunner(config: AcceptanceTestConfig) extends AnyFlatSpec {
 

--- a/labs.yml
+++ b/labs.yml
@@ -58,3 +58,7 @@ commands:
     flags:
       - name: name
         description: Filename to debug
+      - name: dialect
+        description: sql dialect
+  - name: debug-me
+    description: "[INTERNAL] Debug SDK connectivity"

--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -25,6 +25,7 @@ def raise_validation_exception(msg: str) -> Exception:
 
 
 proxy_command(remorph, "debug-script")
+proxy_command(remorph, "debug-me")
 
 
 @remorph.command


### PR DESCRIPTION
This PR makes it possible to use `databricks labs remorph debug-script --name tests/resources/functional/snowflake/nested_query_with_json_1.sql --dialect snowflake` command and sets up basic Dependency Injection infrastructure via `ApplicationContext` trait.

<img width="1465" alt="image" src="https://github.com/user-attachments/assets/6e4df343-c305-4495-9a6f-bd3c5c71e314">
