### PR TITLE
Rephrase implementation using a monadic `Result`

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/Result.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/Result.scala
@@ -17,8 +17,4 @@ object Result {
 
     override def flatMap[B](f: Nothing => Result[B]): Result[B] = this
   }
-
-  implicit class ResultKleisli[A, B](f: A => Result[B]) {
-    def >>[C](other: B => Result[C]): A => Result[C] = a => f(a).flatMap(other)
-  }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/Result.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/Result.scala
@@ -1,1 +1,27 @@
 package com.databricks.labs.remorph.transpilers
+
+sealed trait Result[+A]{
+  def stage: WorkflowStage
+  def map[B](f: A => B): Result[B]
+  def flatMap[B](f: A => Result[B]): Result[B]
+}
+
+object Result {
+  case class Success[A](
+                         stage: WorkflowStage = WorkflowStage.PARSE,
+                         output: A) extends Result[A] {
+    override def map[B](f: A => B): Result[B] = Success(stage, f(output))
+
+    override def flatMap[B](f: A => Result[B]): Result[B] = f(output)
+  }
+
+  case class Failure(stage: WorkflowStage, errorJson: String) extends Result[Nothing] {
+    override def map[B](f: Nothing => B): Result[B] = this
+
+    override def flatMap[B](f: Nothing => Result[B]): Result[B] = this
+  }
+
+  implicit class ResultKleisli[A, B](f: A => Result[B]) {
+    def >>[C](other: B => Result[C]): A => Result[C] = a => f(a).flatMap(other)
+  }
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/Result.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/Result.scala
@@ -1,14 +1,13 @@
 package com.databricks.labs.remorph.transpilers
 
 sealed trait Result[+A] {
-  def stage: WorkflowStage
   def map[B](f: A => B): Result[B]
   def flatMap[B](f: A => Result[B]): Result[B]
 }
 
 object Result {
-  case class Success[A](stage: WorkflowStage = WorkflowStage.PARSE, output: A) extends Result[A] {
-    override def map[B](f: A => B): Result[B] = Success(stage, f(output))
+  case class Success[A](output: A) extends Result[A] {
+    override def map[B](f: A => B): Result[B] = Success(f(output))
 
     override def flatMap[B](f: A => Result[B]): Result[B] = f(output)
   }

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/Result.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/Result.scala
@@ -1,15 +1,13 @@
 package com.databricks.labs.remorph.transpilers
 
-sealed trait Result[+A]{
+sealed trait Result[+A] {
   def stage: WorkflowStage
   def map[B](f: A => B): Result[B]
   def flatMap[B](f: A => Result[B]): Result[B]
 }
 
 object Result {
-  case class Success[A](
-                         stage: WorkflowStage = WorkflowStage.PARSE,
-                         output: A) extends Result[A] {
+  case class Success[A](stage: WorkflowStage = WorkflowStage.PARSE, output: A) extends Result[A] {
     override def map[B](f: A => B): Result[B] = Success(stage, f(output))
 
     override def flatMap[B](f: A => Result[B]): Result[B] = f(output)

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspiler.scala
@@ -38,7 +38,7 @@ class SnowflakeToDatabricksTranspiler extends BaseTranspiler {
     if (errListener.errorCount > 0) {
       Result.Failure(stage = WorkflowStage.PARSE, errListener.errorsAsJson) // , tree = Some(tree))
     } else {
-      Result.Success(stage = WorkflowStage.PARSE, output = tree)
+      Result.Success(tree)
     }
   }
 
@@ -47,7 +47,7 @@ class SnowflakeToDatabricksTranspiler extends BaseTranspiler {
   override def visit(tree: ParserRuleContext): Result[ir.LogicalPlan] = {
     try {
       val plan = astBuilder.visit(tree)
-      Result.Success(stage = WorkflowStage.PLAN, plan)
+      Result.Success(plan)
     } catch {
       case e: Exception =>
         val sw = new StringWriter
@@ -62,7 +62,7 @@ class SnowflakeToDatabricksTranspiler extends BaseTranspiler {
   override def optimize(logicalPlan: ir.LogicalPlan): Result[ir.LogicalPlan] = {
     try {
       val plan = optimizer.apply(logicalPlan)
-      Result.Success(stage = WorkflowStage.OPTIMIZE, plan)
+      Result.Success(plan)
     } catch {
       case e: Exception =>
         val sw = new StringWriter
@@ -80,7 +80,7 @@ class SnowflakeToDatabricksTranspiler extends BaseTranspiler {
 
       // If the final result is without errors, we can return the output and discard the other generated
       // pieces.
-      Result.Success(stage = WorkflowStage.GENERATE, output)
+      Result.Success(output)
     } catch {
       case e: Exception =>
         val sw = new StringWriter

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspiler.scala
@@ -62,9 +62,7 @@ class SnowflakeToDatabricksTranspiler extends BaseTranspiler {
   override def optimize(logicalPlan: ir.LogicalPlan): Result[ir.LogicalPlan] = {
     try {
       val plan = optimizer.apply(logicalPlan)
-      Result.Success(
-        stage = WorkflowStage.OPTIMIZE,
-        plan)
+      Result.Success(stage = WorkflowStage.OPTIMIZE, plan)
     } catch {
       case e: Exception =>
         val sw = new StringWriter
@@ -90,9 +88,7 @@ class SnowflakeToDatabricksTranspiler extends BaseTranspiler {
         val stackTrace = sw.toString
         val errorJson = write(
           Map("exception" -> e.getClass.getSimpleName, "message" -> e.getMessage, "stackTrace" -> stackTrace))
-        Result.Failure(
-          stage = WorkflowStage.GENERATE,
-          errorJson)
+        Result.Failure(stage = WorkflowStage.GENERATE, errorJson)
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/Source.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/Source.scala
@@ -8,9 +8,6 @@ case class SourceCode(source: String, filename: String = "-- test source --")
 
 trait Source extends Iterator[SourceCode]
 
-
-
-
 class DirectorySource(root: String, fileFilter: Option[Path => Boolean] = None) extends Source {
   private val files =
     Files

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/TSqlToDatabricksTranspiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/TSqlToDatabricksTranspiler.scala
@@ -5,7 +5,7 @@ import com.databricks.labs.remorph.generators.sql.{ExpressionGenerator, LogicalP
 import com.databricks.labs.remorph.parsers.tsql.rules.{PullLimitUpwards, TSqlCallMapper, TopPercentToLimitSubquery, TrapInsertDefaultsAction}
 import com.databricks.labs.remorph.parsers.tsql.{TSqlAstBuilder, TSqlErrorStrategy, TSqlLexer, TSqlParser}
 import com.databricks.labs.remorph.parsers.{ProductionErrorCollector, intermediate => ir}
-import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
+import org.antlr.v4.runtime.{CharStreams, CommonTokenStream, ParserRuleContext}
 import org.json4s._
 import org.json4s.jackson.Serialization
 import org.json4s.jackson.Serialization.write
@@ -21,7 +21,7 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
     TrapInsertDefaultsAction)
   private val generator = new LogicalPlanGenerator(new ExpressionGenerator(new TSqlCallMapper()))
 
-  override def parse(input: SourceCode): Result = {
+  override def parse(input: SourceCode): Result[ParserRuleContext] = {
     val inputString = CharStreams.fromString(input.source)
     val lexer = new TSqlLexer(inputString)
     val tokenStream = new CommonTokenStream(lexer)
@@ -32,18 +32,18 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
     parser.addErrorListener(errListener)
     val tree = parser.tSqlFile()
     if (errListener.errorCount > 0) {
-      Result(stage = WorkflowStage.PARSE, errorsJson = errListener.errorsAsJson, tree = Some(tree))
+      Result.Failure(stage = WorkflowStage.PARSE, errListener.errorsAsJson)
     } else {
-      Result(stage = WorkflowStage.PARSE, tree = Some(tree))
+      Result.Success(stage = WorkflowStage.PARSE, tree)
     }
   }
 
   implicit val formats: Formats = Serialization.formats(NoTypeHints)
 
-  override def visit(tree: Result): Result = {
+  override def visit(tree: ParserRuleContext): Result[ir.LogicalPlan] = {
     try {
-      val plan = astBuilder.visit(tree.tree.get)
-      Result(stage = WorkflowStage.PLAN, plan = Some(plan), tree = tree.tree)
+      val plan = astBuilder.visit(tree)
+      Result.Success(stage = WorkflowStage.PLAN, plan )
     } catch {
       case e: Exception =>
         val sw = new StringWriter
@@ -51,18 +51,16 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
         val stackTrace = sw.toString
         val errorJson = write(
           Map("exception" -> e.getClass.getSimpleName, "message" -> e.getMessage, "stackTrace" -> stackTrace))
-        Result(stage = WorkflowStage.PLAN, errorsJson = errorJson, tree = tree.tree)
+        Result.Failure(stage = WorkflowStage.PLAN, errorJson )
     }
   }
 
-  override def optimize(logicalPlan: Result): Result = {
+  override def optimize(logicalPlan: ir.LogicalPlan): Result[ir.LogicalPlan] = {
     try {
-      val plan = optimizer.apply(logicalPlan.plan.get)
-      Result(
+      val plan = optimizer.apply(logicalPlan)
+      Result.Success(
         stage = WorkflowStage.OPTIMIZE,
-        plan = logicalPlan.plan,
-        optimizedPlan = Some(plan),
-        tree = logicalPlan.tree)
+        plan)
     } catch {
       case e: Exception =>
         val sw = new StringWriter
@@ -70,19 +68,17 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
         val stackTrace = sw.toString
         val errorJson = write(
           Map("exception" -> e.getClass.getSimpleName, "message" -> e.getMessage, "stackTrace" -> stackTrace))
-        Result(stage = WorkflowStage.OPTIMIZE, errorsJson = errorJson, plan = logicalPlan.plan, tree = logicalPlan.tree)
+        Result.Failure(stage = WorkflowStage.OPTIMIZE, errorJson)
     }
   }
 
-  override def generate(optimizedLogicalPlan: Result): Result = {
+  override def generate(optimizedLogicalPlan: ir.LogicalPlan): Result[String] = {
     try {
-      val output = generator.generate(GeneratorContext(generator), optimizedLogicalPlan.optimizedPlan.get)
+      val output = generator.generate(GeneratorContext(generator), optimizedLogicalPlan)
 
       // If the final result is without errors, we can return the output and discard the other generated
       // pieces.
-      Result(
-        stage = WorkflowStage.GENERATE,
-        output = Some(output))
+      Result.Success(stage = WorkflowStage.GENERATE, output )
     } catch {
       case e: Exception =>
         val sw = new StringWriter
@@ -90,11 +86,9 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
         val stackTrace = sw.toString
         val errorJson = write(
           Map("exception" -> e.getClass.getSimpleName, "message" -> e.getMessage, "stackTrace" -> stackTrace))
-        Result(
+        Result.Failure(
           stage = WorkflowStage.GENERATE,
-          errorsJson = errorJson,
-          plan = optimizedLogicalPlan.plan,
-          tree = optimizedLogicalPlan.tree)
+           errorJson)
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/TSqlToDatabricksTranspiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/TSqlToDatabricksTranspiler.scala
@@ -34,7 +34,7 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
     if (errListener.errorCount > 0) {
       Result.Failure(stage = WorkflowStage.PARSE, errListener.errorsAsJson)
     } else {
-      Result.Success(stage = WorkflowStage.PARSE, tree)
+      Result.Success(tree)
     }
   }
 
@@ -43,7 +43,7 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
   override def visit(tree: ParserRuleContext): Result[ir.LogicalPlan] = {
     try {
       val plan = astBuilder.visit(tree)
-      Result.Success(stage = WorkflowStage.PLAN, plan)
+      Result.Success(plan)
     } catch {
       case e: Exception =>
         val sw = new StringWriter
@@ -58,7 +58,7 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
   override def optimize(logicalPlan: ir.LogicalPlan): Result[ir.LogicalPlan] = {
     try {
       val plan = optimizer.apply(logicalPlan)
-      Result.Success(stage = WorkflowStage.OPTIMIZE, plan)
+      Result.Success(plan)
     } catch {
       case e: Exception =>
         val sw = new StringWriter
@@ -76,7 +76,7 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
 
       // If the final result is without errors, we can return the output and discard the other generated
       // pieces.
-      Result.Success(stage = WorkflowStage.GENERATE, output)
+      Result.Success(output)
     } catch {
       case e: Exception =>
         val sw = new StringWriter

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/TSqlToDatabricksTranspiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/TSqlToDatabricksTranspiler.scala
@@ -43,7 +43,7 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
   override def visit(tree: ParserRuleContext): Result[ir.LogicalPlan] = {
     try {
       val plan = astBuilder.visit(tree)
-      Result.Success(stage = WorkflowStage.PLAN, plan )
+      Result.Success(stage = WorkflowStage.PLAN, plan)
     } catch {
       case e: Exception =>
         val sw = new StringWriter
@@ -51,16 +51,14 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
         val stackTrace = sw.toString
         val errorJson = write(
           Map("exception" -> e.getClass.getSimpleName, "message" -> e.getMessage, "stackTrace" -> stackTrace))
-        Result.Failure(stage = WorkflowStage.PLAN, errorJson )
+        Result.Failure(stage = WorkflowStage.PLAN, errorJson)
     }
   }
 
   override def optimize(logicalPlan: ir.LogicalPlan): Result[ir.LogicalPlan] = {
     try {
       val plan = optimizer.apply(logicalPlan)
-      Result.Success(
-        stage = WorkflowStage.OPTIMIZE,
-        plan)
+      Result.Success(stage = WorkflowStage.OPTIMIZE, plan)
     } catch {
       case e: Exception =>
         val sw = new StringWriter
@@ -78,7 +76,7 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
 
       // If the final result is without errors, we can return the output and discard the other generated
       // pieces.
-      Result.Success(stage = WorkflowStage.GENERATE, output )
+      Result.Success(stage = WorkflowStage.GENERATE, output)
     } catch {
       case e: Exception =>
         val sw = new StringWriter
@@ -86,9 +84,7 @@ class TSqlToDatabricksTranspiler extends BaseTranspiler {
         val stackTrace = sw.toString
         val errorJson = write(
           Map("exception" -> e.getClass.getSimpleName, "message" -> e.getMessage, "stackTrace" -> stackTrace))
-        Result.Failure(
-          stage = WorkflowStage.GENERATE,
-           errorJson)
+        Result.Failure(stage = WorkflowStage.GENERATE, errorJson)
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/Transpiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/Transpiler.scala
@@ -16,19 +16,12 @@ object WorkflowStage {
   case object GENERATE extends WorkflowStage
 }
 
-case class Result(
-    stage: WorkflowStage = WorkflowStage.PARSE,
-    errorsJson: String = "",
-    tree: Option[ParserRuleContext] = None,
-    plan: Option[ir.LogicalPlan] = None,
-    optimizedPlan: Option[ir.LogicalPlan] = None,
-    output: Option[String] = None) {
 
-  def inError(): Boolean = errorsJson.nonEmpty
-}
+
+
 
 trait Transpiler {
-  def transpile(input: SourceCode): Result
+  def transpile(input: SourceCode): Result[String]
 }
 
 class Sed(rules: (String, String)*) {
@@ -65,45 +58,15 @@ trait Formatter {
 
 abstract class BaseTranspiler extends Transpiler with Formatter {
 
-  protected def parse(input: SourceCode): Result
-  protected def toParseTree(input: SourceCode): Result = {
-    val parsed = parse(input)
-    if (parsed.inError()) parsed
-    else Result(stage = WorkflowStage.PARSE, tree = parsed.tree)
-  }
-  protected def visit(tree: Result): Result
-  protected def toPlan(input: SourceCode): Result = {
-    val parsed = parse(input)
-    val visited = processStage(parsed, r => visit(parsed))
-    if (visited.inError()) visited
-    else Result(stage = WorkflowStage.PLAN, plan = visited.plan, tree = visited.tree)
-  }
+  protected def parse(input: SourceCode): Result[ParserRuleContext]
 
-  protected def optimize(logicalPlan: Result): Result
+  protected def visit(tree: ParserRuleContext): Result[ir.LogicalPlan]
 
-  protected def toOptimizedPlan(input: SourceCode): Result = {
-    val parsed = parse(input)
-    val visited = processStage(parsed, r => visit(parsed))
-    val optimized = processStage(visited, r => optimize(visited))
-    if (optimized.inError()) optimized
-    else Result(stage = WorkflowStage.OPTIMIZE, optimizedPlan = optimized.optimizedPlan)
-  }
+  protected def optimize(logicalPlan: ir.LogicalPlan): Result[ir.LogicalPlan]
 
-  protected def generate(optimizedLogicalPlan: Result): Result
+  protected def generate(optimizedLogicalPlan: ir.LogicalPlan): Result[String]
 
-  def processStage(currentResult: Result, nextStage: Result => Result): Result = {
-    if (currentResult.inError()) currentResult
-    else nextStage(currentResult)
-  }
-
-  override def transpile(input: SourceCode): Result = {
-
-    val parsed = parse(input)
-    val visited = processStage(parsed, r => visit(parsed))
-    val optimized = processStage(visited, r => optimize(visited))
-    val generated = processStage(optimized, r => generate(optimized))
-
-    if (generated.inError()) generated
-    else Result(stage = WorkflowStage.GENERATE, output = Some(format(generated.output.get)))
+  override def transpile(input: SourceCode): Result[String] = {
+    (parse _ >> visit >> optimize >> generate)(input)
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/Transpiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/Transpiler.scala
@@ -63,6 +63,6 @@ abstract class BaseTranspiler extends Transpiler with Formatter {
   protected def generate(optimizedLogicalPlan: ir.LogicalPlan): Result[String]
 
   override def transpile(input: SourceCode): Result[String] = {
-    (parse _ >> visit >> optimize >> generate)(input)
+    parse(input).flatMap(visit).flatMap(optimize).flatMap(generate)
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/Transpiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/Transpiler.scala
@@ -16,10 +16,6 @@ object WorkflowStage {
   case object GENERATE extends WorkflowStage
 }
 
-
-
-
-
 trait Transpiler {
   def transpile(input: SourceCode): Result[String]
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
@@ -18,10 +18,10 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
       "!options catch=true" transpilesTo "-- !options catch=true;"
     }
     "transpile BANG with negative scenario unknown command" in {
-      "!test unknown command" transpilesTo ""
+      "!test unknown command".failsTranspilation
     }
     "transpile BANG with negative scenario unknown command2" in {
-      "!abc set=abc" transpilesTo ""
+      "!abc set=abc".failsTranspilation
     }
   }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/TranspilerTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/TranspilerTestCommon.scala
@@ -10,7 +10,7 @@ trait TranspilerTestCommon extends Matchers with Formatter {
   implicit class TranspilerTestOps(input: String) {
     def transpilesTo(expectedOutput: String): Assertion = {
       transpiler.transpile(SourceCode(input)) match {
-        case Result.Success(_, output) => format(output) shouldBe format(expectedOutput)
+        case Result.Success(output) => format(output) shouldBe format(expectedOutput)
         case Result.Failure(_, err) => fail(err)
       }
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/TranspilerTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/TranspilerTestCommon.scala
@@ -3,13 +3,22 @@ package com.databricks.labs.remorph.transpilers
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 
-trait TranspilerTestCommon extends Matchers {
+trait TranspilerTestCommon extends Matchers with Formatter {
 
   protected def transpiler: Transpiler
 
   implicit class TranspilerTestOps(input: String) {
     def transpilesTo(expectedOutput: String): Assertion = {
-      transpiler.transpile(SourceCode(input)).output.getOrElse("").toLowerCase() shouldBe expectedOutput.toLowerCase()
+      transpiler.transpile(SourceCode(input)) match {
+        case Result.Success(_, output) => format(output) shouldBe format(expectedOutput)
+        case Result.Failure(_, err) => fail(err)
+      }
+    }
+    def failsTranspilation: Assertion = {
+      transpiler.transpile(SourceCode(input)) match {
+        case Result.Failure(_, _) => succeed
+        case _ => fail("query was expected to fail transpilation but didn't")
+      }
     }
   }
 }

--- a/coverage/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
+++ b/coverage/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
@@ -22,7 +22,7 @@ abstract class BaseQueryRunner(transpiler: Transpiler) extends QueryRunner {
     transpiler.transpile(SourceCode(exampleQuery.query)) match {
       case Result.Failure(PARSE, errorJson) => ReportEntryReport(statements = 1, parsing_error = Some(errorJson))
       case Result.Failure(_, errorJson) => ReportEntryReport(statements = 1, transpilation_error = Some(errorJson))
-      case Result.Success(_, output) =>
+      case Result.Success(output) =>
         if (exampleQuery.expectedTranslation.map(format).exists(_ != format(output))) {
           val expected = exampleQuery.expectedTranslation.getOrElse("")
           ReportEntryReport(

--- a/coverage/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
+++ b/coverage/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
@@ -2,7 +2,7 @@ package com.databricks.labs.remorph.coverage
 
 import com.databricks.labs.remorph.queries.ExampleQuery
 import com.databricks.labs.remorph.transpilers.WorkflowStage.PARSE
-import com.databricks.labs.remorph.transpilers.{Formatter, SnowflakeToDatabricksTranspiler, SourceCode, TSqlToDatabricksTranspiler}
+import com.databricks.labs.remorph.transpilers.{Formatter, Result, SnowflakeToDatabricksTranspiler, SourceCode, TSqlToDatabricksTranspiler, Transpiler}
 import com.databricks.labs.remorph.utils.Strings
 
 trait QueryRunner extends Formatter {
@@ -16,49 +16,27 @@ trait QueryRunner extends Formatter {
   }
 }
 
-class IsTranspiledFromSnowflakeQueryRunner extends QueryRunner {
-  private val snowflakeTranspiler = new SnowflakeToDatabricksTranspiler
+abstract class BaseQueryRunner(transpiler: Transpiler) extends QueryRunner {
 
   override def runQuery(exampleQuery: ExampleQuery): ReportEntryReport = {
-    val transpiled = snowflakeTranspiler.transpile(SourceCode(exampleQuery.query))
-    if (transpiled.inError()) {
-      if (transpiled.stage == PARSE) {
-        ReportEntryReport(statements = 1, parsing_error = Some(transpiled.errorsJson))
-      } else {
-        ReportEntryReport(statements = 1, transpilation_error = Some(transpiled.errorsJson))
-      }
-    } else if (exampleQuery.expectedTranslation.map(format).exists(_ != transpiled.output.getOrElse(""))) {
-      val expected = exampleQuery.expectedTranslation.getOrElse("")
-      ReportEntryReport(
-        parsed = 1,
-        transpiled = 1,
-        statements = 1,
-        transpilation_error = Some(compareQueries(expected, transpiled.output.getOrElse(""))))
-    } else {
-      ReportEntryReport(parsed = 1, transpiled = 1, statements = 1)
+    transpiler.transpile(SourceCode(exampleQuery.query)) match {
+      case Result.Failure(PARSE, errorJson) => ReportEntryReport(statements = 1, parsing_error = Some(errorJson))
+      case Result.Failure(_, errorJson) => ReportEntryReport(statements = 1, transpilation_error = Some(errorJson))
+      case Result.Success(_, output) =>
+        if (exampleQuery.expectedTranslation.map(format).exists(_ != format(output))) {
+          val expected = exampleQuery.expectedTranslation.getOrElse("")
+          ReportEntryReport(
+            parsed = 1,
+            transpiled = 1,
+            statements = 1,
+            transpilation_error = Some(compareQueries(expected, output)))
+        } else {
+          ReportEntryReport(parsed = 1, transpiled = 1, statements = 1)
+        }
     }
   }
 }
 
-class IsTranspiledFromTSqlQueryRunner extends QueryRunner {
-  private val tsqlTranspiler = new TSqlToDatabricksTranspiler
-  override def runQuery(exampleQuery: ExampleQuery): ReportEntryReport = {
-    val transpiled = tsqlTranspiler.transpile(SourceCode(exampleQuery.query))
-    if (transpiled.inError()) {
-      if (transpiled.stage == PARSE) {
-        ReportEntryReport(statements = 1, parsing_error = Some(transpiled.errorsJson))
-      } else {
-        ReportEntryReport(statements = 1, transpilation_error = Some(transpiled.errorsJson))
-      }
-    } else if (exampleQuery.expectedTranslation.map(format).exists(_ != transpiled.output.getOrElse(""))) {
-      val expected = exampleQuery.expectedTranslation.getOrElse("")
-      ReportEntryReport(
-        parsed = 1,
-        transpiled = 1,
-        statements = 1,
-        transpilation_error = Some(compareQueries(expected, transpiled.output.getOrElse(""))))
-    } else {
-      ReportEntryReport(parsed = 1, transpiled = 1, statements = 1)
-    }
-  }
-}
+class IsTranspiledFromSnowflakeQueryRunner extends BaseQueryRunner(new SnowflakeToDatabricksTranspiler)
+
+class IsTranspiledFromTSqlQueryRunner extends BaseQueryRunner(new TSqlToDatabricksTranspiler)


### PR DESCRIPTION
Incidentally, this helped fixing a bug where tests `transpile BANG with negative scenario unknown command` and `transpile BANG with negative scenario unknown command2` were mistakenly expected to return an empty string. 

The changes introduced by the original PR should have detected that as wrong (these tests should actually raise an error), but failed to do so because of a combination of `Option` fields in `Result` and `.getOrElse("")` calls here and there. 