### PR TITLE
Ensure that successful parsing is recorded even if transpilation fails and record reconciled generations

### DIFF
--- a/coverage/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
+++ b/coverage/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
@@ -2,7 +2,7 @@ package com.databricks.labs.remorph.coverage
 
 import com.databricks.labs.remorph.queries.ExampleQuery
 import com.databricks.labs.remorph.transpilers.WorkflowStage.PARSE
-import com.databricks.labs.remorph.transpilers.{Formatter, Result, SnowflakeToDatabricksTranspiler, SourceCode, TSqlToDatabricksTranspiler, Transpiler}
+import com.databricks.labs.remorph.transpilers._
 import com.databricks.labs.remorph.utils.Strings
 
 trait QueryRunner extends Formatter {
@@ -21,7 +21,9 @@ abstract class BaseQueryRunner(transpiler: Transpiler) extends QueryRunner {
   override def runQuery(exampleQuery: ExampleQuery): ReportEntryReport = {
     transpiler.transpile(SourceCode(exampleQuery.query)) match {
       case Result.Failure(PARSE, errorJson) => ReportEntryReport(statements = 1, parsing_error = Some(errorJson))
-      case Result.Failure(_, errorJson) => ReportEntryReport(statements = 1, transpilation_error = Some(errorJson))
+      case Result.Failure(_, errorJson) =>
+        // If we got past the PARSE stage, then remember to record that we parsed it correctly
+        ReportEntryReport(parsed = 1, statements = 1, transpilation_error = Some(errorJson))
       case Result.Success(output) =>
         if (exampleQuery.expectedTranslation.map(format).exists(_ != format(output))) {
           val expected = exampleQuery.expectedTranslation.getOrElse("")

--- a/coverage/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
+++ b/coverage/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
@@ -27,19 +27,9 @@ abstract class BaseQueryRunner(transpiler: Transpiler) extends QueryRunner {
       case Result.Success(output) =>
         if (exampleQuery.expectedTranslation.map(format).exists(_ != format(output))) {
           val expected = exampleQuery.expectedTranslation.getOrElse("")
-          ReportEntryReport(
-            parsed = 1,
-            transpiled = 1,
-            statements = 1,
-            reconciliation_error = Some(compareQueries(expected, output)))
+          ReportEntryReport(parsed = 1, statements = 1, transpilation_error = Some(compareQueries(expected, output)))
         } else {
-          ReportEntryReport(
-            parsed = 1,
-            transpiled = 1,
-            reconciled = 1,
-            statements = 1,
-            transpiled_statements = 1,
-            reconciled_statements = 1)
+          ReportEntryReport(parsed = 1, transpiled = 1, statements = 1, transpiled_statements = 1)
         }
     }
   }

--- a/coverage/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
+++ b/coverage/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
@@ -33,7 +33,12 @@ abstract class BaseQueryRunner(transpiler: Transpiler) extends QueryRunner {
             statements = 1,
             reconciliation_error = Some(compareQueries(expected, output)))
         } else {
-          ReportEntryReport(parsed = 1, transpiled = 1, reconciled = 1, statements = 1, transpiled_statements = 1,
+          ReportEntryReport(
+            parsed = 1,
+            transpiled = 1,
+            reconciled = 1,
+            statements = 1,
+            transpiled_statements = 1,
             reconciled_statements = 1)
         }
     }

--- a/coverage/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
+++ b/coverage/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
@@ -31,9 +31,10 @@ abstract class BaseQueryRunner(transpiler: Transpiler) extends QueryRunner {
             parsed = 1,
             transpiled = 1,
             statements = 1,
-            transpilation_error = Some(compareQueries(expected, output)))
+            reconciliation_error = Some(compareQueries(expected, output)))
         } else {
-          ReportEntryReport(parsed = 1, transpiled = 1, statements = 1)
+          ReportEntryReport(parsed = 1, transpiled = 1, reconciled = 1, statements = 1, transpiled_statements = 1,
+            reconciled_statements = 1)
         }
     }
   }

--- a/coverage/src/main/scala/com/databricks/labs/remorph/coverage/ReportEntry.scala
+++ b/coverage/src/main/scala/com/databricks/labs/remorph/coverage/ReportEntry.scala
@@ -14,7 +14,10 @@ case class ReportEntryReport(
     parsing_error: Option[String] = None,
     transpiled: Int = 0, // 1 for success, 0 for failure
     transpiled_statements: Int = 0, // number of statements transpiled
-    transpilation_error: Option[String] = None) {
+    transpilation_error: Option[String] = None,
+    reconciled: Int = 0,
+    reconciled_statements: Int = 0,
+    reconciliation_error: Option[String] = None) {
   def isSuccess: Boolean = parsing_error.isEmpty && transpilation_error.isEmpty
   def errorMessage: Option[String] = parsing_error.orElse(transpilation_error)
 }
