### PR TITLE
TSQL: Reorg of DML IR and generation production after CREATE TABLE

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -2735,7 +2735,7 @@ expression
     | expression withinGroup                                  # exprWithinGroup
     | DOLLAR_ACTION                                           # exprDollar
     | <assoc = right> expression DOT expression               # exprDot
-    | LPAREN subquery RPAREN                                  # exprSubquery
+    | LPAREN selectStatement RPAREN                           # exprSubquery
     | ALL expression                                          # exprAll
     | DISTINCT expression                                     # exprDistinct
     | DOLLAR_ACTION                                           # exprDollar
@@ -2755,9 +2755,6 @@ primitiveExpression: op = (DEFAULT | NULL | LOCAL_ID) | constant
     ;
 
 caseExpression: CASE caseExpr = expression? switchSection+ ( ELSE elseExpr = expression)? END
-    ;
-
-subquery: selectStatement
     ;
 
 withExpression: WITH xmlNamespaces? commonTableExpression ( COMMA commonTableExpression)*
@@ -2790,12 +2787,12 @@ searchCondition
     ;
 
 predicate
-    : EXISTS LPAREN subquery RPAREN
+    : EXISTS LPAREN selectStatement RPAREN
     | freetextPredicate
     | expression comparisonOperator expression
-    | expression comparisonOperator (ALL | SOME | ANY) LPAREN subquery RPAREN
+    | expression comparisonOperator (ALL | SOME | ANY) LPAREN selectStatement RPAREN
     | expression NOT* BETWEEN expression AND expression
-    | expression NOT* IN LPAREN (subquery | expressionList) RPAREN
+    | expression NOT* IN LPAREN (selectStatement | expressionList) RPAREN
     | expression NOT* LIKE expression (ESCAPE expression)?
     | expression IS nullNotnull
     | expression
@@ -2982,7 +2979,7 @@ rowsetFunction
     | (OPENROWSET LPAREN BULK STRING COMMA ( id EQ STRING COMMA optionList? | id) RPAREN)
     ;
 
-derivedTable: subquery | tableValueConstructor | LPAREN tableValueConstructor RPAREN
+derivedTable: selectStatement | tableValueConstructor | LPAREN tableValueConstructor RPAREN
     ;
 
 functionCall
@@ -3052,7 +3049,7 @@ hierarchyidStaticMethod
     ;
 
 nodesMethod
