### PR TITLE
Translation Complexity Analyzer

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/ApplicationContext.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/ApplicationContext.scala
@@ -48,8 +48,11 @@ trait ApplicationContext {
       planParser(dialect),
       new EstimationAnalyzer())
 
-  def jsonEstimationReporter(outputDir: os.Path, estimate: EstimationReport): JsonEstimationReporter =
-    new JsonEstimationReporter(outputDir, estimate)
+  def jsonEstimationReporter(
+      outputDir: os.Path,
+      preserveQueries: Boolean,
+      estimate: EstimationReport): JsonEstimationReporter =
+    new JsonEstimationReporter(outputDir, preserveQueries, estimate)
 
   def consoleEstimationReporter(estimate: EstimationReport): ConsoleEstimationReporter =
     new ConsoleEstimationReporter(estimate)

--- a/core/src/main/scala/com/databricks/labs/remorph/Main.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/Main.scala
@@ -13,7 +13,7 @@ object Main extends App with ApplicationContext {
       coverageTest.run(os.Path(args("src")), os.Path(args("dst")), args("extractor"), args("source-dialect"))
     case Payload("debug-estimate", args) =>
       val report = estimator(args("source-dialect")).run()
-      jsonEstimationReporter(os.Path(args("dst")), report).report()
+      jsonEstimationReporter(os.Path(args("dst")), args("preserve-queries").toBoolean, report).report()
       args("console-output") match {
         case "true" => consoleEstimationReporter(report).report()
       }

--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/EstimationReport.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/EstimationReport.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.coverage
 
-import com.databricks.labs.remorph.coverage.estimation.{SqlComplexity, EstimationStatistics}
+import com.databricks.labs.remorph.coverage.estimation.{EstimationStatistics, SqlComplexity}
 import com.databricks.labs.remorph.discovery.Fingerprint
 import upickle.default.{ReadWriter, macroRW}
 
@@ -13,7 +13,12 @@ case class EstimationReport(
     parseFailures: Int,
     transpileFailures: Int,
     records: Seq[EstimationReportRecord] // The actual records - includes failures
-)
+) {
+
+  def withRecords(newRecords: Seq[EstimationReportRecord]): EstimationReport = {
+    this.copy(records = newRecords)
+  }
+}
 
 object EstimationReport {
   implicit val rw: ReadWriter[EstimationReport] = macroRW
@@ -22,7 +27,11 @@ object EstimationReport {
 @upickle.implicits.serializeDefaults(true)
 case class EstimationReportRecord(
     transpilationReport: EstimationTranspilationReport,
-    analysisReport: EstimationAnalysisReport)
+    analysisReport: EstimationAnalysisReport) {
+  def withQueries(newQuery: String, output: Option[String]): EstimationReportRecord = {
+    this.copy(transpilationReport = transpilationReport.withQueries(newQuery, output))
+  }
+}
 
 object EstimationReportRecord {
   implicit val rw: ReadWriter[EstimationReportRecord] = macroRW
@@ -31,12 +40,18 @@ object EstimationReportRecord {
 @upickle.implicits.serializeDefaults(true)
 case class EstimationTranspilationReport(
     query: Option[String] = None,
+    output: Option[String] = None,
     parsed: Int = 0, // 1 for success, 0 for failure
     statements: Int = 0, // number of statements parsed
     parsing_error: Option[String] = None,
     transpiled: Int = 0, // 1 for success, 0 for failure
     transpiled_statements: Int = 0, // number of statements transpiled
-    transpilation_error: Option[String] = None)
+    transpilation_error: Option[String] = None) {
+
+  def withQueries(newQuery: String, output: Option[String]): EstimationTranspilationReport = {
+    this.copy(query = Some(newQuery), output = output)
+  }
+}
 
 object EstimationTranspilationReport {
   implicit val rw: ReadWriter[EstimationTranspilationReport] = macroRW

--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/EstimationReport.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/EstimationReport.scala
@@ -1,18 +1,19 @@
 package com.databricks.labs.remorph.coverage
 
-import com.databricks.labs.remorph.coverage.estimation.SqlComplexity
+import com.databricks.labs.remorph.coverage.estimation.{SqlComplexity, EstimationStatistics}
 import com.databricks.labs.remorph.discovery.Fingerprint
 import upickle.default.{ReadWriter, macroRW}
 
 @upickle.implicits.serializeDefaults(true)
 case class EstimationReport(
+    overallComplexity: EstimationStatistics,
     dialect: String, // What dialect of SQL is this a report for?
     sampleSize: Int, // How many records were used to estimate
     uniqueSuccesses: Int, // How many unique queries were successfully estimated
     parseFailures: Int,
     transpileFailures: Int,
-    records: Seq[EstimationReportRecord], // The actual records - includes failures
-    overallComplexity: SqlComplexity = SqlComplexity.LOW)
+    records: Seq[EstimationReportRecord] // The actual records - includes failures
+)
 
 object EstimationReport {
   implicit val rw: ReadWriter[EstimationReport] = macroRW
@@ -44,7 +45,8 @@ object EstimationTranspilationReport {
 @upickle.implicits.serializeDefaults(true)
 case class EstimationAnalysisReport(
     fingerprint: Option[Fingerprint] = None,
-    complexity: SqlComplexity = SqlComplexity.LOW)
+    complexity: SqlComplexity = SqlComplexity.LOW,
+    score: Int = 10)
 
 object EstimationAnalysisReport {
   implicit val rw: ReadWriter[EstimationAnalysisReport] = macroRW

--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/EstimationAnalyzer.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/EstimationAnalyzer.scala
@@ -18,7 +18,15 @@ object SqlComplexity {
     macroRW[SqlComplexity.VERY_COMPLEX.type])
 }
 
+case class SourceTextComplexity(lineCount: Int, textLength: Int)
+
 class EstimationAnalyzer extends LazyLogging {
   // TODO: We will do this and the rest of the analysis in the next PR
   def countStatements(plan: ir.LogicalPlan): Int = 1
+
+  def estimateComplexity(plan: ir.LogicalPlan): SqlComplexity = SqlComplexity.LOW
+
+  def sourceTextComplexity(query: String): SourceTextComplexity = {
+    SourceTextComplexity(query.split("\n").length, query.length)
+  }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/EstimationAnalyzer.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/EstimationAnalyzer.scala
@@ -107,26 +107,22 @@ class EstimationAnalyzer extends LazyLogging {
 
   private def logicalPlanEvaluator: PartialFunction[LogicalPlan, Int] = { case lp: LogicalPlan =>
     try {
-      // scalastyle:off println
-      println(lp)
-      // scalastyle:on println
       1
     } catch {
       case _: Throwable => 5
     }
   }
 
-  def expressionEvaluator: PartialFunction[Expression, Int] = { case expr: Expression =>
+  private def expressionEvaluator: PartialFunction[Expression, Int] = { case expr: Expression =>
     try {
-      // scalastyle:off println
-      println(expr)
-      // scalastyle:on println
       1
     } catch {
       case _: Throwable => 5
     }
   }
 
+  // TODO: Verify these calculations and decide if they are all needed or not. May not harm to keep them around anyway
+  // TODO: calculate complexity using above stats not just the median score
   def summarizeComplexity(reportEntries: Seq[EstimationReportRecord]): EstimationStatistics = {
     val scores = reportEntries.map(_.analysisReport.score)
 
@@ -152,7 +148,7 @@ class EstimationAnalyzer extends LazyLogging {
 
     // Percentiles
     def percentile(p: Double): Double = {
-      val k = (p * (sortedScores.size - 1) + 1).toInt - 1
+      val k = (p * (sortedScores.size - 1)).toInt
       sortedScores(k)
     }
     val percentile25 = percentile(0.25)
@@ -160,7 +156,7 @@ class EstimationAnalyzer extends LazyLogging {
     val percentile75 = percentile(0.75)
 
     // Geometric Mean
-    val geometricMeanScore = math.pow(scores.product.toDouble, 1.0 / scores.size)
+    val geometricMeanScore = math.pow(scores.map(_.toDouble).product, 1.0 / scores.size)
 
     EstimationStatistics(
       medianScore,
@@ -171,7 +167,6 @@ class EstimationAnalyzer extends LazyLogging {
       percentile50,
       percentile75,
       geometricMeanScore,
-      SqlComplexity.fromScore(medianScore)
-    ) // TODO: calculate complexity using above stats not just the median
+      SqlComplexity.fromScore(medianScore))
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/EstimationAnalyzer.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/EstimationAnalyzer.scala
@@ -1,5 +1,8 @@
 package com.databricks.labs.remorph.coverage.estimation
 
+import com.databricks.labs.remorph.coverage.EstimationReportRecord
+import com.databricks.labs.remorph.discovery.ExecutedQuery
+import com.databricks.labs.remorph.parsers.intermediate.{Expression, LogicalPlan, TreeNode}
 import com.databricks.labs.remorph.parsers.{intermediate => ir}
 import com.typesafe.scalalogging.LazyLogging
 import upickle.default._
@@ -11,6 +14,14 @@ object SqlComplexity {
   case object COMPLEX extends SqlComplexity
   case object VERY_COMPLEX extends SqlComplexity
 
+  // TODO: Define the scores for each complexity level
+  def fromScore(score: Int): SqlComplexity = score match {
+    case s if s < 10 => LOW
+    case s if s < 20 => MEDIUM
+    case s if s < 30 => COMPLEX
+    case _ => VERY_COMPLEX
+  }
+
   implicit val rw: ReadWriter[SqlComplexity] = ReadWriter.merge(
     macroRW[SqlComplexity.LOW.type],
     macroRW[SqlComplexity.MEDIUM.type],
@@ -18,15 +29,149 @@ object SqlComplexity {
     macroRW[SqlComplexity.VERY_COMPLEX.type])
 }
 
+case class ComplexityEstimate(complexity: SqlComplexity, statementCount: Int, charCount: Int, lineCount: Int)
 case class SourceTextComplexity(lineCount: Int, textLength: Int)
+
+case class EstimationStatistics(
+    medianScore: Int,
+    meanScore: Double,
+    modeScore: Int,
+    stdDeviation: Double,
+    percentile25: Double,
+    percentile50: Double,
+    percentile75: Double,
+    geometricMeanScore: Double,
+    complexity: SqlComplexity)
+
+object EstimationStatistics {
+  implicit val rw: ReadWriter[EstimationStatistics] = macroRW
+}
 
 class EstimationAnalyzer extends LazyLogging {
   // TODO: We will do this and the rest of the analysis in the next PR
   def countStatements(plan: ir.LogicalPlan): Int = 1
 
-  def estimateComplexity(plan: ir.LogicalPlan): SqlComplexity = SqlComplexity.LOW
+  def estimateComplexity(query: ExecutedQuery, plan: ir.LogicalPlan): ComplexityEstimate = {
+    val s = sourceTextComplexity(query.source)
+    ComplexityEstimate(SqlComplexity.LOW, countStatements(plan), s.textLength, s.lineCount)
+  }
 
+  def evaluateTree(node: TreeNode[_]): Int = {
+    evaluateTree(node, logicalPlanEvaluator, expressionEvaluator)
+  }
+
+  def evaluateTree(
+      node: TreeNode[_],
+      logicalPlanVisitor: PartialFunction[LogicalPlan, Int],
+      expressionVisitor: PartialFunction[Expression, Int]): Int = {
+    if (node == null) return 0 // Return 0 if the node is null
+
+    node match {
+      case lp: LogicalPlan =>
+        if (lp.children == null) return 0
+        val currentValue = if (logicalPlanVisitor.isDefinedAt(lp)) logicalPlanVisitor(lp) else 0
+        val childrenValue = lp.children.map(child => evaluateTree(child, logicalPlanVisitor, expressionVisitor)).sum
+        val expressionsValue = lp.expressions.map(expr => evaluateTree(expr, logicalPlanVisitor, expressionVisitor)).sum
+        currentValue + childrenValue + expressionsValue
+
+      case expr: Expression =>
+        if (expr.children == null) return 0
+        val currentValue = if (expressionVisitor.isDefinedAt(expr)) expressionVisitor(expr) else 0
+        val childrenValue = expr.children.map(child => evaluateTree(child, logicalPlanVisitor, expressionVisitor)).sum
+        currentValue + childrenValue
+
+      case _ =>
+        throw new IllegalArgumentException(s"Unsupported node type: ${node.getClass.getSimpleName}")
+    }
+  }
+
+  /**
+   * <p>
+   *   Given the raw query text, produce some statistics that are purely derived from the text, rather than
+   *   a parsed plan or translation result.
+   * </p>
+   * <p>
+   *   Text complexity is just one component for the overall score of a query, but it can be a good indicator
+   *   of how complex the query is in terms of a human translating it. For example, a query with many lines
+   *   and a lot of text is likely to take some time to manually translate, even if there are no complex
+   *   expressions, UDFs or subqueries. Text length is of little consequence to the transpiler if it is
+   *   successful in parsing but there is.
+   * </p>
+   *
+   * @param query the raw text of the query
+   * @return a set of statistics about the query text
+   */
   def sourceTextComplexity(query: String): SourceTextComplexity = {
     SourceTextComplexity(query.split("\n").length, query.length)
+  }
+
+  private def logicalPlanEvaluator: PartialFunction[LogicalPlan, Int] = { case lp: LogicalPlan =>
+    try {
+      // scalastyle:off println
+      println(lp)
+      // scalastyle:on println
+      1
+    } catch {
+      case _: Throwable => 5
+    }
+  }
+
+  def expressionEvaluator: PartialFunction[Expression, Int] = { case expr: Expression =>
+    try {
+      // scalastyle:off println
+      println(expr)
+      // scalastyle:on println
+      1
+    } catch {
+      case _: Throwable => 5
+    }
+  }
+
+  def summarizeComplexity(reportEntries: Seq[EstimationReportRecord]): EstimationStatistics = {
+    val scores = reportEntries.map(_.analysisReport.score)
+
+    // Median
+    val sortedScores = scores.sorted
+    val medianScore = if (sortedScores.size % 2 == 1) {
+      sortedScores(sortedScores.size / 2)
+    } else {
+      val (up, down) = sortedScores.splitAt(sortedScores.size / 2)
+      (up.last + down.head) / 2
+    }
+
+    // Mean
+    val meanScore = scores.sum.toDouble / scores.size
+
+    // Mode
+    val modeScore = scores.groupBy(identity).maxBy(_._2.size)._1
+
+    // Standard Deviation
+    val mean = scores.sum.toDouble / scores.size
+    val variance = scores.map(score => math.pow(score - mean, 2)).sum / scores.size
+    val stdDeviation = math.sqrt(variance)
+
+    // Percentiles
+    def percentile(p: Double): Double = {
+      val k = (p * (sortedScores.size - 1) + 1).toInt - 1
+      sortedScores(k)
+    }
+    val percentile25 = percentile(0.25)
+    val percentile50 = percentile(0.50) // Same as median
+    val percentile75 = percentile(0.75)
+
+    // Geometric Mean
+    val geometricMeanScore = math.pow(scores.product.toDouble, 1.0 / scores.size)
+
+    EstimationStatistics(
+      medianScore,
+      meanScore,
+      modeScore,
+      stdDeviation,
+      percentile25,
+      percentile50,
+      percentile75,
+      geometricMeanScore,
+      SqlComplexity.fromScore(medianScore)
+    ) // TODO: calculate complexity using above stats not just the median
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/EstimationReporter.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/EstimationReporter.scala
@@ -27,9 +27,35 @@ class JsonEstimationReporter(outputDir: os.Path, preserveQueries: Boolean, estim
     extends EstimationReporter {
   override def report(): Unit = {
     val now = Instant.now
-    os.makeDir.all(outputDir)
-    val resultPath = outputDir / s"${estimate.dialect}_${now.getEpochSecond}.json"
-    val jsonReport: String = write(estimate, indent = 4)
+    val queriesDir = outputDir / s"${now.getEpochSecond}" / "queries"
+    os.makeDir.all(queriesDir)
+    val resultPath = outputDir / s"${now.getEpochSecond}" / s"${estimate.dialect}.json"
+
+    // Iterate over the records and modify the transpilationReport.query field
+    var count = 0
+    val newRecords = estimate.records.map { record =>
+      if (preserveQueries) {
+        val (queryFilePath, outputFilepath) = record.analysisReport.fingerprint match {
+          case Some(fingerprint) =>
+            (queriesDir / s"${fingerprint.fingerprint}.sql", queriesDir / s"${fingerprint.fingerprint}_transpiled.sql")
+          case None =>
+            count += 1
+            (queriesDir / s"parse_fail_${count}.sql", null) // No output file for failed transpiles
+        }
+        os.write(queryFilePath, record.transpilationReport.query)
+        record.transpilationReport.output match {
+          case Some(output) =>
+            os.write(outputFilepath, output)
+            record.withQueries(queryFilePath.toString, Some(outputFilepath.toString))
+          case None =>
+            record.withQueries(queryFilePath.toString, None)
+        }
+      } else {
+        record.withQueries("<redacted>", None)
+      }
+    }
+    val newEstimate = estimate.withRecords(newRecords)
+    val jsonReport: String = write(newEstimate, indent = 4)
     os.write(resultPath, jsonReport)
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/EstimationReporter.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/EstimationReporter.scala
@@ -17,13 +17,14 @@ class ConsoleEstimationReporter(estimate: EstimationReport) extends EstimationRe
     println(s"Unique successful parses : ${estimate.uniqueSuccesses}")
     println(s"Parse failures           : ${estimate.parseFailures}")
     println(s"Transpile failures       : ${estimate.transpileFailures}")
-    println(s"Overall complexity       : ${estimate.overallComplexity}")
+    println(s"Overall complexity       : ${estimate.overallComplexity.complexity}")
     println()
     // scalastyle:on println
   }
 }
 
-class JsonEstimationReporter(outputDir: os.Path, estimate: EstimationReport) extends EstimationReporter {
+class JsonEstimationReporter(outputDir: os.Path, preserveQueries: Boolean, estimate: EstimationReport)
+    extends EstimationReporter {
   override def report(): Unit = {
     val now = Instant.now
     os.makeDir.all(outputDir)

--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/Estimator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/Estimator.scala
@@ -97,7 +97,7 @@ class Estimator(queryHistory: QueryHistoryProvider, planParser: PlanParser[_], a
             score = score + 100,
             complexity = SqlComplexity.fromScore(score)))
 
-      case Success(_: String) =>
+      case Success(output: String) =>
         // A successful transpilation means that we can reduce the score because the query seems
         // to be successfully translated. However, that does not mean that it scores 0 because there
         // will be some effort required to verify the translation.
@@ -105,6 +105,8 @@ class Estimator(queryHistory: QueryHistoryProvider, planParser: PlanParser[_], a
         val statCount = analyzer.countStatements(plan)
         EstimationReportRecord(
           EstimationTranspilationReport(
+            query = Some(query.source),
+            output = Some(output),
             statements = statCount,
             transpiled = 1,
             transpiled_statements = statCount,

--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/Estimator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/Estimator.scala
@@ -28,9 +28,10 @@ class Estimator(queryHistory: QueryHistoryProvider, planParser: PlanParser[_], a
       parseFailures = parseFailures,
       transpileFailures = transpileFailures,
       records = reportEntries,
-      overallComplexity = SqlComplexity.LOW // Will calculate this later
-    )
+      overallComplexity = analyzer.summarizeComplexity(reportEntries))
   }
+
+  // TODO: Remove hard coding of scores and record all scoring reports
 
   private def processQuery(
       query: ExecutedQuery,
@@ -41,19 +42,25 @@ class Estimator(queryHistory: QueryHistoryProvider, planParser: PlanParser[_], a
         Some(
           EstimationReportRecord(
             EstimationTranspilationReport(Some(query.source), statements = 1, parsing_error = Some(errorJson)),
-            EstimationAnalysisReport()))
+            EstimationAnalysisReport(score = 1000, complexity = SqlComplexity.VERY_COMPLEX)))
 
       case Failure(PLAN, errorJson) =>
         Some(
           EstimationReportRecord(
             EstimationTranspilationReport(Some(query.source), statements = 1, transpilation_error = Some(errorJson)),
-            EstimationAnalysisReport()))
+            EstimationAnalysisReport(score = 1000, complexity = SqlComplexity.VERY_COMPLEX)))
 
       case Success(plan) =>
         val queryHash = anonymizer(plan)
+        // scalastyle:off println
+        println(s"Query: ${query.source}")
+        val sourceTextComplexity = analyzer.sourceTextComplexity(query.source)
+        val score = analyzer.evaluateTree(plan) + analyzer.countStatements(
+          plan) + sourceTextComplexity.textLength + sourceTextComplexity.lineCount
+        // scalastyle:on println
         if (!parsedSet.contains(queryHash)) {
           parsedSet += queryHash
-          Some(generateReportRecord(query, plan, anonymizer))
+          Some(generateReportRecord(query, plan, score, anonymizer))
         } else {
           None
         }
@@ -65,26 +72,36 @@ class Estimator(queryHistory: QueryHistoryProvider, planParser: PlanParser[_], a
               query = Some(query.source),
               statements = 1,
               parsing_error = Some("Unexpected result from parse phase")),
-            EstimationAnalysisReport()))
+            EstimationAnalysisReport(score = 1000, complexity = SqlComplexity.VERY_COMPLEX)))
     }
   }
 
   private def generateReportRecord(
       query: ExecutedQuery,
       plan: LogicalPlan,
+      score: Int,
       anonymizer: Anonymizer): EstimationReportRecord = {
     val generator = new SqlGenerator
     planParser.optimize(plan).flatMap(generator.generate) match {
       case Failure(_, errorJson) =>
+        // Failure to transpile means that we need to increase the score as it will take some
+        // time to manually investigate and fix the issue
         EstimationReportRecord(
           EstimationTranspilationReport(
             query = Some(query.source),
             statements = 1,
             parsed = 1,
             transpilation_error = Some(errorJson)),
-          EstimationAnalysisReport(fingerprint = Some(anonymizer(query, plan))))
+          EstimationAnalysisReport(
+            fingerprint = Some(anonymizer(query, plan)),
+            score = score + 100,
+            complexity = SqlComplexity.fromScore(score)))
 
       case Success(_: String) =>
+        // A successful transpilation means that we can reduce the score because the query seems
+        // to be successfully translated. However, that does not mean that it scores 0 because there
+        // will be some effort required to verify the translation.
+        val newScore = math.max(score * 0.1, 5).toInt
         val statCount = analyzer.countStatements(plan)
         EstimationReportRecord(
           EstimationTranspilationReport(
@@ -92,7 +109,10 @@ class Estimator(queryHistory: QueryHistoryProvider, planParser: PlanParser[_], a
             transpiled = 1,
             transpiled_statements = statCount,
             parsed = 1),
-          EstimationAnalysisReport(fingerprint = Some(anonymizer(query, plan))))
+          EstimationAnalysisReport(
+            fingerprint = Some(anonymizer(query, plan)),
+            SqlComplexity.fromScore(newScore),
+            newScore))
 
       case _ =>
         EstimationReportRecord(
@@ -101,7 +121,10 @@ class Estimator(queryHistory: QueryHistoryProvider, planParser: PlanParser[_], a
             statements = 1,
             parsed = 1,
             transpilation_error = Some("Unexpected result from transpilation")),
-          EstimationAnalysisReport(fingerprint = Some(anonymizer(query, plan))))
+          EstimationAnalysisReport(
+            fingerprint = Some(anonymizer(query, plan)),
+            score = 1000,
+            complexity = SqlComplexity.VERY_COMPLEX))
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/discovery/Anonymizer.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/discovery/Anonymizer.scala
@@ -80,12 +80,14 @@ class Anonymizer(parser: PlanParser[_]) extends LazyLogging {
 
   /**
    * <p>
-   * Provide a generic hash for the given plan
-   * </p><p>
-   * Before hashing the plan, we replace all literals with a placeholder. This way we can hash the plan
-   * without worrying about the actual values and will generate the same hash code for queries that only
-   * differ by literal values.
-   * </p><p>
+   *   Provide a generic hash for the given plan
+   * </p>
+   * <p>
+   *   Before hashing the plan, we replace all literals with a placeholder. This way we can hash the plan
+   *   without worrying about the actual values and will generate the same hash code for queries that only
+   *   differ by literal values.
+   * </p>
+   * <p>
    *   This is a very simple anonymization technique, but it's good enough for our purposes.
    *   e.g. ... "LIMIT 500 OFFSET 0" and "LIMIT 100 OFFSET 20" will have
    *   the same fingerprint.

--- a/core/src/main/scala/com/databricks/labs/remorph/discovery/SnowflakeQueryHistory.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/discovery/SnowflakeQueryHistory.scala
@@ -27,6 +27,8 @@ class SnowflakeQueryHistory(conn: Connection) extends QueryHistoryProvider {
            |    QUERY_TEXT != ''  -- Many system queries are empty
            |  AND
            |    QUERY_TEXT != '<redacted>' -- Certain queries are completely redacted
+           |  AND
+           |    QUERY_TEXT IS NOT NULL
            |ORDER BY
            |  START_TIME
            |""".stripMargin)

--- a/core/src/test/scala/com/databricks/labs/remorph/discovery/AnonymizerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/discovery/AnonymizerTest.scala
@@ -21,6 +21,7 @@ class AnonymizerTest extends AnyWordSpec with Matchers {
 
       anonymizer.fingerprint(query) should equal(
         Fingerprint(
+          "id",
           new Timestamp(1725032011000L),
           "4e1ebb6993509ec6bb977224ecec02fc9bb6f118",
           Duration.ofMillis(300),
@@ -42,6 +43,7 @@ class AnonymizerTest extends AnyWordSpec with Matchers {
 
       anonymizer.fingerprint(query) should equal(
         Fingerprint(
+          "id",
           new Timestamp(1725032011000L),
           "828f7eb7d417310ab5c1673c96ec82c47f0231e4",
           Duration.ofMillis(300),
@@ -57,6 +59,7 @@ class AnonymizerTest extends AnyWordSpec with Matchers {
 
       anonymizer.fingerprint(query) should equal(
         Fingerprint(
+          "id",
           new Timestamp(1725032011000L),
           "unknown",
           Duration.ofMillis(300),


### PR DESCRIPTION
Here, we create a query analyzer to extend the current analysis of a translation source query history. 

The complexity analysis is intended as a guide to members of a translation project as to how much work is involved in converting the source system's SQL to Databricks SQL.

This version of the analyzer establishes the framework for assessing and reporting query complexity, but it does not yet attempt to ascribe rules to the analysis of the plan in order to accumulate an overall complexity score. As such, the output from this version of the analyzer is not useful as complexity measure, but will become so when we add properly though t out rules about what scores each element of a query should contribute to the overall score. 

For instance:

 - what score does being unable to parse the query give vs parsing but falling to generate? 
 - what score does a simple AND condition contribute vs a chain of CASEs?
 - and so on...