### PR TITLE
Functional Test Ignore Folder

### DIFF
--- a/tests/resources/functional/snowflake/core_engine/sample.sql
+++ b/tests/resources/functional/snowflake/core_engine/sample.sql
@@ -1,0 +1,5 @@
+-- snowflake sql:
+select * from table_name;
+
+-- databricks sql:
+select * from table_name;

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -179,9 +179,15 @@ def dialect_context():
     yield validate_source_transpile, validate_target_transpile
 
 
+_ANTLR_CORE_FOLDER = 'core_engine'
+
+
 def parse_sql_files(input_dir: Path, source: str, target: str, is_expected_exception):
     suite: list[FunctionalTestFile | FunctionalTestFileWithExpectedException] = []
     for filenames in input_dir.rglob("*.sql"):
+        # Skip files in the core directory
+        if _ANTLR_CORE_FOLDER in filenames.parts:
+            continue
         with open(filenames, 'r', encoding="utf-8") as file_content:
             content = file_content.read()
         if content:


### PR DESCRIPTION
Added core-only folder to be ignored inside our parameterized test; it will ignore the core_engine folder in all dialects.