### PR TITLE
feat: Implement all of TSQL predicates except for SOME ALL ANY

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -2787,15 +2787,15 @@ searchCondition
     ;
 
 predicate
-    : EXISTS LPAREN selectStatement RPAREN
-    | freetextPredicate
-    | expression comparisonOperator expression
-    | expression comparisonOperator (ALL | SOME | ANY) LPAREN selectStatement RPAREN
-    | expression NOT* BETWEEN expression AND expression
-    | expression NOT* IN LPAREN (selectStatement | expressionList) RPAREN
-    | expression NOT* LIKE expression (ESCAPE expression)?
-    | expression IS nullNotnull
-    | expression
+    : EXISTS LPAREN selectStatement RPAREN                                           # predExists
+    | freetextPredicate                                                              # predFreetext
+    | expression comparisonOperator expression                                       # predBinop
+    | expression comparisonOperator (ALL | SOME | ANY) LPAREN selectStatement RPAREN # predASA
+    | expression NOT? BETWEEN expression AND expression                              # predBetween
+    | expression NOT? IN LPAREN (selectStatement | expressionList) RPAREN            # predIn
+    | expression NOT? LIKE expression (ESCAPE expression)?                           # predLike
+    | expression IS NOT? NULL                                                        # predIsNull
+    | expression                                                                     # predExpression
     ;
 
 queryExpression

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/ExpressionGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/ExpressionGenerator.scala
@@ -200,11 +200,11 @@ class ExpressionGenerator extends Generator[ir.Expression, String] {
       ctx: GeneratorContext,
       subject: ir.Expression,
       pattern: ir.Expression,
-      escapeChar: Char,
+      escapeChar: Option[ir.Expression],
       caseSensitive: Boolean): String = {
     val op = if (caseSensitive) { "LIKE" }
     else { "ILIKE" }
-    val escape = if (escapeChar != '\\') s" ESCAPE '${escapeChar}'" else ""
+    val escape = escapeChar.map(char => s" ESCAPE ${expression(ctx, char)}").getOrElse("")
     s"${expression(ctx, subject)} $op ${expression(ctx, pattern)}$escape"
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/operators.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/intermediate/operators.scala
@@ -70,8 +70,10 @@ case class Subtract(left: Expression, right: Expression) extends Binary(left, ri
 /**
  * str like pattern[ ESCAPE escape] - Returns true if str matches `pattern` with `escape`, null if any arguments are
  * null, false otherwise.
+ *
+ * NB: escapeChar is a full expression that evaluates to a single char at runtime, not parse time
  */
-case class Like(left: Expression, right: Expression, escapeChar: Char = '\\') extends Binary(left, right) {
+case class Like(left: Expression, right: Expression, escapeChar: Option[Expression]) extends Binary(left, right) {
   override def dataType: DataType = BooleanType
 }
 
@@ -85,7 +87,8 @@ case class LikeAny(child: Expression, patterns: Seq[Expression]) extends Express
   override def dataType: DataType = BooleanType
 }
 
-case class ILike(left: Expression, right: Expression, escapeChar: Char = '\\') extends Binary(left, right) {
+// NB: escapeChar is a full expression that evaluates to a single char at runtime, not parse time
+case class ILike(left: Expression, right: Expression, escapeChar: Option[Expression]) extends Binary(left, right) {
   override def dataType: DataType = BooleanType
 }
 
@@ -103,4 +106,3 @@ case class ILikeAny(child: Expression, patterns: Seq[Expression]) extends Expres
 case class RLike(left: Expression, right: Expression) extends Binary(left, right) {
   override def dataType: DataType = BooleanType
 }
-

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -523,12 +523,11 @@ class SnowflakeExpressionBuilder()
   private def buildLikeExpression(ctx: LikeExpressionContext, child: ir.Expression): ir.Expression = ctx match {
     case single: LikeExprSinglePatternContext =>
       val pattern = single.pat.accept(this)
+      // NB: The escape character is a complete expression that evaluates to a single char at runtime
+      // and not a single char at parse time.
       val escape = Option(single.escapeChar)
         .map(_.accept(this))
-        .collect { case ir.StringLiteral(s) =>
-          s.head
-        }
-        .getOrElse('\\')
+
       single.op.getType match {
         case LIKE => ir.Like(child, pattern, escape)
         case ILIKE => ir.ILike(child, pattern, escape)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilder.scala
@@ -12,7 +12,7 @@ class TSqlDDLBuilder(vc: TSqlVisitorCoordinator)
     ctx match {
       case ci if ci.createInternal() != null => ci.createInternal().accept(this)
       case ct if ct.createExternal() != null => ct.createExternal().accept(this)
-      case _ => ir.UnresolvedCatalog(ctx.getText)
+      case _ => ir.UnresolvedCatalog(getTextFromParserRuleContext(ctx))
     }
 
   override def visitCreateInternal(ctx: TSqlParser.CreateInternalContext): ir.Catalog = {
@@ -56,7 +56,7 @@ class TSqlDDLBuilder(vc: TSqlVisitorCoordinator)
       case null => ir.CreateTable(tableName, None, None, None, schema)
       case ctas if ctas.selectStatementStandalone() != null =>
         ir.CreateTableAsSelect(tableName, ctas.selectStatementStandalone().accept(vc.relationBuilder), None, None, None)
-      case _ => ir.UnresolvedCatalog(ctx.getText)
+      case _ => ir.UnresolvedCatalog(getTextFromParserRuleContext(ctx))
     }
 
     // But because TSQL is so much more complicated than Databricks SQL, we need to build the table alterations
@@ -106,7 +106,7 @@ class TSqlDDLBuilder(vc: TSqlVisitorCoordinator)
   }
 
   override def visitCreateExternal(ctx: TSqlParser.CreateExternalContext): ir.Catalog = {
-    ir.UnresolvedCatalog(ctx.getText)
+    ir.UnresolvedCatalog(getTextFromParserRuleContext(ctx))
   }
 
   /**
@@ -117,7 +117,7 @@ class TSqlDDLBuilder(vc: TSqlVisitorCoordinator)
    * @return the option we have parsed
    */
   private def buildOption(ctx: TSqlParser.TableOptionContext): ir.GenericOption = {
-    ir.OptionUnresolved(ctx.getText)
+    ir.OptionUnresolved(getTextFromParserRuleContext(ctx))
   }
 
   private case class TSqlColDef(
@@ -220,7 +220,7 @@ class TSqlDDLBuilder(vc: TSqlVisitorCoordinator)
       case pu if pu.PRIMARY() != null || pu.UNIQUE() != null =>
         if (pu.clustered() != null) {
           if (pu.clustered().CLUSTERED() != null) {
-            options += ir.OptionUnresolved(pu.clustered().getText)
+            options += ir.OptionUnresolved(getTextFromParserRuleContext(pu.clustered()))
           }
         }
         val colNames = ctx.columnNameListWithOrder().columnNameWithOrder().asScala.map { cnwo =>
@@ -253,11 +253,11 @@ class TSqlDDLBuilder(vc: TSqlVisitorCoordinator)
 
       case cc if cc.CONNECTION() != null =>
         // CONNECTION is not supported in Databricks SQL
-        ir.UnresolvedConstraint(ctx.getText)
+        ir.UnresolvedConstraint(getTextFromParserRuleContext(ctx))
 
       case defVal if defVal.DEFAULT() != null =>
         // DEFAULT is not supported in Databricks SQL at TABLE constraint level
-        ir.UnresolvedConstraint(ctx.getText)
+        ir.UnresolvedConstraint(getTextFromParserRuleContext(ctx))
 
       case cc if cc.checkConstraint() != null =>
         // Check constraint construction
@@ -267,7 +267,7 @@ class TSqlDDLBuilder(vc: TSqlVisitorCoordinator)
         }
         ir.CheckConstraint(expr)
 
-      case _ => ir.UnresolvedConstraint(ctx.getText)
+      case _ => ir.UnresolvedConstraint(getTextFromParserRuleContext(ctx))
     }
 
     // Name the constraint if it is named and not unresolved
@@ -302,7 +302,7 @@ class TSqlDDLBuilder(vc: TSqlVisitorCoordinator)
       case pu if pu.PRIMARY() != null || pu.UNIQUE() != null =>
         // Primary or unique key construction.
         if (pu.clustered() != null) {
-          options += ir.OptionUnresolved(pu.clustered().getText)
+          options += ir.OptionUnresolved(getTextFromParserRuleContext(pu.clustered()))
         }
 
         if (pu.primaryKeyOptions() != null) {
@@ -337,7 +337,7 @@ class TSqlDDLBuilder(vc: TSqlVisitorCoordinator)
         }
         ir.CheckConstraint(expr)
 
-      case _ => ir.UnresolvedConstraint(ctx.getText)
+      case _ => ir.UnresolvedConstraint(getTextFromParserRuleContext(ctx))
     }
 
     // Name the constraint if it is named and not unresolved
@@ -392,7 +392,7 @@ class TSqlDDLBuilder(vc: TSqlVisitorCoordinator)
    * @return An unresolved constraint representing the index syntax
    */
   private def buildIndex(ctx: TSqlParser.TableIndicesContext): ir.UnresolvedConstraint = {
-    ir.UnresolvedConstraint(ctx.getText)
+    ir.UnresolvedConstraint(getTextFromParserRuleContext(ctx))
   }
 
   /**

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
@@ -2,10 +2,12 @@ package com.databricks.labs.remorph.parsers.tsql
 
 import com.databricks.labs.remorph.parsers.tsql.TSqlParser._
 import com.databricks.labs.remorph.parsers.tsql.rules.InsertDefaultsAction
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.parsers.{ParserCommon, intermediate => ir}
 
 import scala.collection.JavaConverters.asScalaBufferConverter
-class TSqlDMLBuilder(vc: TSqlVisitorCoordinator) extends TSqlParserBaseVisitor[ir.Modification] {
+class TSqlDMLBuilder(vc: TSqlVisitorCoordinator)
+    extends TSqlParserBaseVisitor[ir.Modification]
+    with ParserCommon[ir.Modification] {
 
   override def visitDmlClause(ctx: DmlClauseContext): ir.Modification =
     ctx match {
@@ -15,7 +17,7 @@ class TSqlDMLBuilder(vc: TSqlVisitorCoordinator) extends TSqlParserBaseVisitor[i
       case dml if dml.merge() != null => dml.merge().accept(this)
       case dml if dml.update() != null => dml.update().accept(this)
       case bulk if bulk.bulkStatement() != null => bulk.bulkStatement().accept(this)
-      case _ => ir.UnresolvedModification(ctx.getText)
+      case _ => ir.UnresolvedModification(getTextFromParserRuleContext(ctx))
     }
 
   override def visitMerge(ctx: MergeContext): ir.Modification = {

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
@@ -107,16 +107,18 @@ class ExpressionGeneratorTest
 
   "like" should {
     "a LIKE 'b%'" in {
-      ir.Like(ir.UnresolvedAttribute("a"), ir.Literal("b%")) generates "a LIKE 'b%'"
+      ir.Like(ir.UnresolvedAttribute("a"), ir.Literal("b%"), None) generates "a LIKE 'b%'"
     }
     "a LIKE b ESCAPE '/'" in {
-      ir.Like(ir.UnresolvedAttribute("a"), ir.UnresolvedAttribute("b"), '/') generates "a LIKE b ESCAPE '/'"
+      ir.Like(ir.UnresolvedAttribute("a"), ir.UnresolvedAttribute("b"), Some(ir.Literal('/'))) generates
+        "a LIKE b ESCAPE '/'"
     }
     "a ILIKE 'b%'" in {
-      ir.ILike(ir.UnresolvedAttribute("a"), ir.Literal("b%")) generates "a ILIKE 'b%'"
+      ir.ILike(ir.UnresolvedAttribute("a"), ir.Literal("b%"), None) generates "a ILIKE 'b%'"
     }
     "a ILIKE b ESCAPE '/'" in {
-      ir.ILike(ir.UnresolvedAttribute("a"), ir.UnresolvedAttribute("b"), '/') generates "a ILIKE b ESCAPE '/'"
+      ir.ILike(ir.UnresolvedAttribute("a"), ir.UnresolvedAttribute("b"), Some(ir.Literal('/'))) generates
+        "a ILIKE b ESCAPE '/'"
     }
     "a LIKE ANY ('b%', 'c%')" in {
       ir.LikeAny(

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
@@ -162,28 +162,32 @@ class SnowflakeExprSpec extends AnyWordSpec with SnowflakeParserTestCommon with 
 
     "translate LIKE expressions" should {
       "col1 LIKE '%foo'" in {
-        exprAndPredicateExample("col1 LIKE '%foo'", Like(Id("col1"), Literal("%foo")))
+        exprAndPredicateExample("col1 LIKE '%foo'", Like(Id("col1"), Literal("%foo"), None))
       }
       "col1 ILIKE '%foo'" in {
-        exprAndPredicateExample("col1 ILIKE '%foo'", ILike(Id("col1"), Literal("%foo")))
+        exprAndPredicateExample("col1 ILIKE '%foo'", ILike(Id("col1"), Literal("%foo"), None))
       }
       "col1 NOT LIKE '%foo'" in {
-        exprAndPredicateExample("col1 NOT LIKE '%foo'", Not(Like(Id("col1"), Literal("%foo"))))
+        exprAndPredicateExample("col1 NOT LIKE '%foo'", Not(Like(Id("col1"), Literal("%foo"), None)))
       }
       "col1 NOT ILIKE '%foo'" in {
-        exprAndPredicateExample("col1 NOT ILIKE '%foo'", Not(ILike(Id("col1"), Literal("%foo"))))
+        exprAndPredicateExample("col1 NOT ILIKE '%foo'", Not(ILike(Id("col1"), Literal("%foo"), None)))
       }
       "col1 LIKE '%foo' ESCAPE '^'" in {
-        exprAndPredicateExample("col1 LIKE '%foo' ESCAPE '^'", Like(Id("col1"), Literal("%foo"), '^'))
+        exprAndPredicateExample("col1 LIKE '%foo' ESCAPE '^'", Like(Id("col1"), Literal("%foo"), Some(Literal('^'))))
       }
       "col1 ILIKE '%foo' ESCAPE '^'" in {
-        exprAndPredicateExample("col1 ILIKE '%foo' ESCAPE '^'", ILike(Id("col1"), Literal("%foo"), '^'))
+        exprAndPredicateExample("col1 ILIKE '%foo' ESCAPE '^'", ILike(Id("col1"), Literal("%foo"), Some(Literal('^'))))
       }
       "col1 NOT LIKE '%foo' ESCAPE '^'" in {
-        exprAndPredicateExample("col1 NOT LIKE '%foo' ESCAPE '^'", Not(Like(Id("col1"), Literal("%foo"), '^')))
+        exprAndPredicateExample(
+          "col1 NOT LIKE '%foo' ESCAPE '^'",
+          Not(Like(Id("col1"), Literal("%foo"), Some(Literal('^')))))
       }
       "col1 NOT ILIKE '%foo' ESCAPE '^'" in {
-        exprAndPredicateExample("col1 NOT ILIKE '%foo' ESCAPE '^'", Not(ILike(Id("col1"), Literal("%foo"), '^')))
+        exprAndPredicateExample(
+          "col1 NOT ILIKE '%foo' ESCAPE '^'",
+          Not(ILike(Id("col1"), Literal("%foo"), Some(Literal('^')))))
       }
       "col1 LIKE ANY ('%foo', 'bar%', '%qux%')" in {
         exprAndPredicateExample(

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilderSpec.scala
@@ -174,7 +174,7 @@ class TSqlDDLBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         Seq.empty,
         Seq.empty,
         None,
-        Some(Seq(ir.OptionUnresolved("LEDGER=ON")))))
+        Some(Seq(ir.OptionUnresolved("LEDGER = ON")))))
 
   }
 }


### PR DESCRIPTION
Thee IR generation for TSQL predicates was not complete. Here, we implement all of the IR for predicates such as IN, IS, BETWEEN, LIKE....

Additionally the LIKE IR was incorrectly assuming that the ESCAPE character had to be a single character at parse time, but in fact it accepts a full expression which must evaluate to a single character at runtime. We correct that here.

