### PR TITLE
Implement more missing visitor functions for Snowflake and TSQL

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilder.scala
@@ -49,7 +49,6 @@ class SnowflakeCommandBuilder
       case s: ir.ScalarSubquery => Some(s.dataType)
       case _ => Option(ctx.dataType()).flatMap(dt => Some(typeBuilder.buildDataType(dt)))
     }
-
     ir.SetVariable(variableName, variableValue, variableDataType)
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
@@ -162,6 +162,10 @@ class SnowflakeDDLBuilder
     case c => ir.UnresolvedConstraint(c.getText)
   }
 
+  override def visitCreateUser(ctx: CreateUserContext): ir.Catalog = {
+    ir.UnresolvedCommand(getTextFromParserRuleContext(ctx))
+  }
+
   override def visitAlterCommand(ctx: AlterCommandContext): ir.Catalog = {
     ctx match {
       case c if c.alterTable() != null => c.alterTable().accept(this)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -260,6 +260,10 @@ class SnowflakeExpressionBuilder()
     buildWindow(ctx.overClause(), ctx.expr().accept(this))
   }
 
+  override def visitExprCast(ctx: ExprCastContext): ir.Expression = {
+    ctx.castExpr().accept(this)
+  }
+
   override def visitExprAscribe(ctx: ExprAscribeContext): ir.Expression = {
     ir.Cast(ctx.expr().accept(this), typeBuilder.buildDataType(ctx.dataType()))
   }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilderSpec.scala
@@ -288,8 +288,8 @@ class SnowflakeDDLBuilderSpec
       }
     }
 
-    "wrap unknown AST in UnresolvedCatalog" in {
-      astBuilder.visit(parseString("CREATE USER homer", _.createCommand())) shouldBe a[UnresolvedCatalog]
+    "wrap unknown AST in UnresolvedCommand" in {
+      astBuilder.visit(parseString("CREATE USER homer", _.createCommand())) shouldBe a[UnresolvedCommand]
     }
   }
 


### PR DESCRIPTION
A number of required visitor methods were missing from both Snowflake and TSQL builder classes. When a visitor is not implemented, the default visitor is called, which visits all the children of the ParseTree. In some cases this happens to work as it results in just one IR node being returned. However, this is not the way to traverse the ParseTree as a small change in the ANTLR grammar will accidentally break the visitor as the default result is no longer valid. 

Here we implement a number of the missing visitors not covered by #966 