### PR TITLE
Move intermediate package out of parsers

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/Estimator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/Estimator.scala
@@ -3,7 +3,7 @@ package com.databricks.labs.remorph.coverage.estimation
 import com.databricks.labs.remorph.coverage._
 import com.databricks.labs.remorph.discovery.{Anonymizer, ExecutedQuery, QueryHistoryProvider}
 import com.databricks.labs.remorph.parsers.PlanParser
-import com.databricks.labs.remorph.parsers.intermediate.LogicalPlan
+import com.databricks.labs.remorph.intermediate.LogicalPlan
 import com.databricks.labs.remorph.transpilers.Result.{Failure, Success}
 import com.databricks.labs.remorph.transpilers.WorkflowStage.{PARSE, PLAN}
 import com.databricks.labs.remorph.transpilers.{SourceCode, SqlGenerator}

--- a/core/src/main/scala/com/databricks/labs/remorph/discovery/Anonymizer.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/discovery/Anonymizer.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.discovery
 
 import com.databricks.labs.remorph.parsers.PlanParser
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 import com.databricks.labs.remorph.transpilers.WorkflowStage.PARSE
 import com.databricks.labs.remorph.transpilers.{Result, SourceCode}
 import com.typesafe.scalalogging.LazyLogging

--- a/core/src/main/scala/com/databricks/labs/remorph/discovery/SnowflakeTableDefinitions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/discovery/SnowflakeTableDefinitions.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.discovery
 
-import com.databricks.labs.remorph.parsers.intermediate.{DataType, StructField}
+import com.databricks.labs.remorph.intermediate.{DataType, StructField}
 import com.databricks.labs.remorph.parsers.snowflake.{SnowflakeLexer, SnowflakeParser}
 import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeTypeBuilder

--- a/core/src/main/scala/com/databricks/labs/remorph/discovery/queries.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/discovery/queries.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.discovery
 
-import com.databricks.labs.remorph.parsers.intermediate.StructField
+import com.databricks.labs.remorph.intermediate.StructField
 
 import java.sql.Timestamp
 import java.time.Duration

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/Generator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/Generator.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.generators
 