-    : (locId = LOCAL_ID | valueId = fullColumnName | LPAREN subquery RPAREN) DOT NODES LPAREN xquery = STRING RPAREN
+    : (locId = LOCAL_ID | valueId = fullColumnName | LPAREN selectStatement RPAREN) DOT NODES LPAREN xquery = STRING RPAREN
     ;
 
 switchSection: WHEN searchCondition THEN expression

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/PlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/PlanParser.scala
@@ -17,6 +17,7 @@ trait PlanParser[P <: Parser] {
   protected def createParser(stream: TokenStream): P
   protected def createTree(parser: P): ParserRuleContext
   protected def createPlan(tree: ParserRuleContext): ir.LogicalPlan
+  protected def addErrorStrategy(parser: P): Unit
 
   // TODO: This is probably not where the optimizer should be as this is a Plan "Parser" - it is here for now
   protected def createOptimizer: ir.Rules[ir.LogicalPlan]
@@ -30,6 +31,7 @@ trait PlanParser[P <: Parser] {
     val inputString = CharStreams.fromString(input.source)
     val tokenStream = new CommonTokenStream(createLexer(inputString))
     val parser = createParser(tokenStream)
+    addErrorStrategy(parser)
     val errListener = new ProductionErrorCollector(input.source, input.filename)
     parser.removeErrorListeners()
     parser.addErrorListener(errListener)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/VisitorCoordinator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/VisitorCoordinator.scala
@@ -1,0 +1,30 @@
+package com.databricks.labs.remorph.parsers
+import com.databricks.labs.remorph.parsers.tsql.DataTypeBuilder
+import org.antlr.v4.runtime.tree.ParseTreeVisitor
+
+/**
+ * <p>
+ *   An implementation of this class should provide an instance of each of the ParseTreeVisitors
+ *   required to build IR and each visitor should be initialized with a reference to the implementation
+ *   of this class so that the visitors can call each other without needing to know the specific implementation
+ *   of any visitor or creating circular dependencies between them.
+ * </p>
+ * <p>
+ *   Implementations can also supply other shared resources, builders, etc. via the same mechanism
+ * </p>
+ */
+abstract class VisitorCoordinator {
+
+  // Parse tree visitors
+  val astBuilder: ParseTreeVisitor[_]
+  val relationBuilder: ParseTreeVisitor[_]
+  val expressionBuilder: ParseTreeVisitor[_]
+  val dmlBuilder: ParseTreeVisitor[_]
+  val ddlBuilder: ParseTreeVisitor[_]
+
+  // A function builder that can be used to build function calls for a particular dialect
+  val functionBuilder: FunctionBuilder
+
+  // Common builders that are used across all parsers, but can still be overridden
+  val dataTypeBuilder = new DataTypeBuilder
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/unresolved.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/unresolved.scala
@@ -51,3 +51,8 @@ case class UnresolvedCTAS(inputText: String) extends Catalog with Command {
   override def output: Seq[Attribute] = Seq.empty
   override def children: Seq[LogicalPlan] = Seq.empty
 }
+
+case class UnresolvedModification(inputText: String) extends Modification {
+  override def output: Seq[Attribute] = Seq.empty
+  override def children: Seq[LogicalPlan] = Seq.empty
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakePlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakePlanParser.scala
@@ -17,6 +17,8 @@ class SnowflakePlanParser extends PlanParser[SnowflakeParser] {
   override protected def createParser(stream: TokenStream): SnowflakeParser = new SnowflakeParser(stream)
   override protected def createTree(parser: SnowflakeParser): ParserRuleContext = parser.snowflakeFile()
   override protected def createPlan(tree: ParserRuleContext): LogicalPlan = astBuilder.visit(tree)
+  override protected def addErrorStrategy(parser: SnowflakeParser): Unit =
+    parser.setErrorHandler(new SnowflakeErrorStrategy)
 
   // TODO: Note that this is not the correct place for the optimizer, but it is here for now
   override protected def createOptimizer: ir.Rules[ir.LogicalPlan] = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/OptionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/OptionBuilder.scala
@@ -3,7 +3,7 @@ package com.databricks.labs.remorph.parsers.tsql
 import com.databricks.labs.remorph.parsers.tsql.TSqlParser.GenericOptionContext
 import com.databricks.labs.remorph.parsers.{intermediate => ir}
 
-class OptionBuilder(expressionBuilder: TSqlExpressionBuilder) {
+class OptionBuilder(vc: TSqlVisitorCoordinator) {
 
   private[tsql] def buildOptionList(opts: Seq[GenericOptionContext]): ir.OptionLists = {
     val options = opts.map(this.buildOption)
@@ -35,10 +35,10 @@ class OptionBuilder(expressionBuilder: TSqlExpressionBuilder) {
       // FOR cannot be allowed as an id as it clashes with the FOR clause in SELECT et al. So
       // we special case it here and elide the FOR. It handles just a few things such as OPTIMIZE FOR UNKNOWN,
       // which becomes "OPTIMIZE", Id(UNKNOWN)
-      case c if c.FOR() != null => ir.OptionExpression(id, expressionBuilder.visitId(c.id(1)), None)
+      case c if c.FOR() != null => ir.OptionExpression(id, vc.expressionBuilder.visitId(c.id(1)), None)
       case c if c.expression() != null =>
         val supplement = if (c.id(1) != null) Some(ctx.id(1).getText) else None
-        ir.OptionExpression(id, c.expression().accept(expressionBuilder), supplement)
+        ir.OptionExpression(id, c.expression().accept(vc.expressionBuilder), supplement)
       case _ if id == "DEFAULT" => ir.OptionDefault(id)
       case _ if id == "ON" => ir.OptionOn(id)
       case _ if id == "OFF" => ir.OptionOff(id)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilder.scala
@@ -1,7 +1,5 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.intermediate.LogicalPlan
-import com.databricks.labs.remorph.parsers.tsql.TSqlParser.DmlClauseContext
 import com.databricks.labs.remorph.parsers.{intermediate => ir}
 
 import scala.collection.JavaConverters.asScalaBufferConverter

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilder.scala
@@ -1,5 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql
 
+import com.databricks.labs.remorph.parsers.intermediate.LogicalPlan
 import com.databricks.labs.remorph.parsers.tsql.TSqlParser.DmlClauseContext
 import com.databricks.labs.remorph.parsers.{intermediate => ir}
 
@@ -11,8 +12,10 @@ import scala.collection.JavaConverters.asScalaBufferConverter
  */
 class TSqlAstBuilder extends TSqlParserBaseVisitor[ir.LogicalPlan] {
 
-  private val relationBuilder = new TSqlRelationBuilder
-  private val expressionBuilder = new TSqlExpressionBuilder
+  private val expressionBuilder = new TSqlExpressionBuilder(null)
+  private val relationBuilder = new TSqlRelationBuilder(expressionBuilder)
+  expressionBuilder.relationBuilder = relationBuilder
+  private val dmlBuilder = new TSqlDMLBuilder(expressionBuilder, relationBuilder)
   private val optionBuilder = new OptionBuilder(expressionBuilder)
   private val ddlBuilder = new TSqlDDLBuilder(optionBuilder, expressionBuilder, relationBuilder)
 
@@ -41,7 +44,7 @@ class TSqlAstBuilder extends TSqlParserBaseVisitor[ir.LogicalPlan] {
       case another if another.anotherStatement() != null => another.anotherStatement().accept(this)
       case ddl if ddl.ddlClause() != null => ddl.ddlClause().accept(ddlBuilder)
       case dbcc if dbcc.dbccClause() != null => dbcc.dbccClause().accept(this)
-      case backup if backup.backupStatement() != null => backup.backupStatement().accept(this)
+      case backup if backup.backupStatement() != null => backup.backupStatement().accept(ddlBuilder)
       case coaFunction if coaFunction.createOrAlterFunction() != null =>
         coaFunction.createOrAlterFunction().accept(this)
       case coaProcedure if coaProcedure.createOrAlterProcedure() != null =>
@@ -53,54 +56,19 @@ class TSqlAstBuilder extends TSqlParserBaseVisitor[ir.LogicalPlan] {
     }
   }
 
-  override def visitDmlClause(ctx: DmlClauseContext): ir.LogicalPlan = {
-    val query = ctx match {
-      case insert if insert.insert() != null => insert.insert().accept(relationBuilder)
-      case select if select.selectStatement() != null =>
-        select.selectStatement.accept(relationBuilder)
-      case delete if delete.delete() != null => delete.delete().accept(relationBuilder)
-      case merge if merge.merge() != null => merge.merge().accept(relationBuilder)
-      case update if update.update() != null => update.update().accept(relationBuilder)
-      case bulk if bulk.bulkStatement() != null => bulk.bulkStatement().accept(relationBuilder)
-      case _ => ir.UnresolvedRelation(ctx.getText)
+  override def visitDmlClause(ctx: TSqlParser.DmlClauseContext): ir.LogicalPlan = {
+    val dml = ctx match {
+      case dml if dml.selectStatement() != null =>
+        dml.selectStatement().accept(relationBuilder)
+      case _ =>
+        ctx.accept(dmlBuilder)
     }
+
     Option(ctx.withExpression())
       .map { withExpression =>
         val ctes = withExpression.commonTableExpression().asScala.map(_.accept(relationBuilder))
-        ir.WithCTE(ctes, query)
+        ir.WithCTE(ctes, dml)
       }
-      .getOrElse(query)
-  }
-
-  /**
-   * This is not actually implemented but was a quick way to exercise the genericOption builder before we had other
-   * syntax implemented to test it with.
-   *
-   * @param ctx
-   *   the parse tree
-   */
-  override def visitBackupStatement(ctx: TSqlParser.BackupStatementContext): ir.LogicalPlan = {
-    ctx.backupDatabase().accept(this)
-  }
-
-  override def visitBackupDatabase(ctx: TSqlParser.BackupDatabaseContext): ir.LogicalPlan = {
-    val database = ctx.id().getText
-    val opts = ctx.optionList()
-    val options = opts.asScala.flatMap(_.genericOption().asScala).toList.map(optionBuilder.buildOption)
-    val (disks, boolFlags, autoFlags, values) = options.foldLeft(
-      (List.empty[String], Map.empty[String, Boolean], List.empty[String], Map.empty[String, ir.Expression])) {
-      case ((disks, boolFlags, autoFlags, values), option) =>
-        option match {
-          case ir.OptionString("DISK", value) =>
-            (value.stripPrefix("'").stripSuffix("'") :: disks, boolFlags, autoFlags, values)
-          case ir.OptionOn(id) => (disks, boolFlags + (id -> true), autoFlags, values)
-          case ir.OptionOff(id) => (disks, boolFlags + (id -> false), autoFlags, values)
-          case ir.OptionAuto(id) => (disks, boolFlags, id :: autoFlags, values)
-          case ir.OptionExpression(id, expr, _) => (disks, boolFlags, autoFlags, values + (id -> expr))
-          case _ => (disks, boolFlags, autoFlags, values)
-        }
-    }
-    // Default flags generally don't need to be specified as they are by definition, the default
-    BackupDatabase(database, disks, boolFlags, autoFlags, values)
+      .getOrElse(dml)
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
@@ -1,0 +1,192 @@
+package com.databricks.labs.remorph.parsers.tsql
+
+import com.databricks.labs.remorph.parsers.tsql.TSqlParser._
+import com.databricks.labs.remorph.parsers.tsql.rules.InsertDefaultsAction
+import com.databricks.labs.remorph.parsers.{intermediate => ir}
+
+import scala.collection.JavaConverters.asScalaBufferConverter
+class TSqlDMLBuilder(expressionBuilder: TSqlExpressionBuilder, relationBuilder: TSqlRelationBuilder)
+    extends TSqlParserBaseVisitor[ir.Modification] {
+
+  override def visitDmlClause(ctx: DmlClauseContext): ir.Modification =
+    ctx match {
+      // NB: select is handled by the relationBuilder
+      case dml if dml.insert() != null => dml.insert.accept(this)
+      case dml if dml.delete() != null => dml.delete().accept(this)
+      case dml if dml.merge() != null => dml.merge().accept(this)
+      case dml if dml.update() != null => dml.update().accept(this)
+      case bulk if bulk.bulkStatement() != null => bulk.bulkStatement().accept(this)
+      case _ => ir.UnresolvedModification(ctx.getText)
+    }
+
+  override def visitMerge(ctx: MergeContext): ir.Modification = {
+    val targetPlan = ctx.ddlObject().accept(relationBuilder)
+    val hints = relationBuilder.buildTableHints(Option(ctx.withTableHints()))
+    val finalTarget = if (hints.nonEmpty) {
+      ir.TableWithHints(targetPlan, hints)
+    } else {
+      targetPlan
+    }
+
+    val mergeCondition = ctx.searchCondition().accept(expressionBuilder)
+    val tableSourcesPlan = ctx.tableSources().tableSource().asScala.map(_.accept(relationBuilder))
+    val sourcePlan = tableSourcesPlan.tail.foldLeft(tableSourcesPlan.head)(
+      ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
+
+    // We may have a number of when clauses, each with a condition and an action. We keep the ANTLR syntax compact
+    // and lean and determine which of the three types of action we have in the whenMatch method based on
+    // the presence or absence of syntactical elements NOT and SOURCE as SOURCE can only be used with NOT
+    val (matchedActions, notMatchedActions, notMatchedBySourceActions) = Option(ctx.whenMatch())
+      .map(_.asScala.foldLeft((List.empty[ir.MergeAction], List.empty[ir.MergeAction], List.empty[ir.MergeAction])) {
+        case ((matched, notMatched, notMatchedBySource), m) =>
+          val action = buildWhenMatch(m)
+          (m.NOT(), m.SOURCE()) match {
+            case (null, _) => (action :: matched, notMatched, notMatchedBySource)
+            case (_, null) => (matched, action :: notMatched, notMatchedBySource)
+            case _ => (matched, notMatched, action :: notMatchedBySource)
+          }
+      })
+      .getOrElse((List.empty, List.empty, List.empty))
+
+    val optionClause = Option(ctx.optionClause).map(_.accept(expressionBuilder))
+    val outputClause = Option(ctx.outputClause()).map(buildOutputClause)
+
+    val mergeIntoTable = ir.MergeIntoTable(
+      finalTarget,
+      sourcePlan,
+      mergeCondition,
+      matchedActions,
+      notMatchedActions,
+      notMatchedBySourceActions)
+
+    val withOptions = optionClause match {
+      case Some(option) => ir.WithModificationOptions(mergeIntoTable, option)
+      case None => mergeIntoTable
+    }
+
+    outputClause match {
+      case Some(output) => WithOutputClause(withOptions, output)
+      case None => withOptions
+    }
+  }
+
+  private def buildWhenMatch(ctx: WhenMatchContext): ir.MergeAction = {
+    val condition = Option(ctx.searchCondition()).map(_.accept(expressionBuilder))
+    ctx.mergeAction() match {
+      case action if action.DELETE() != null => ir.DeleteAction(condition)
+      case action if action.UPDATE() != null => buildUpdateAction(action, condition)
+      case action if action.INSERT() != null => buildInsertAction(action, condition)
+    }
+  }
+
+  private def buildInsertAction(ctx: MergeActionContext, condition: Option[ir.Expression]): ir.MergeAction = {
+
+    ctx match {
+      case action if action.DEFAULT() != null => InsertDefaultsAction(condition)
+      case _ =>
+        val assignments =
+          (ctx.cols
+            .expression()
+            .asScala
+            .map(_.accept(expressionBuilder)) zip ctx.vals.expression().asScala.map(_.accept(expressionBuilder)))
+            .map { case (col, value) =>
+              ir.Assign(col, value)
+            }
+        ir.InsertAction(condition, assignments)
+    }
+  }
+
+  private def buildUpdateAction(ctx: MergeActionContext, condition: Option[ir.Expression]): ir.UpdateAction = {
+    val setElements = ctx.updateElem().asScala.collect { case elem =>
+      elem.accept(expressionBuilder) match {
+        case assign: ir.Assign => assign
+      }
+    }
+    ir.UpdateAction(condition, setElements)
+  }
+
+  override def visitUpdate(ctx: UpdateContext): ir.Modification = {
+    val target = ctx.ddlObject().accept(relationBuilder)
+    val hints = relationBuilder.buildTableHints(Option(ctx.withTableHints()))
+    val hintTarget = if (hints.nonEmpty) {
+      ir.TableWithHints(target, hints)
+    } else {
+      target
+    }
+
+    val finalTarget = relationBuilder.buildTop(Option(ctx.topClause()), hintTarget)
+    val output = Option(ctx.outputClause()).map(buildOutputClause)
+    val setElements = ctx.updateElem().asScala.map(_.accept(expressionBuilder))
+
+    val tableSourcesOption = Option(ctx.tableSources()).map(_.tableSource().asScala.map(_.accept(relationBuilder)))
+    val sourceRelation = tableSourcesOption.map { tableSources =>
+      tableSources.tail.foldLeft(tableSources.head)(
+        ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
+    }
+
+    val where = Option(ctx.updateWhereClause()) map (_.accept(expressionBuilder))
+    val optionClause = Option(ctx.optionClause).map(_.accept(expressionBuilder))
+    ir.UpdateTable(finalTarget, sourceRelation, setElements, where, output, optionClause)
+  }
+
+  override def visitDelete(ctx: DeleteContext): ir.Modification = {
+    val target = ctx.ddlObject().accept(relationBuilder)
+    val hints = relationBuilder.buildTableHints(Option(ctx.withTableHints()))
+    val finalTarget = if (hints.nonEmpty) {
+      ir.TableWithHints(target, hints)
+    } else {
+      target
+    }
+
+    val output = Option(ctx.outputClause()).map(buildOutputClause)
+    val tableSourcesOption = Option(ctx.tableSources()).map(_.tableSource().asScala.map(_.accept(relationBuilder)))
+    val sourceRelation = tableSourcesOption.map { tableSources =>
+      tableSources.tail.foldLeft(tableSources.head)(
+        ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
+    }
+
+    val where = Option(ctx.updateWhereClause()) map (_.accept(expressionBuilder))
+    val optionClause = Option(ctx.optionClause).map(_.accept(expressionBuilder))
+    ir.DeleteFromTable(finalTarget, sourceRelation, where, output, optionClause)
+  }
+
+  override def visitInsert(ctx: InsertContext): ir.Modification = {
+    val target = ctx.ddlObject().accept(relationBuilder)
+    val hints = relationBuilder.buildTableHints(Option(ctx.withTableHints()))
+    val finalTarget = if (hints.nonEmpty) {
+      ir.TableWithHints(target, hints)
+    } else {
+      target
+    }
+
+    val columns = Option(ctx.expressionList())
+      .map(_.expression().asScala.map(_.accept(expressionBuilder)).collect { case col: ir.Column => col.columnName })
+
+    val output = Option(ctx.outputClause()).map(buildOutputClause)
+    val values = buildInsertStatementValue(ctx.insertStatementValue())
+    val optionClause = Option(ctx.optionClause).map(_.accept(expressionBuilder))
+    ir.InsertIntoTable(finalTarget, columns, values, output, optionClause, overwrite = false)
+  }
+
+  private def buildInsertStatementValue(ctx: InsertStatementValueContext): ir.LogicalPlan = {
+    Option(ctx) match {
+      case Some(context) if context.derivedTable() != null => context.derivedTable().accept(relationBuilder)
+      case Some(context) if context.VALUES() != null => DefaultValues()
+      case Some(context) => context.executeStatement().accept(relationBuilder)
+    }
+  }
+
+  private def buildOutputClause(ctx: OutputClauseContext): Output = {
+    val outputs = ctx.outputDmlListElem().asScala.map(_.accept(expressionBuilder))
+    val target = Option(ctx.ddlObject()).map(_.accept(relationBuilder))
+    val columns =
+      Option(ctx.columnNameList())
+        .map(_.id().asScala.map(id => ir.Column(None, expressionBuilder.visitId(id))))
+
+    // Databricks SQL does not support the OUTPUT clause, but we may be able to translate
+    // the clause to SELECT statements executed before or after the INSERT/DELETE/UPDATE/MERGE
+    // is executed
+    Output(target, outputs, columns)
+  }
+
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -236,7 +236,7 @@ class TSqlExpressionBuilder(var relationBuilder: TSqlRelationBuilder)
   }
 
   override def visitExprSubquery(ctx: ExprSubqueryContext): ir.Expression = {
-    ScalarSubquery(ctx.subquery().accept(relationBuilder))
+    ir.ScalarSubquery(ctx.subquery().accept(relationBuilder))
   }
 
   override def visitExprTz(ctx: ExprTzContext): ir.Expression = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -257,13 +257,15 @@ class TSqlExpressionBuilder(vc: TSqlVisitorCoordinator)
   override def visitPredicate(ctx: TSqlParser.PredicateContext): ir.Expression = {
 
     ctx match {
-      case e if e.EXISTS() != null => ir.UnresolvedExpression(ctx.getText) // TODO: build EXISTS
-      case f if f.freetextPredicate() != null => ir.UnresolvedExpression(ctx.getText) // TODO: build FREETEXT
-      case i if i.IN() != null => ir.UnresolvedExpression(ctx.getText) // TODO: build IN
+      case e if e.EXISTS() != null => ir.UnresolvedExpression(getTextFromParserRuleContext(ctx)) // TODO: build EXISTS
+      case f if f.freetextPredicate() != null =>
+        ir.UnresolvedExpression(getTextFromParserRuleContext(ctx)) // TODO: build FREETEXT
+      case i if i.IN() != null => ir.UnresolvedExpression(getTextFromParserRuleContext(ctx)) // TODO: build IN
       // TODO: build = ALL/SOM/ANY subquery
-      case asa if asa.selectStatement() != null => ir.UnresolvedExpression(ctx.getText)
-      case l if l.LIKE() != null => ir.UnresolvedExpression(ctx.getText) // TODO: build LIKE
-      case i if i.IS() != null => ir.UnresolvedExpression(ctx.getText) // TODO: build IS
+      case asa if asa.selectStatement() != null => ir.UnresolvedExpression(getTextFromParserRuleContext(ctx))
+      case l if l.LIKE() != null => ir.UnresolvedExpression(getTextFromParserRuleContext(ctx)) // TODO: build LIKE
+      case i if i.IS() != null => ir.UnresolvedExpression(getTextFromParserRuleContext(ctx)) // TODO: build IS
+      case b if b.BETWEEN() != null => ir.UnresolvedExpression(getTextFromParserRuleContext(ctx)) // TODO: build BETWEEN
       case _ =>
         ctx.expression().size() match {
           // Single expression as a predicate

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -7,7 +7,9 @@ import org.antlr.v4.runtime.tree.Trees
 
 import scala.collection.JavaConverters._
 
-class TSqlExpressionBuilder() extends TSqlParserBaseVisitor[ir.Expression] with ParserCommon[ir.Expression] {
+class TSqlExpressionBuilder(var relationBuilder: TSqlRelationBuilder)
+    extends TSqlParserBaseVisitor[ir.Expression]
+    with ParserCommon[ir.Expression] {
 
   private val functionBuilder = new TSqlFunctionBuilder
   private[tsql] val optionBuilder = new OptionBuilder(this)
@@ -234,7 +236,7 @@ class TSqlExpressionBuilder() extends TSqlParserBaseVisitor[ir.Expression] with 
   }
 
   override def visitExprSubquery(ctx: ExprSubqueryContext): ir.Expression = {
-    ir.ScalarSubquery(ctx.subquery().accept(new TSqlRelationBuilder))
+    ScalarSubquery(ctx.subquery().accept(relationBuilder))
   }
 
   override def visitExprTz(ctx: ExprTzContext): ir.Expression = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
@@ -7,12 +7,12 @@ import org.antlr.v4.runtime.{CharStream, ParserRuleContext, TokenSource, TokenSt
 
 class TSqlPlanParser extends PlanParser[TSqlParser] {
 
-  private val astBuilder = new TSqlAstBuilder()
+  private val vc = new TSqlVisitorCoordinator
 
   override protected def createLexer(input: CharStream): TokenSource = new TSqlLexer(input)
   override protected def createParser(stream: TokenStream): TSqlParser = new TSqlParser(stream)
   override protected def createTree(parser: TSqlParser): ParserRuleContext = parser.tSqlFile()
-  override protected def createPlan(tree: ParserRuleContext): LogicalPlan = astBuilder.visit(tree)
+  override protected def createPlan(tree: ParserRuleContext): LogicalPlan = vc.astBuilder.visit(tree)
 
   // TODO: Note that this is not the correct place for the optimizer, but it is here for now
   override protected def createOptimizer: Rules[LogicalPlan] = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
@@ -13,6 +13,7 @@ class TSqlPlanParser extends PlanParser[TSqlParser] {
   override protected def createParser(stream: TokenStream): TSqlParser = new TSqlParser(stream)
   override protected def createTree(parser: TSqlParser): ParserRuleContext = parser.tSqlFile()
   override protected def createPlan(tree: ParserRuleContext): LogicalPlan = vc.astBuilder.visit(tree)
+  override protected def addErrorStrategy(parser: TSqlParser): Unit = parser.setErrorHandler(new TSqlErrorStrategy)
 
   // TODO: Note that this is not the correct place for the optimizer, but it is here for now
   override protected def createOptimizer: Rules[LogicalPlan] = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -7,9 +7,7 @@ import org.antlr.v4.runtime.ParserRuleContext
 
 import scala.collection.JavaConverters.asScalaBufferConverter
 
-class TSqlRelationBuilder extends TSqlParserBaseVisitor[ir.LogicalPlan] {
-
-  private val expressionBuilder = new TSqlExpressionBuilder
+class TSqlRelationBuilder(expressionBuilder: TSqlExpressionBuilder) extends TSqlParserBaseVisitor[ir.LogicalPlan] {
 
   override def visitCommonTableExpression(ctx: CommonTableExpressionContext): ir.LogicalPlan = {
     val tableName = expressionBuilder.visitId(ctx.id())
@@ -61,7 +59,7 @@ class TSqlRelationBuilder extends TSqlParserBaseVisitor[ir.LogicalPlan] {
     }
   }
 
-  private def buildTop(ctxOpt: Option[TSqlParser.TopClauseContext], input: ir.LogicalPlan): ir.LogicalPlan =
+  private[tsql] def buildTop(ctxOpt: Option[TSqlParser.TopClauseContext], input: ir.LogicalPlan): ir.LogicalPlan =
     ctxOpt.fold(input) { top =>
       val limit = top.expression().accept(expressionBuilder)
       if (top.PERCENT() != null) {
@@ -193,7 +191,7 @@ class TSqlRelationBuilder extends TSqlParserBaseVisitor[ir.LogicalPlan] {
   // we build a single map from both sources, either or both of which may be empty.
   // In true TSQL style, some of the hints have non-orthodox syntax, and must be handled
   // directly.
-  private def buildTableHints(ctx: Option[WithTableHintsContext]): Seq[ir.TableHint] = {
+  private[tsql] def buildTableHints(ctx: Option[WithTableHintsContext]): Seq[ir.TableHint] = {
     ctx.map(_.tableHint().asScala.map(buildHint).toList).getOrElse(Seq.empty)
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlVisitorCoordinator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlVisitorCoordinator.scala
@@ -1,0 +1,13 @@
+package com.databricks.labs.remorph.parsers.tsql
+
+class TSqlVisitorCoordinator {
+
+  val relationBuilder: TSqlRelationBuilder = new TSqlRelationBuilder(this)
+  val expressionBuilder = new TSqlExpressionBuilder(this)
+  val dmlBuilder = new TSqlDMLBuilder(this)
+  val optionBuilder = new OptionBuilder(this)
+  val ddlBuilder = new TSqlDDLBuilder(this)
+  val dataTypeBuilder: DataTypeBuilder = new DataTypeBuilder
+  val functionBuilder = new TSqlFunctionBuilder
+  val astBuilder = new TSqlAstBuilder(this)
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlVisitorCoordinator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlVisitorCoordinator.scala
@@ -1,13 +1,16 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-class TSqlVisitorCoordinator {
+import com.databricks.labs.remorph.parsers.VisitorCoordinator
 
-  val relationBuilder: TSqlRelationBuilder = new TSqlRelationBuilder(this)
+class TSqlVisitorCoordinator extends VisitorCoordinator {
+
+  val astBuilder = new TSqlAstBuilder(this)
+  val relationBuilder = new TSqlRelationBuilder(this)
   val expressionBuilder = new TSqlExpressionBuilder(this)
   val dmlBuilder = new TSqlDMLBuilder(this)
-  val optionBuilder = new OptionBuilder(this)
   val ddlBuilder = new TSqlDDLBuilder(this)
-  val dataTypeBuilder: DataTypeBuilder = new DataTypeBuilder
   val functionBuilder = new TSqlFunctionBuilder
-  val astBuilder = new TSqlAstBuilder(this)
+
+  // TSQL extension
+  val optionBuilder = new OptionBuilder(this)
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/relations.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/relations.scala
@@ -12,7 +12,7 @@ case class Output(target: Option[LogicalPlan], outputs: Seq[Expression], columns
   override def children: Seq[LogicalPlan] = Seq(target.getOrElse(NoopNode))
 }
 
-case class WithOutputClause(input: LogicalPlan, target: LogicalPlan) extends RelationCommon {
+case class WithOutputClause(input: LogicalPlan, target: LogicalPlan) extends Modification {
   override def output: Seq[Attribute] = target.output
   override def children: Seq[LogicalPlan] = Seq(input, target)
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers with IRHelpers {
 
-  override protected def astBuilder: TSqlParserBaseVisitor[_] = new TSqlAstBuilder
+  override protected def astBuilder: TSqlParserBaseVisitor[_] = vc.astBuilder
 
   private def example(query: String, expectedAst: LogicalPlan): Unit =
     example(query, _.tSqlFile(), expectedAst)
@@ -218,10 +218,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
       when(joinTypeContextMock.INNER()).thenReturn(null)
       when(joinOnContextMock.joinType()).thenReturn(joinTypeContextMock)
 
-      val expressionBuilder = new TSqlExpressionBuilder(null)
-      val builder = new TSqlRelationBuilder(expressionBuilder)
-      expressionBuilder.relationBuilder = builder
-      val result = builder.translateJoinType(joinOnContextMock)
+      val result = vc.relationBuilder.translateJoinType(joinOnContextMock)
       result shouldBe UnspecifiedJoin
     }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -218,7 +218,9 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
       when(joinTypeContextMock.INNER()).thenReturn(null)
       when(joinOnContextMock.joinType()).thenReturn(joinTypeContextMock)
 
-      val builder = new TSqlRelationBuilder
+      val expressionBuilder = new TSqlExpressionBuilder(null)
+      val builder = new TSqlRelationBuilder(expressionBuilder)
+      expressionBuilder.relationBuilder = builder
       val result = builder.translateJoinType(joinOnContextMock)
       result shouldBe UnspecifiedJoin
     }
@@ -889,7 +891,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             | WHEN NOT MATCHED THEN INSERT (a, b) VALUES (s.a, s.b)
             | OPTION ( KEEPFIXED PLAN, FAST 666, MAX_GRANT_PERCENT = 30, FLAME ON, FLAME OFF, QUICKLY) """.stripMargin,
       expectedAst = Batch(
-        Seq(WithOptions(
+        Seq(WithModificationOptions(
           MergeIntoTable(
             NamedTable("t", Map(), is_streaming = false),
             NamedTable("s", Map(), is_streaming = false),

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -953,41 +953,4 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 Assign(Column(None, Id("a")), Column(Some(ObjectReference(Id("s"))), Id("a"))),
                 Assign(Column(None, Id("b")), Column(Some(ObjectReference(Id("s"))), Id("b")))))))))))
   }
-
-  "not crash" in {
-    example(
-      query = """-- query12
-                |SELECT TOP 100
-                |         i_item_id ,
-                |         i_item_desc ,
-                |         i_category ,
-                |         i_class ,
-                |         i_current_price ,
-                |         Sum(ws_ext_sales_price)                                                              AS itemrevenue ,
-                |         Sum(ws_ext_sales_price)*100/Sum(Sum(ws_ext_sales_price)) OVER (partition BY i_class) AS revenueratio
-                |FROM     web_sales ,
-                |         item ,
-                |         date_dim
-                |WHERE    ws_item_sk = i_item_sk
-                |AND      i_category IN ('Home',
-                |                        'Men',
-                |                        'Women')
-                |AND      ws_sold_date_sk = d_date_sk
-                |AND      Cast(d_date AS DATE) BETWEEN Cast('2000-05-11' AS DATE) AND      (
-                |                  Cast('2000-06-11' AS DATE))
-                |GROUP BY i_item_id ,
-                |         i_item_desc ,
-                |         i_category ,
-                |         i_class ,
-                |         i_current_price
-                |ORDER BY i_category ,
-                |         i_class ,
-                |         i_item_id ,
-                |         i_item_desc ,
-                |         revenueratio
-                |""".stripMargin,
-        expectedAst = Batch(Seq.empty)
-
-    )
-  }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -953,4 +953,41 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 Assign(Column(None, Id("a")), Column(Some(ObjectReference(Id("s"))), Id("a"))),
                 Assign(Column(None, Id("b")), Column(Some(ObjectReference(Id("s"))), Id("b")))))))))))
   }
+
+  "not crash" in {
+    example(
+      query = """-- query12
+                |SELECT TOP 100
+                |         i_item_id ,
+                |         i_item_desc ,
+                |         i_category ,
+                |         i_class ,
+                |         i_current_price ,
+                |         Sum(ws_ext_sales_price)                                                              AS itemrevenue ,
+                |         Sum(ws_ext_sales_price)*100/Sum(Sum(ws_ext_sales_price)) OVER (partition BY i_class) AS revenueratio
+                |FROM     web_sales ,
+                |         item ,
+                |         date_dim
+                |WHERE    ws_item_sk = i_item_sk
+                |AND      i_category IN ('Home',
+                |                        'Men',
+                |                        'Women')
+                |AND      ws_sold_date_sk = d_date_sk
+                |AND      Cast(d_date AS DATE) BETWEEN Cast('2000-05-11' AS DATE) AND      (
+                |                  Cast('2000-06-11' AS DATE))
+                |GROUP BY i_item_id ,
+                |         i_item_desc ,
+                |         i_category ,
+                |         i_class ,
+                |         i_current_price
+                |ORDER BY i_category ,
+                |         i_class ,
+                |         i_item_id ,
+                |         i_item_desc ,
+                |         revenueratio
+                |""".stripMargin,
+        expectedAst = Batch(Seq.empty)
+
+    )
+  }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilderSpec.scala
@@ -7,10 +7,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class TSqlDDLBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers with IRHelpers {
 
-  override protected def astBuilder: TSqlParserBaseVisitor[_] = new TSqlAstBuilder
-
-//  private def example(query: String, expectedAst: LogicalPlan): Unit =
-//    example(query, _.tSqlFile(), expectedAst)
+  override protected def astBuilder: TSqlParserBaseVisitor[_] = vc.astBuilder
 
   private def singleQueryExample(query: String, expectedAst: LogicalPlan): Unit =
     example(query, _.tSqlFile(), Batch(Seq(expectedAst)))

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlErrorStategySpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlErrorStategySpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class TSqlErrorStategySpec extends AnyWordSpec with TSqlParserTestCommon with Matchers with IRHelpers {
-  override protected def astBuilder: TSqlParserBaseVisitor[_] = new TSqlAstBuilder
+  override protected def astBuilder: TSqlParserBaseVisitor[_] = vc.astBuilder
 
   private def checkError(query: String, errContains: String): Assertion =
     checkError(query, _.tSqlFile(), errContains)

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -11,9 +11,11 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers with IRHelpers {
 
-  private val exprBuilder = new TSqlExpressionBuilder
+  private val exprBuilder = new TSqlExpressionBuilder(null)
+  private val relationBuilder = new TSqlRelationBuilder(exprBuilder)
+  exprBuilder.relationBuilder = relationBuilder
 
-  override protected def astBuilder: TSqlParserBaseVisitor[_] = new TSqlExpressionBuilder
+  override protected def astBuilder: TSqlParserBaseVisitor[_] = exprBuilder
 
   "TSqlExpressionBuilder" should {
     "translate literals" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -11,11 +11,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers with IRHelpers {
 
-  private val exprBuilder = new TSqlExpressionBuilder(null)
-  private val relationBuilder = new TSqlRelationBuilder(exprBuilder)
-  exprBuilder.relationBuilder = relationBuilder
-
-  override protected def astBuilder: TSqlParserBaseVisitor[_] = exprBuilder
+  override protected def astBuilder: TSqlParserBaseVisitor[_] = vc.expressionBuilder
 
   "TSqlExpressionBuilder" should {
     "translate literals" in {
@@ -332,7 +328,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
       val expressionMockFunc = mock(classOf[TSqlParser.ExpressionContext])
       when(mockCtx.expression(1)).thenReturn(expressionMockFunc)
       when(expressionMockFunc.accept(any())).thenReturn(ir.CallFunction("UNKNOWN_FUNCTION", List()))
-      val result = exprBuilder.visitExprDot(mockCtx)
+      val result = vc.expressionBuilder.visitExprDot(mockCtx)
       result shouldBe a[ir.Dot]
     }
 
@@ -399,7 +395,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
       when(mockCtx.expressionElem()).thenReturn(null)
 
       // Call the method with the mock instance
-      val result = exprBuilder.visitSelectListElem(mockCtx)
+      val result = vc.expressionBuilder.visitSelectListElem(mockCtx)
 
       // Verify the result
       result shouldBe a[ir.UnresolvedExpression]
@@ -417,7 +413,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
       when(expressionContextMock.accept(any())).thenReturn(null)
       when(selectListElemContextMock.expression()).thenReturn(expressionContextMock)
 
-      val result = exprBuilder.visitSelectListElem(selectListElemContextMock)
+      val result = vc.expressionBuilder.visitSelectListElem(selectListElemContextMock)
 
       result shouldBe a[ir.UnresolvedExpression]
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionGeneratorTest.scala
@@ -15,6 +15,6 @@ class TSqlExpressionGeneratorTest
     with MockitoSugar
     with IRHelpers {
 
-  override protected val generator = new ExpressionGenerator
+  override protected val generator = new ExpressionGenerator()
 
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers with IRHelpers {
 
-  override protected def astBuilder: TSqlParserBaseVisitor[_] = new TSqlExpressionBuilder(null)
+  override protected def astBuilder: TSqlParserBaseVisitor[_] = vc.expressionBuilder
 
   "translate functions with no parameters" in {
     exampleExpr("APP_NAME()", _.expression(), ir.CallFunction("APP_NAME", List()))

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers with IRHelpers {
 
-  override protected def astBuilder: TSqlParserBaseVisitor[_] = new TSqlExpressionBuilder
+  override protected def astBuilder: TSqlParserBaseVisitor[_] = new TSqlExpressionBuilder(null)
 
   "translate functions with no parameters" in {
     exampleExpr("APP_NAME()", _.expression(), ir.CallFunction("APP_NAME", List()))

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlParserTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlParserTestCommon.scala
@@ -6,6 +6,7 @@ import org.scalatest.Assertions
 
 trait TSqlParserTestCommon extends ParserTestCommon[TSqlParser] { self: Assertions =>
 
+  val vc: TSqlVisitorCoordinator = new TSqlVisitorCoordinator
   override final protected def makeLexer(chars: CharStream): TokenSource = new TSqlLexer(chars)
 
   override final protected def makeErrStrategy(): TSqlErrorStrategy = new TSqlErrorStrategy

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
@@ -13,9 +13,7 @@ class TSqlRelationBuilderSpec
     with MockitoSugar
     with IRHelpers {
 
-  private val expressionBuilder = new TSqlExpressionBuilder(null)
-  override protected def astBuilder: TSqlRelationBuilder = new TSqlRelationBuilder(expressionBuilder)
-  expressionBuilder.relationBuilder = astBuilder
+  override protected def astBuilder: TSqlRelationBuilder = vc.relationBuilder
 
   "TSqlRelationBuilder" should {
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
@@ -13,7 +13,9 @@ class TSqlRelationBuilderSpec
     with MockitoSugar
     with IRHelpers {
 
-  override protected def astBuilder: TSqlRelationBuilder = new TSqlRelationBuilder
+  private val expressionBuilder = new TSqlExpressionBuilder(null)
+  override protected def astBuilder: TSqlRelationBuilder = new TSqlRelationBuilder(expressionBuilder)
+  expressionBuilder.relationBuilder = astBuilder
 
   "TSqlRelationBuilder" should {
 


### PR DESCRIPTION
Follows Snowflake reorg of separation DDL and DML and cleanly separates CREATE TABLE etc from DML. Also changes the IR Builders for TSQL such that they are all injected via a visitor coordination class rather than created within each builder, thus making each visitor independent of any other, which solves cyclic dependencies.  

An implementation of the VisitorCoordinator can also supply any other common resources in the same manner.