@@ -35,6 +38,9 @@ case class ReportEntry(header: ReportEntryHeader, report: ReportEntryReport) {
       "parsing_error" -> report.parsing_error.map(ujson.Str).getOrElse(ujson.Null),
       "transpiled" -> ujson.Num(report.transpiled),
       "transpiled_statements" -> ujson.Num(report.transpiled_statements),
-      "transpilation_error" -> report.transpilation_error.map(ujson.Str).getOrElse(ujson.Null))
+      "transpilation_error" -> report.transpilation_error.map(ujson.Str).getOrElse(ujson.Null),
+      "reconciled" -> ujson.Num(report.reconciled),
+      "reconciled_statements" -> ujson.Num(report.reconciled_statements),
+      "reconciliation_error" -> report.reconciliation_error.map(ujson.Str).getOrElse(ujson.Null))
   }
 }

--- a/coverage/src/main/scala/com/databricks/labs/remorph/coverage/ReportEntry.scala
+++ b/coverage/src/main/scala/com/databricks/labs/remorph/coverage/ReportEntry.scala
@@ -14,10 +14,7 @@ case class ReportEntryReport(
     parsing_error: Option[String] = None,
     transpiled: Int = 0, // 1 for success, 0 for failure
     transpiled_statements: Int = 0, // number of statements transpiled
-    transpilation_error: Option[String] = None,
-    reconciled: Int = 0,
-    reconciled_statements: Int = 0,
-    reconciliation_error: Option[String] = None) {
+    transpilation_error: Option[String] = None) {
   def isSuccess: Boolean = parsing_error.isEmpty && transpilation_error.isEmpty
   def errorMessage: Option[String] = parsing_error.orElse(transpilation_error)
 }
@@ -38,9 +35,6 @@ case class ReportEntry(header: ReportEntryHeader, report: ReportEntryReport) {
       "parsing_error" -> report.parsing_error.map(ujson.Str).getOrElse(ujson.Null),
       "transpiled" -> ujson.Num(report.transpiled),
       "transpiled_statements" -> ujson.Num(report.transpiled_statements),
-      "transpilation_error" -> report.transpilation_error.map(ujson.Str).getOrElse(ujson.Null),
-      "reconciled" -> ujson.Num(report.reconciled),
-      "reconciled_statements" -> ujson.Num(report.reconciled_statements),
-      "reconciliation_error" -> report.reconciliation_error.map(ujson.Str).getOrElse(ujson.Null))
+      "transpilation_error" -> report.transpilation_error.map(ujson.Str).getOrElse(ujson.Null))
   }
 }

--- a/src/databricks/labs/remorph/coverage/commons.py
+++ b/src/databricks/labs/remorph/coverage/commons.py
@@ -4,17 +4,18 @@ import dataclasses
 import json
 import logging
 import os
-import sqlglot
 import subprocess
 import time
 from collections.abc import Generator
 from datetime import datetime, timezone
 from pathlib import Path
-from sqlglot.dialects.databricks import Databricks
-from sqlglot.dialects.dialect import Dialect
-from sqlglot.errors import ErrorLevel
-from sqlglot.expressions import Expression
 from typing import TextIO
+
+import sqlglot
+from sqlglot.expressions import Expression
+from sqlglot.dialects.dialect import Dialect
+from sqlglot.dialects.databricks import Databricks
+from sqlglot.errors import ErrorLevel
 
 logger = logging.getLogger(__name__)
 

--- a/src/databricks/labs/remorph/coverage/commons.py
+++ b/src/databricks/labs/remorph/coverage/commons.py
@@ -35,9 +35,6 @@ class ReportEntry:
     transpiled: int = 0  # 1 for success, 0 for failure
     transpiled_statements: int = 0  # number of statements transpiled
     transpilation_error: str | None = None
-    reconciled: int = 0  # 1 for success, 0 for failure
-    reconciled_statements: int = 0  # number of statements reconciled
-    reconciliation_error: str | None = None  # Difference between transpiled and expected output
 
 
 def sqlglot_run_coverage(dialect, subfolder):
@@ -74,14 +71,11 @@ def local_report(output_dir: Path):
         total = len(entries)
         parsed = sum(entry.parsed for entry in entries)
         transpiled = sum(entry.transpiled for entry in entries)
-        reconciled = sum(entry.reconciled for entry in entries)
         parse_ratio = parsed / total
         transpile_ratio = transpiled / total
-        reconcile_ratio = reconciled / total
         print(
             f"{project} -> {dialect}: {parse_ratio:.2%} parsed ({parsed}/{total}), "
-            f"{transpile_ratio:.2%} transpiled ({transpiled}/{total}), "
-            f"{reconcile_ratio:.2%} reconciled ({reconciled}/{total})"
+            f"{transpile_ratio:.2%} transpiled ({transpiled}/{total})"
         )
 
 


### PR DESCRIPTION
A small bug meant that if the transpile failed, then the fact that the parse was successful was not recorded. Here we correct that oversight.

We also add an extra field to the report entry to record what percentage of code generations resulted in the expected translation as currently we record that there was a generation difference but do not report how many resulted in the expected translation according to the coverage test.