-import com.databricks.labs.remorph.parsers.intermediate.TreeNode
+import com.databricks.labs.remorph.intermediate.TreeNode
 import com.databricks.labs.remorph.transpilers.TranspileException
 
 trait Generator[In <: TreeNode[In], Out] {

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/GeneratorContext.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/GeneratorContext.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.generators
 
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 
 case class GeneratorContext(
     logical: Generator[ir.LogicalPlan, String],

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/DataTypeGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/DataTypeGenerator.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.generators.sql
 
 import com.databricks.labs.remorph.generators.GeneratorContext
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import com.databricks.labs.remorph.transpilers.TranspileException
 
 /**

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/ExpressionGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/ExpressionGenerator.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.generators.sql
 
 import com.databricks.labs.remorph.generators.{Generator, GeneratorContext}
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import com.databricks.labs.remorph.transpilers.TranspileException
 
 import java.time._

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.generators.sql
 
 import com.databricks.labs.remorph.generators.{Generator, GeneratorContext}
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import com.databricks.labs.remorph.transpilers.TranspileException
 
 class LogicalPlanGenerator(

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/OptionGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/OptionGenerator.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.generators.sql
 
 import com.databricks.labs.remorph.generators.GeneratorContext
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 
 class OptionGenerator(expr: ExpressionGenerator) {
 

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/IRHelpers.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/IRHelpers.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 trait IRHelpers {
 

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/commands.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/commands.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 trait Command extends LogicalPlan {
   def output: Seq[Attribute] = Seq.empty

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/common.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/common.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 case class StorageLevel(
     use_disk: Boolean,

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/ddl.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/ddl.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 abstract class DataType {
   def isPrimitive: Boolean = this match {

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/dml.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/dml.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 // Used for DML other than SELECT
 abstract class Modification extends LogicalPlan

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/expressions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/expressions.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 import java.util.{UUID}
 

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/extensions.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 trait AstExtension
 

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/functions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/functions.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 import com.databricks.labs.remorph.transpilers.TranspileException
 

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/literals.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/literals.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 import java.time.ZoneOffset
 

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/operators.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/operators.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 trait Predicate extends AstExtension {
   def dataType: DataType = BooleanType

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/options.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/options.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 trait GenericOption {
   def id: String

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/plans.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/plans.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 /**
  * A [[Plan]] is the structure that carries the runtime information for the execution from the client to the server. A

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/relations.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/relations.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 abstract class Relation extends LogicalPlan
 

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/rules.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/rules.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 abstract class Rule[T <: TreeNode[_]] {
   val ruleName: String = {

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/subqueries.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/subqueries.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 abstract class SubqueryExpression(plan: LogicalPlan) extends Expression {
   override def children: Seq[Expression] = plan.expressions // TODO: not sure if this is a good idea

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/trees.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/trees.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 import com.databricks.labs.remorph.utils.Strings.truncatedString
 

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/unresolved.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/unresolved.scala
@@ -1,4 +1,4 @@
-package com.databricks.labs.remorph.parsers.intermediate
+package com.databricks.labs.remorph.intermediate
 
 case class UnresolvedRelation(inputText: String) extends LeafNode {
   override def output: Seq[Attribute] = Seq.empty

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/ConversionStrategy.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/ConversionStrategy.scala
@@ -1,5 +1,5 @@
 package com.databricks.labs.remorph.parsers
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 
 import java.util.Locale
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/FunctionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/FunctionBuilder.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.parsers
 
 import com.databricks.labs.remorph.parsers.snowflake.NamedArgumentExpression
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 
 sealed trait FunctionType
 case object StandardFunction extends FunctionType

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/PlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/PlanParser.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers
 
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import com.databricks.labs.remorph.transpilers.{Result, SourceCode, WorkflowStage}
 import org.antlr.v4.runtime.{CharStream, CharStreams, CommonTokenStream, Parser, ParserRuleContext, TokenSource, TokenStream}
 import org.json4s.jackson.Serialization

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
@@ -1,7 +1,8 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser._
-import com.databricks.labs.remorph.parsers.{ParserCommon, intermediate => ir}
+import com.databricks.labs.remorph.parsers.ParserCommon
+import com.databricks.labs.remorph.{intermediate => ir}
 
 import scala.collection.JavaConverters._
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilder.scala
@@ -1,7 +1,8 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser._
-import com.databricks.labs.remorph.parsers.{IncompleteParser, ParserCommon, intermediate => ir}
+import com.databricks.labs.remorph.parsers.{IncompleteParser, ParserCommon}
+import com.databricks.labs.remorph.{intermediate => ir}
 
 class SnowflakeCommandBuilder
     extends SnowflakeParserBaseVisitor[ir.Command]

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
@@ -1,7 +1,8 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser.{StringContext => StrContext, _}
-import com.databricks.labs.remorph.parsers.{IncompleteParser, ParserCommon, intermediate => ir}
+import com.databricks.labs.remorph.parsers.{IncompleteParser, ParserCommon}
+import com.databricks.labs.remorph.{intermediate => ir}
 
 import scala.collection.JavaConverters._
 class SnowflakeDDLBuilder

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilder.scala
@@ -1,8 +1,9 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
 import SnowflakeParser._
-import com.databricks.labs.remorph.parsers.intermediate.IRHelpers
-import com.databricks.labs.remorph.parsers.{ParserCommon, intermediate => ir}
+import com.databricks.labs.remorph.intermediate.IRHelpers
+import com.databricks.labs.remorph.parsers.ParserCommon
+import com.databricks.labs.remorph.{intermediate => ir}
 
 import scala.collection.JavaConverters._
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -1,8 +1,8 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
-import com.databricks.labs.remorph.parsers.intermediate.UnresolvedType
+import com.databricks.labs.remorph.{intermediate => ir}
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser.{StringContext => _, _}
-import com.databricks.labs.remorph.parsers.{IncompleteParser, ParserCommon, intermediate => ir}
+import com.databricks.labs.remorph.parsers.{IncompleteParser, ParserCommon}
 import org.antlr.v4.runtime.Token
 
 import java.time.LocalDateTime
@@ -288,7 +288,7 @@ class SnowflakeExpressionBuilder()
 
   override def visitArrayLiteral(ctx: ArrayLiteralContext): ir.Expression = {
     val elements = ctx.literal().asScala.map(visitLiteral).toList.toSeq
-    val dataType = elements.headOption.map(_.dataType).getOrElse(UnresolvedType)
+    val dataType = elements.headOption.map(_.dataType).getOrElse(ir.UnresolvedType)
     ir.ArrayExpr(elements, dataType)
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeFunctionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeFunctionBuilder.scala
@@ -1,7 +1,8 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeFunctionConverters.SynonymOf
-import com.databricks.labs.remorph.parsers.{ConversionStrategy, FunctionBuilder, FunctionDefinition, intermediate => ir}
+import com.databricks.labs.remorph.parsers.{ConversionStrategy, FunctionBuilder, FunctionDefinition}
+import com.databricks.labs.remorph.{intermediate => ir}
 
 class SnowflakeFunctionBuilder extends FunctionBuilder {
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakePlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakePlanParser.scala
@@ -1,9 +1,9 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
 import com.databricks.labs.remorph.generators.sql.{ExpressionGenerator, LogicalPlanGenerator, OptionGenerator}
-import com.databricks.labs.remorph.parsers.intermediate.LogicalPlan
+import com.databricks.labs.remorph.{intermediate => ir}
 import com.databricks.labs.remorph.parsers.snowflake.rules._
-import com.databricks.labs.remorph.parsers.{PlanParser, intermediate => ir}
+import com.databricks.labs.remorph.parsers.PlanParser
 import org.antlr.v4.runtime.{CharStream, ParserRuleContext, TokenSource, TokenStream}
 
 class SnowflakePlanParser extends PlanParser[SnowflakeParser] {
@@ -16,7 +16,7 @@ class SnowflakePlanParser extends PlanParser[SnowflakeParser] {
   override protected def createLexer(input: CharStream): TokenSource = new SnowflakeLexer(input)
   override protected def createParser(stream: TokenStream): SnowflakeParser = new SnowflakeParser(stream)
   override protected def createTree(parser: SnowflakeParser): ParserRuleContext = parser.snowflakeFile()
-  override protected def createPlan(tree: ParserRuleContext): LogicalPlan = astBuilder.visit(tree)
+  override protected def createPlan(tree: ParserRuleContext): ir.LogicalPlan = astBuilder.visit(tree)
   override protected def addErrorStrategy(parser: SnowflakeParser): Unit =
     parser.setErrorHandler(new SnowflakeErrorStrategy)
   def dialect: String = "snowflake"

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
@@ -1,7 +1,8 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser._
-import com.databricks.labs.remorph.parsers.{IncompleteParser, ParserCommon, intermediate => ir}
+import com.databricks.labs.remorph.parsers.{IncompleteParser, ParserCommon}
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.antlr.v4.runtime.ParserRuleContext
 
 import scala.collection.JavaConverters._

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeTypeBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeTypeBuilder.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser.DataTypeContext
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 
 import scala.collection.JavaConverters._
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/expressions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/expressions.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 
 case class NamedArgumentExpression(key: String, value: ir.Expression) extends ir.Expression {
   override def children: Seq[ir.Expression] = value :: Nil

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/CastParseJsonToFromJson.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/CastParseJsonToFromJson.scala
@@ -2,7 +2,7 @@ package com.databricks.labs.remorph.parsers.snowflake.rules
 
 import com.databricks.labs.remorph.generators.{Generator, GeneratorContext}
 import com.databricks.labs.remorph.generators.sql.DataTypeGenerator
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 
 class CastParseJsonToFromJson(logical: Generator[LogicalPlan, String]) extends Rule[LogicalPlan] {
   private val ctx = GeneratorContext(logical)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/CompactJsonAccess.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/CompactJsonAccess.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake.rules
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 
 class CompactJsonAccess extends Rule[LogicalPlan] with IRHelpers {
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformAllExpressions { case expression: Expression =>

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/ConvertFractionalSecond.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/ConvertFractionalSecond.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake.rules
 
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 
 class ConvertFractionalSecond extends ir.Rule[ir.LogicalPlan] {
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/FlattenLateralViewToExplode.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/FlattenLateralViewToExplode.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake.rules
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 import com.databricks.labs.remorph.parsers.snowflake.NamedArgumentExpression
 
 // @see https://docs.snowflake.com/en/sql-reference/functions/flatten

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/FlattenNestedConcat.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/FlattenNestedConcat.scala
@@ -1,5 +1,5 @@
 package com.databricks.labs.remorph.parsers.snowflake.rules
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 
 /**
  * Flattens nested invocations of CONCAT into a single one. For example, `CONCAT(CONCAT(a, b), CONCAT(c, d))` becomes

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/SnowflakeCallMapper.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/SnowflakeCallMapper.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake.rules
 
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import com.databricks.labs.remorph.transpilers.TranspileException
 
 import java.time.format.DateTimeFormatter

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/SnowflakeTimeUnits.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/SnowflakeTimeUnits.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.parsers.snowflake.rules
 
-import com.databricks.labs.remorph.parsers.intermediate.IRHelpers
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.intermediate.IRHelpers
+import com.databricks.labs.remorph.{intermediate => ir}
 import com.databricks.labs.remorph.transpilers.TranspileException
 
 object SnowflakeTimeUnits extends IRHelpers {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/TranslateWithinGroup.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/TranslateWithinGroup.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.parsers.snowflake.rules
 
-import com.databricks.labs.remorph.parsers.intermediate.UnresolvedNamedLambdaVariable
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.intermediate.UnresolvedNamedLambdaVariable
+import com.databricks.labs.remorph.{intermediate => ir}
 
 import scala.annotation.tailrec
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/UpdateToMerge.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/rules/UpdateToMerge.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake.rules
 
-import com.databricks.labs.remorph.parsers.intermediate.{Assign, Expression, Join, LogicalPlan, MergeAction, MergeIntoTable, Noop, NoopNode, Rule, UpdateAction, UpdateTable}
+import com.databricks.labs.remorph.intermediate.{Assign, Expression, Join, LogicalPlan, MergeAction, MergeIntoTable, Noop, NoopNode, Rule, UpdateAction, UpdateTable}
 
 class UpdateToMerge extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan transform {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/DataTypeBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/DataTypeBuilder.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.parsers.tsql
 
 import com.databricks.labs.remorph.parsers.tsql.TSqlParser.DataTypeContext
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 
 class DataTypeBuilder {
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/OptionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/OptionBuilder.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.parsers.tsql
 
 import com.databricks.labs.remorph.parsers.tsql.TSqlParser.GenericOptionContext
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 
 class OptionBuilder(vc: TSqlVisitorCoordinator) {
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilder.scala
@@ -1,6 +1,7 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.{ParserCommon, intermediate => ir}
+import com.databricks.labs.remorph.parsers.ParserCommon
+import com.databricks.labs.remorph.{intermediate => ir}
 
 import scala.collection.JavaConverters.asScalaBufferConverter
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilder.scala
@@ -1,6 +1,7 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.{ParserCommon, intermediate => ir}
+import com.databricks.labs.remorph.parsers.ParserCommon
+import com.databricks.labs.remorph.{intermediate => ir}
 
 import scala.collection.JavaConverters.asScalaBufferConverter
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
@@ -2,7 +2,8 @@ package com.databricks.labs.remorph.parsers.tsql
 
 import com.databricks.labs.remorph.parsers.tsql.TSqlParser._
 import com.databricks.labs.remorph.parsers.tsql.rules.InsertDefaultsAction
-import com.databricks.labs.remorph.parsers.{ParserCommon, intermediate => ir}
+import com.databricks.labs.remorph.parsers.ParserCommon
+import com.databricks.labs.remorph.{intermediate => ir}
 
 import scala.collection.JavaConverters.asScalaBufferConverter
 class TSqlDMLBuilder(vc: TSqlVisitorCoordinator)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -1,7 +1,8 @@
 package com.databricks.labs.remorph.parsers.tsql
 
 import com.databricks.labs.remorph.parsers.tsql.TSqlParser._
-import com.databricks.labs.remorph.parsers.{ParserCommon, XmlFunction, tsql, intermediate => ir}
+import com.databricks.labs.remorph.parsers.{ParserCommon, XmlFunction, tsql}
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.antlr.v4.runtime.Token
 import org.antlr.v4.runtime.tree.Trees
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionBuilder.scala
@@ -1,6 +1,7 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.{FunctionBuilder, FunctionDefinition, StringConverter, intermediate => ir}
+import com.databricks.labs.remorph.parsers.{FunctionBuilder, FunctionDefinition, StringConverter}
+import com.databricks.labs.remorph.{intermediate => ir}
 
 class TSqlFunctionBuilder extends FunctionBuilder with StringConverter {
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.{PlanParser, intermediate => ir}
-import com.databricks.labs.remorph.parsers.intermediate.{LogicalPlan, Rules}
+import com.databricks.labs.remorph.parsers.PlanParser
+import com.databricks.labs.remorph.{intermediate => ir}
 import com.databricks.labs.remorph.parsers.tsql.rules.{PullLimitUpwards, TSqlCallMapper, TopPercentToLimitSubquery, TrapInsertDefaultsAction}
 import org.antlr.v4.runtime.{CharStream, ParserRuleContext, TokenSource, TokenStream}
 
@@ -12,12 +12,12 @@ class TSqlPlanParser extends PlanParser[TSqlParser] {
   override protected def createLexer(input: CharStream): TokenSource = new TSqlLexer(input)
   override protected def createParser(stream: TokenStream): TSqlParser = new TSqlParser(stream)
   override protected def createTree(parser: TSqlParser): ParserRuleContext = parser.tSqlFile()
-  override protected def createPlan(tree: ParserRuleContext): LogicalPlan = vc.astBuilder.visit(tree)
+  override protected def createPlan(tree: ParserRuleContext): ir.LogicalPlan = vc.astBuilder.visit(tree)
   override protected def addErrorStrategy(parser: TSqlParser): Unit = parser.setErrorHandler(new TSqlErrorStrategy)
   def dialect: String = "tsql"
 
   // TODO: Note that this is not the correct place for the optimizer, but it is here for now
-  override protected def createOptimizer: Rules[LogicalPlan] = {
+  override protected def createOptimizer: ir.Rules[ir.LogicalPlan] = {
     ir.Rules(
       new TSqlCallMapper,
       ir.AlwaysUpperNameForCallFunction,

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -2,7 +2,8 @@ package com.databricks.labs.remorph.parsers.tsql
 
 import com.databricks.labs.remorph.parsers.tsql.TSqlParser._
 import com.databricks.labs.remorph.parsers.tsql.rules.{InsertDefaultsAction, TopPercent}
-import com.databricks.labs.remorph.parsers.{ParserCommon, intermediate => ir}
+import com.databricks.labs.remorph.parsers.ParserCommon
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.antlr.v4.runtime.ParserRuleContext
 
 import scala.collection.JavaConverters.asScalaBufferConverter

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/expressions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/expressions.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 
 // Specialized function calls, such as XML functions that usually apply to columns
 case class TsqlXmlFunction(function: CallFunction, column: Expression) extends Binary(function, column) {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/relations.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/relations.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 
 case class DerivedRows(rows: Seq[Seq[Expression]]) extends LeafNode {
   override def output: Seq[Attribute] = rows.flatten.map(e => AttributeReference(e.toString, e.dataType))

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/PullLimitUpwards.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/PullLimitUpwards.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql.rules
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 
 // TSQL has "SELECT TOP N * FROM .." vs "SELECT * FROM .. LIMIT N", so we fix it here
 object PullLimitUpwards extends Rule[LogicalPlan] {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/TSqlCallMapper.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/TSqlCallMapper.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql.rules
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 
 class TSqlCallMapper extends CallMapper {
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/TopPercentToLimitSubquery.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/TopPercentToLimitSubquery.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql.rules
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 
 import java.util.concurrent.atomic.AtomicLong
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/TrapInsertDefaultsAction.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/TrapInsertDefaultsAction.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql.rules
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 
 case class InsertDefaultsAction(condition: Option[Expression]) extends MergeAction {
   override def children: Seq[Expression] = condition.toSeq

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/SqlGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/SqlGenerator.scala
@@ -2,7 +2,7 @@ package com.databricks.labs.remorph.transpilers
 
 import com.databricks.labs.remorph.generators.GeneratorContext
 import com.databricks.labs.remorph.generators.sql.{ExpressionGenerator, LogicalPlanGenerator, OptionGenerator}
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.json4s.jackson.Serialization
 import org.json4s.jackson.Serialization.write
 import org.json4s.{Formats, NoTypeHints}

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/Transpiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/Transpiler.scala
@@ -1,6 +1,7 @@
 package com.databricks.labs.remorph.transpilers
 
-import com.databricks.labs.remorph.parsers.{PlanParser, intermediate => ir}
+import com.databricks.labs.remorph.parsers.PlanParser
+import com.databricks.labs.remorph.{intermediate => ir}
 import com.github.vertical_blank.sqlformatter.SqlFormatter
 import com.github.vertical_blank.sqlformatter.core.FormatConfig
 import com.github.vertical_blank.sqlformatter.languages.Dialect

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/DataTypeGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/DataTypeGeneratorTest.scala
@@ -1,15 +1,14 @@
 package com.databricks.labs.remorph.generators.sql
 
 import com.databricks.labs.remorph.generators.GeneratorContext
-import com.databricks.labs.remorph.parsers.intermediate.DataType
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor2}
 import org.scalatest.wordspec.AnyWordSpec
 
 class DataTypeGeneratorTest extends AnyWordSpec with Matchers with TableDrivenPropertyChecks {
 
-  val translations: TableFor2[DataType, String] = Table(
+  val translations: TableFor2[ir.DataType, String] = Table(
     ("datatype", "expected translation"),
     (ir.NullType, "VOID"),
     (ir.BooleanType, "BOOLEAN"),

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
@@ -1,7 +1,6 @@
 package com.databricks.labs.remorph.generators.sql
 
-import com.databricks.labs.remorph.parsers.intermediate.IRHelpers
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 
@@ -11,7 +10,7 @@ class ExpressionGeneratorTest
     extends AnyWordSpec
     with GeneratorTestCommon[ir.Expression]
     with MockitoSugar
-    with IRHelpers {
+    with ir.IRHelpers {
 
   override protected val generator = new ExpressionGenerator
 

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/GeneratorTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/GeneratorTestCommon.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.generators.sql
 
 import com.databricks.labs.remorph.generators.{Generator, GeneratorContext}
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import com.databricks.labs.remorph.transpilers.TranspileException
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.Assertion

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGeneratorTest.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.generators.sql
 
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.scalatest.wordspec.AnyWordSpec
 
 class LogicalPlanGeneratorTest extends AnyWordSpec with GeneratorTestCommon[ir.LogicalPlan] with ir.IRHelpers {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/ParserTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/ParserTestCommon.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers
 
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.antlr.v4.runtime._
 import org.antlr.v4.runtime.tree.ParseTreeVisitor
 import org.scalatest.{Assertion, Assertions}

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/PlanComparison.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/PlanComparison.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.parsers
 
 import com.databricks.labs.remorph.utils.Strings
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.scalatest.Assertions
 
 trait PlanComparison {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/common/FunctionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/common/FunctionBuilderSpec.scala
@@ -1,15 +1,15 @@
 package com.databricks.labs.remorph.parsers.common
 
-import com.databricks.labs.remorph.parsers.intermediate.{IRHelpers, UnresolvedFunction}
 import com.databricks.labs.remorph.parsers.snowflake.{NamedArgumentExpression, SnowflakeFunctionBuilder}
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeFunctionConverters.SynonymOf
 import com.databricks.labs.remorph.parsers.tsql.TSqlFunctionBuilder
-import com.databricks.labs.remorph.parsers.{snowflake, intermediate => ir, _}
+import com.databricks.labs.remorph.parsers._
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 
-class FunctionBuilderSpec extends AnyFlatSpec with Matchers with TableDrivenPropertyChecks with IRHelpers {
+class FunctionBuilderSpec extends AnyFlatSpec with Matchers with TableDrivenPropertyChecks with ir.IRHelpers {
 
   "TSqlFunctionBuilder" should "return correct arity for each function" in {
     val functions = Table(
@@ -518,14 +518,14 @@ class FunctionBuilderSpec extends AnyFlatSpec with Matchers with TableDrivenProp
     val functionBuilder = new SnowflakeFunctionBuilder
 
     val result1 = functionBuilder.buildFunction("ISNULL", Seq(simplyNamedColumn("x"), ir.Literal(0)))
-    result1 shouldBe a[UnresolvedFunction]
+    result1 shouldBe a[ir.UnresolvedFunction]
   }
 
   "buildFunction" should "not resolve IFNULL when child dialect isn't Snowflake" in {
     val functionBuilder = new TSqlFunctionBuilder
 
     val result1 = functionBuilder.buildFunction("IFNULL", Seq(simplyNamedColumn("x"), ir.Literal(0)))
-    result1 shouldBe a[UnresolvedFunction]
+    result1 shouldBe a[ir.UnresolvedFunction]
   }
 
   "buildFunction" should "Should preserve case if it can" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilderSpec.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilderSpec.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser.{StringContext => _, _}
 import org.mockito.Mockito._
 import org.scalatest.matchers.should

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilderSpec.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 import org.scalatest.wordspec.AnyWordSpec
 
 class SnowflakeDMLBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon with IRHelpers {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 import org.scalatest.Checkpoints.Checkpoint
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
@@ -1,8 +1,7 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser.{ComparisonOperatorContext, LiteralContext}
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
 import org.mockito.Mockito._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -101,112 +100,92 @@ class SnowflakeExpressionBuilderSpec
 
     "translate simple numeric binary expressions" should {
       "1 + 2" in {
-        exampleExpr("1 + 2", _.expr(), ir.Add(ir.Literal(1), ir.Literal(2)))
+        exampleExpr("1 + 2", _.expr(), Add(Literal(1), Literal(2)))
       }
       "1 +2" in {
-        exampleExpr("1 +2", _.expr(), ir.Add(ir.Literal(1), ir.Literal(2)))
+        exampleExpr("1 +2", _.expr(), Add(Literal(1), Literal(2)))
       }
       "1 - 2" in {
-        exampleExpr("1 - 2", _.expr(), ir.Subtract(ir.Literal(1), ir.Literal(2)))
+        exampleExpr("1 - 2", _.expr(), Subtract(Literal(1), Literal(2)))
       }
       "1 -2" in {
-        exampleExpr("1 -2", _.expr(), ir.Subtract(ir.Literal(1), ir.Literal(2)))
+        exampleExpr("1 -2", _.expr(), Subtract(Literal(1), Literal(2)))
       }
       "1 * 2" in {
-        exampleExpr("1 * 2", _.expr(), ir.Multiply(ir.Literal(1), ir.Literal(2)))
+        exampleExpr("1 * 2", _.expr(), Multiply(Literal(1), Literal(2)))
       }
       "1 / 2" in {
-        exampleExpr("1 / 2", _.expr(), ir.Divide(ir.Literal(1), ir.Literal(2)))
+        exampleExpr("1 / 2", _.expr(), Divide(Literal(1), Literal(2)))
       }
       "1 % 2" in {
-        exampleExpr("1 % 2", _.expr(), ir.Mod(ir.Literal(1), ir.Literal(2)))
+        exampleExpr("1 % 2", _.expr(), Mod(Literal(1), Literal(2)))
       }
       "'A' || 'B'" in {
-        exampleExpr("'A' || 'B'", _.expr(), ir.Concat(Seq(ir.Literal("A"), ir.Literal("B"))))
+        exampleExpr("'A' || 'B'", _.expr(), Concat(Seq(Literal("A"), Literal("B"))))
       }
     }
 
     "translate complex binary expressions" should {
       "a + b * 2" in {
-        exampleExpr("a + b * 2", _.expr(), ir.Add(Id("a"), ir.Multiply(Id("b"), ir.Literal(2))))
+        exampleExpr("a + b * 2", _.expr(), Add(Id("a"), Multiply(Id("b"), Literal(2))))
       }
       "(a + b) * 2" in {
-        exampleExpr("(a + b) * 2", _.expr(), ir.Multiply(ir.Add(Id("a"), Id("b")), ir.Literal(2)))
+        exampleExpr("(a + b) * 2", _.expr(), Multiply(Add(Id("a"), Id("b")), Literal(2)))
       }
       "a % 3 + b * 2 - c / 5" in {
         exampleExpr(
           "a % 3 + b * 2 - c / 5",
           _.expr(),
-          ir.Subtract(
-            ir.Add(ir.Mod(Id("a"), ir.Literal(3)), ir.Multiply(Id("b"), ir.Literal(2))),
-            ir.Divide(Id("c"), ir.Literal(5))))
+          Subtract(Add(Mod(Id("a"), Literal(3)), Multiply(Id("b"), Literal(2))), Divide(Id("c"), Literal(5))))
       }
       "a || b || c" in {
-        exampleExpr("a || b || c", _.expr(), ir.Concat(Seq(ir.Concat(Seq(Id("a"), Id("b"))), Id("c"))))
+        exampleExpr("a || b || c", _.expr(), Concat(Seq(Concat(Seq(Id("a"), Id("b"))), Id("c"))))
       }
     }
 
     "correctly apply operator precedence and associativity" should {
       "1 + -++-2" in {
-        exampleExpr(
-          "1 + -++-2",
-          _.expr(),
-          ir.Add(ir.Literal(1), ir.UMinus(ir.UPlus(ir.UPlus(ir.UMinus(ir.Literal(2)))))))
+        exampleExpr("1 + -++-2", _.expr(), Add(Literal(1), UMinus(UPlus(UPlus(UMinus(Literal(2)))))))
       }
       "1 + -2 * 3" in {
-        exampleExpr("1 + -2 * 3", _.expr(), ir.Add(ir.Literal(1), ir.Multiply(ir.UMinus(ir.Literal(2)), ir.Literal(3))))
+        exampleExpr("1 + -2 * 3", _.expr(), Add(Literal(1), Multiply(UMinus(Literal(2)), Literal(3))))
       }
       "1 + -2 * 3 + 7 || 'leeds1' || 'leeds2' || 'leeds3'" in {
         exampleExpr(
           "1 + -2 * 3 + 7 || 'leeds1' || 'leeds2' || 'leeds3'",
           _.expr(),
-          ir.Concat(
+          Concat(
             Seq(
-              ir.Concat(Seq(
-                ir.Concat(Seq(
-                  ir.Add(ir.Add(ir.Literal(1), ir.Multiply(ir.UMinus(ir.Literal(2)), ir.Literal(3))), ir.Literal(7)),
-                  ir.Literal("leeds1"))),
-                ir.Literal("leeds2"))),
-              ir.Literal("leeds3"))))
+              Concat(
+                Seq(
+                  Concat(
+                    Seq(Add(Add(Literal(1), Multiply(UMinus(Literal(2)), Literal(3))), Literal(7)), Literal("leeds1"))),
+                  Literal("leeds2"))),
+              Literal("leeds3"))))
       }
     }
 
     "correctly respect explicit precedence with parentheses" should {
       "(1 + 2) * 3" in {
-        exampleExpr("(1 + 2) * 3", _.expr(), ir.Multiply(ir.Add(ir.Literal(1), ir.Literal(2)), ir.Literal(3)))
+        exampleExpr("(1 + 2) * 3", _.expr(), Multiply(Add(Literal(1), Literal(2)), Literal(3)))
       }
       "1 + (2 * 3)" in {
-        exampleExpr("1 + (2 * 3)", _.expr(), ir.Add(ir.Literal(1), ir.Multiply(ir.Literal(2), ir.Literal(3))))
+        exampleExpr("1 + (2 * 3)", _.expr(), Add(Literal(1), Multiply(Literal(2), Literal(3))))
       }
       "(1 + 2) * (3 + 4)" in {
-        exampleExpr(
-          "(1 + 2) * (3 + 4)",
-          _.expr(),
-          ir.Multiply(ir.Add(ir.Literal(1), ir.Literal(2)), ir.Add(ir.Literal(3), ir.Literal(4))))
+        exampleExpr("(1 + 2) * (3 + 4)", _.expr(), Multiply(Add(Literal(1), Literal(2)), Add(Literal(3), Literal(4))))
       }
       "1 + (2 * 3) + 4" in {
-        exampleExpr(
-          "1 + (2 * 3) + 4",
-          _.expr(),
-          ir.Add(ir.Add(ir.Literal(1), ir.Multiply(ir.Literal(2), ir.Literal(3))), ir.Literal(4)))
+        exampleExpr("1 + (2 * 3) + 4", _.expr(), Add(Add(Literal(1), Multiply(Literal(2), Literal(3))), Literal(4)))
       }
       "1 + (2 * 3 + 4)" in {
-        exampleExpr(
-          "1 + (2 * 3 + 4)",
-          _.expr(),
-          ir.Add(ir.Literal(1), ir.Add(ir.Multiply(ir.Literal(2), ir.Literal(3)), ir.Literal(4))))
+        exampleExpr("1 + (2 * 3 + 4)", _.expr(), Add(Literal(1), Add(Multiply(Literal(2), Literal(3)), Literal(4))))
       }
       "1 + (2 * (3 + 4))" in {
-        exampleExpr(
-          "1 + (2 * (3 + 4))",
-          _.expr(),
-          ir.Add(ir.Literal(1), ir.Multiply(ir.Literal(2), ir.Add(ir.Literal(3), ir.Literal(4)))))
+        exampleExpr("1 + (2 * (3 + 4))", _.expr(), Add(Literal(1), Multiply(Literal(2), Add(Literal(3), Literal(4)))))
       }
       "(1 + (2 * (3 + 4)))" in {
-        exampleExpr(
-          "(1 + (2 * (3 + 4)))",
-          _.expr(),
-          ir.Add(ir.Literal(1), ir.Multiply(ir.Literal(2), ir.Add(ir.Literal(3), ir.Literal(4)))))
+        exampleExpr("(1 + (2 * (3 + 4)))", _.expr(), Add(Literal(1), Multiply(Literal(2), Add(Literal(3), Literal(4)))))
       }
     }
 
@@ -509,7 +488,7 @@ class SnowflakeExpressionBuilderSpec
     }
   }
 
-  // Note that when we truly handle &vars, we will get ir.Variable here and not Id
+  // Note that when we truly handle &vars, we will get Variable here and not Id
   // and the & parts will not be changed to ${} until we get to the final SQL generation
   // but we are in a half way house transition state
   "variable substitution" should {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 import com.databricks.labs.remorph.parsers.snowflake
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser.{JoinTypeContext, OuterJoinContext}
 import org.antlr.v4.runtime.RuleContext

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeTypeBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeTypeBuilderSpec.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 import org.antlr.v4.runtime.tree.ParseTreeVisitor
 import org.scalatest.Assertion
 import org.scalatest.matchers.should

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/rules/FlattenNestedConcatSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/rules/FlattenNestedConcatSpec.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake.rules
 
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.scalactic.source.Position
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/rules/SnowflakeCallMapperSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/rules/SnowflakeCallMapperSpec.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake.rules
 
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 import com.databricks.labs.remorph.parsers.tsql
 import com.databricks.labs.remorph.parsers.tsql.rules.TopPercent
 import org.mockito.Mockito.{mock, when}

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilderSpec.scala
@@ -1,16 +1,15 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.intermediate.{Batch, IRHelpers, LogicalPlan}
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class TSqlDDLBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers with IRHelpers {
+class TSqlDDLBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers with ir.IRHelpers {
 
   override protected def astBuilder: TSqlParserBaseVisitor[_] = vc.astBuilder
 
-  private def singleQueryExample(query: String, expectedAst: LogicalPlan): Unit =
-    example(query, _.tSqlFile(), Batch(Seq(expectedAst)))
+  private def singleQueryExample(query: String, expectedAst: ir.LogicalPlan): Unit =
+    example(query, _.tSqlFile(), ir.Batch(Seq(expectedAst)))
 
   "tsql DDL visitor" should {
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlErrorStategySpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlErrorStategySpec.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.intermediate.IRHelpers
+import com.databricks.labs.remorph.intermediate.IRHelpers
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -1,7 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.intermediate.IRHelpers
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.antlr.v4.runtime.tree.TerminalNodeImpl
 import org.antlr.v4.runtime.{CommonToken, Token}
 import org.mockito.ArgumentMatchers.{any, anyInt}
@@ -9,7 +8,7 @@ import org.mockito.Mockito.{mock, when}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers with IRHelpers {
+class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers with ir.IRHelpers {
 
   override protected def astBuilder: TSqlParserBaseVisitor[_] = vc.expressionBuilder
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionGeneratorTest.scala
@@ -1,8 +1,7 @@
 package com.databricks.labs.remorph.parsers.tsql
 
 import com.databricks.labs.remorph.generators.sql.{ExpressionGenerator, GeneratorTestCommon}
-import com.databricks.labs.remorph.parsers.intermediate.IRHelpers
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 
@@ -13,7 +12,7 @@ class TSqlExpressionGeneratorTest
     extends AnyWordSpec
     with GeneratorTestCommon[ir.Expression]
     with MockitoSugar
-    with IRHelpers {
+    with ir.IRHelpers {
 
   override protected val generator = new ExpressionGenerator()
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionBuilderSpec.scala
@@ -1,6 +1,7 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.{FunctionDefinition, intermediate => ir}
+import com.databricks.labs.remorph.parsers.FunctionDefinition
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
@@ -1,11 +1,10 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.intermediate.IRHelpers
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers with IRHelpers {
+class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matchers with ir.IRHelpers {
 
   override protected def astBuilder: TSqlParserBaseVisitor[_] = vc.expressionBuilder
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
@@ -1,7 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.intermediate.IRHelpers
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
@@ -11,7 +10,7 @@ class TSqlRelationBuilderSpec
     with TSqlParserTestCommon
     with Matchers
     with MockitoSugar
-    with IRHelpers {
+    with ir.IRHelpers {
 
   override protected def astBuilder: TSqlRelationBuilder = vc.relationBuilder
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/PullLimitUpwardsTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/PullLimitUpwardsTest.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.parsers.tsql.rules
 
 import com.databricks.labs.remorph.parsers.PlanComparison
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/TSqlCallMapperSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/TSqlCallMapperSpec.scala
@@ -1,12 +1,11 @@
 package com.databricks.labs.remorph.parsers.tsql.rules
 
-import com.databricks.labs.remorph.parsers.intermediate.{IRHelpers, ShiftLeft}
-import com.databricks.labs.remorph.parsers.{intermediate => ir}
+import com.databricks.labs.remorph.{intermediate => ir}
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class TSqlCallMapperSpec extends AnyWordSpec with Matchers with IRHelpers {
+class TSqlCallMapperSpec extends AnyWordSpec with Matchers with ir.IRHelpers {
 
   private val tsqlCallMapper = new TSqlCallMapper
 
@@ -29,7 +28,7 @@ class TSqlCallMapperSpec extends AnyWordSpec with Matchers with IRHelpers {
         ir.BitwiseOr(
           ir.BitwiseAnd(
             ir.Literal(42.toShort),
-            ir.BitwiseXor(ir.Literal(-1), ShiftLeft(ir.Literal(1), ir.Literal(7.toShort)))),
+            ir.BitwiseXor(ir.Literal(-1), ir.ShiftLeft(ir.Literal(1), ir.Literal(7.toShort)))),
           ir.ShiftRight(ir.Literal(0.toShort), ir.Literal(7.toShort)))
 
       ir.CallFunction("SET_BIT", Seq(ir.Literal(42.toShort), ir.Literal(7.toShort))) becomes

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/TopPercentToLimitSubqueryTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/TopPercentToLimitSubqueryTest.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.parsers.tsql.rules
 
 import com.databricks.labs.remorph.parsers.PlanComparison
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/TrapInsertDefaultActionTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/TrapInsertDefaultActionTest.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.parsers.tsql.rules
 
 import com.databricks.labs.remorph.parsers.PlanComparison
-import com.databricks.labs.remorph.parsers.intermediate._
+import com.databricks.labs.remorph.intermediate._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/core/src/test/scala/com/databricks/labs/remorph/queries/ExampleDebuggerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/queries/ExampleDebuggerTest.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.queries
 
 import com.databricks.labs.remorph.parsers.PlanParser
-import com.databricks.labs.remorph.parsers.intermediate.NoopNode
+import com.databricks.labs.remorph.intermediate.NoopNode
 import com.databricks.labs.remorph.transpilers.Result
 import org.antlr.v4.runtime.ParserRuleContext
 import org.mockito.ArgumentMatchers.any


### PR DESCRIPTION
A long-overdue refactoring that moves the `intermediate` package out of the `parsers` one. As parsers are meant to depend on the intermediate representation and not the other way around.