### PR TITLE
Unresolved Bang

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
@@ -941,6 +941,8 @@ SQLCOMMAND:
     ) ~[\r\n]*
 ;
 
+ANY_BANG: BANG ID ~[\r\n]*;
+
 STRING_START: '\'' -> pushMode(stringMode);
 
 // This lexer rule is needed so that any unknown character in the lexicon does not

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -152,7 +152,10 @@ otherCommand
     | let
     ;
 
-snowSqlCommand: SQLCOMMAND
+snowSqlCommand: SQLCOMMAND | unresolvedBangCommnad
+    ;
+
+unresolvedBangCommnad: ANY_BANG
     ;
 
 procStatement

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -152,10 +152,10 @@ otherCommand
     | let
     ;
 
-snowSqlCommand: SQLCOMMAND | unresolvedBangCommnad
+snowSqlCommand: SQLCOMMAND | unresolvedBangCommand
     ;
 
-unresolvedBangCommnad: ANY_BANG
+unresolvedBangCommand: ANY_BANG
     ;
 
 procStatement

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
@@ -38,6 +38,7 @@ class LogicalPlanGenerator(val expr: ExpressionGenerator, val explicitDistinct: 
     case a: ir.AlterTableCommand => alterTable(ctx, a)
     case l: ir.Lateral => lateral(ctx, l)
     case ir.NoopNode => ""
+    case ir.UnresolvedSnowSqlCommand(_) => ""
     //  TODO We should always generate an unresolved node, our plan should never be null
     case null => "" // don't fail transpilation if the plan is null
     case x => throw unknown(x)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/unresolved.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/unresolved.scala
@@ -46,3 +46,8 @@ case class UnresolvedCatalog(inputText: String) extends Catalog {
   override def output: Seq[Attribute] = Seq.empty
   override def children: Seq[LogicalPlan] = Seq.empty
 }
+
+case class UnresolvedSnowSqlCommand(inputText: String) extends LogicalPlan {
+  override def output: Seq[Attribute] = Seq.empty
+  override def children: Seq[LogicalPlan] = Seq.empty
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
@@ -64,7 +64,10 @@ class SnowflakeAstBuilder extends SnowflakeParserBaseVisitor[ir.LogicalPlan] wit
     case c => c.accept(dmlBuilder)
   }
 
-  override def visitSnowSqlCommand(ctx: SnowSqlCommandContext): ir.UnresolvedCommand = {
-    ir.UnresolvedCommand(ctx.getText)
+  override def visitSnowSqlCommand(ctx: SnowSqlCommandContext): ir.LogicalPlan = {
+    ctx match {
+      case c if ctx.SQLCOMMAND() != null => ir.UnresolvedCommand(c.getText)
+      case _ => ir.UnresolvedSnowSqlCommand(ctx.getText)
+    }
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
@@ -67,7 +67,7 @@ class SnowflakeAstBuilder extends SnowflakeParserBaseVisitor[ir.LogicalPlan] wit
   override def visitSnowSqlCommand(ctx: SnowSqlCommandContext): ir.LogicalPlan = {
     ctx match {
       case c if ctx.SQLCOMMAND() != null => ir.UnresolvedCommand(c.getText)
-      case i if ctx.unresolvedBangCommnad() != null => ir.UnresolvedSnowSqlCommand(i.getText)
+      case i if ctx.unresolvedBangCommand() != null => ir.UnresolvedSnowSqlCommand(i.getText)
     }
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
@@ -67,7 +67,7 @@ class SnowflakeAstBuilder extends SnowflakeParserBaseVisitor[ir.LogicalPlan] wit
   override def visitSnowSqlCommand(ctx: SnowSqlCommandContext): ir.LogicalPlan = {
     ctx match {
       case c if ctx.SQLCOMMAND() != null => ir.UnresolvedCommand(c.getText)
-      case _ => ir.UnresolvedSnowSqlCommand(ctx.getText)
+      case i if ctx.unresolvedBangCommnad() != null => ir.UnresolvedSnowSqlCommand(i.getText)
     }
   }
 }


### PR DESCRIPTION
This adds a lexer rule to catch any or all unresolved bang into a bucket `unresolvedSnowSqlCommand` if this is not implemented the grammar for `let` creates them as `unresolvedCommand` which is incorrect assumption.