### PR TITLE
Updated Spark setup script

### DIFF
--- a/.github/scripts/setup_spark_remote.sh
+++ b/.github/scripts/setup_spark_remote.sh
@@ -2,31 +2,36 @@
 
 set -xv
 
-mkdir -p $HOME/spark
-cd $HOME/spark
+mkdir -p "$HOME"/spark
+cd "$HOME"/spark || exit
 
 version=$(wget -O - https://dlcdn.apache.org/spark/ | grep 'href="spark' | grep -v 'preview' | sed 's:</a>:\n:g' | sed -n 's/.*>//p' | tr -d spark- | tr -d / | sort -r --version-sort | head -1)
 spark=spark-${version}-bin-hadoop3
-spark_connect=spark-connect_2.12
+spark_connect="spark-connect_2.12"
 
-mkdir ${spark}
-cd {spark}
+mkdir "${spark}"
+
 
 SERVER_SCRIPT=$HOME/spark/${spark}/sbin/start-connect-server.sh
 
 ## check the spark version already exist ,if not download the respective version
-if [ -f ${SERVER_SCRIPT} ];then
+if [ -f "${SERVER_SCRIPT}" ];then
   echo "Spark Version already exists"
 else
-  wget https://dlcdn.apache.org/spark/spark-${version}/${spark}.tgz
-  tar -xvf ${spark}.tgz
+  if [ -f "${spark}.tgz" ];then
+    echo "${spark}.tgz already exists"
+  else
+    wget "https://dlcdn.apache.org/spark/spark-${version}/${spark}.tgz"
+  fi
+  tar -xvf "${spark}.tgz"
 fi
 
+cd "${spark}" || exit
 ## check spark remote is running,if not start the spark remote
-${SERVER_SCRIPT} --packages org.apache.spark:${spark_connect}:${version} > $HOME/spark/log.out
+${SERVER_SCRIPT} --packages org.apache.spark:${spark_connect}:"${version}" > "$HOME"/spark/log.out
 
 if [ $? -ne 0 ]; then
-    count=$(tail ${HOME}/spark/log.out | grep "SparkConnectServer running as process" | wc -l)
+    count=$(tail "${HOME}"/spark/log.out | grep -c "SparkConnectServer running as process")
     if [ "${count}" == "0" ]; then
             echo "Failed to start the server"
         exit 1

--- a/.github/scripts/setup_spark_remote.sh
+++ b/.github/scripts/setup_spark_remote.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 
-set -xv
+set -xve
 
 mkdir -p "$HOME"/spark
-cd "$HOME"/spark || exit
+cd "$HOME"/spark || exit 1
 
 version=$(wget -O - https://dlcdn.apache.org/spark/ | grep 'href="spark' | grep -v 'preview' | sed 's:</a>:\n:g' | sed -n 's/.*>//p' | tr -d spark- | tr -d / | sort -r --version-sort | head -1)
+if [ -z "$version" ]; then
+  echo "Failed to extract Spark version"
+   exit 1
+fi
+
 spark=spark-${version}-bin-hadoop3
 spark_connect="spark-connect_2.12"
 
-mkdir "${spark}"
+mkdir -p "${spark}"
 
 
 SERVER_SCRIPT=$HOME/spark/${spark}/sbin/start-connect-server.sh
@@ -26,17 +31,18 @@ else
   tar -xvf "${spark}.tgz"
 fi
 
-cd "${spark}" || exit
+cd "${spark}" || exit 1
 ## check spark remote is running,if not start the spark remote
-${SERVER_SCRIPT} --packages org.apache.spark:${spark_connect}:"${version}" > "$HOME"/spark/log.out
+result=$(${SERVER_SCRIPT} --packages org.apache.spark:${spark_connect}:"${version}" > "$HOME"/spark/log.out; echo $?)
 
-if [ $? -ne 0 ]; then
+if [ "$result" -ne 0 ]; then
     count=$(tail "${HOME}"/spark/log.out | grep -c "SparkConnectServer running as process")
     if [ "${count}" == "0" ]; then
             echo "Failed to start the server"
         exit 1
     fi
     #sleep time to start the server
-    sleep 2m
+    sleep 120
     echo "Server Already Running"
 fi
+echo "Started the Server"


### PR DESCRIPTION
1. Updated Spark setup script to check whether `spark gzip file` exists

1. Refactored the script to remove the warnings: 
    * `Double quote to prevent globbing and word splitting`
    * `Use 'cd ... || exit' or 'cd ... || return' in case cd fails.`
    * `Consider using 'grep -c' instead of 'grep|wc -l'.`
    * `Usage: sleep seconds`, converted 2m to 120 seconds

1. Tested the following Scenarios:
    1. Scenario: Extracted Spark folder is already present
        Outcome: Directly starts the spark server using `sbin/start-connect-server.sh`
    1. Scenario: Extracted Spark folder **is not present**, and Zip file (`spark-<VERSION>.tgz`) is present
        Outcome:  Extract the zip file and start the spark server
    1. Scenario: Extracted Spark folder **is not present**, and Zip file **is not present**
        Outcome:  Download, Extract and start the spark server
