### PR TITLE
Snowflake: Correct parsing of Array literals

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -3190,7 +3190,7 @@ jsonLiteral: LCB kvPair (COMMA kvPair)* RCB | LCB RCB
 kvPair: key = string COLON literal
     ;
 
-arrayLiteral: LSB literal (COMMA literal)* RSB | LSB RSB
+arrayLiteral: LSB expr (COMMA expr)* RSB | LSB RSB
     ;
 
 dataTypeSize: L_PAREN num R_PAREN

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -287,7 +287,7 @@ class SnowflakeExpressionBuilder()
   }
 
   override def visitArrayLiteral(ctx: ArrayLiteralContext): ir.Expression = {
-    val elements = ctx.literal().asScala.map(visitLiteral).toList.toSeq
+    val elements = ctx.expr().asScala.map(_.accept(this)).toList.toSeq
     val dataType = elements.headOption.map(_.dataType).getOrElse(ir.UnresolvedType)
     ir.ArrayExpr(elements, dataType)
   }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -288,6 +288,12 @@ class SnowflakeExpressionBuilder()
 
   override def visitArrayLiteral(ctx: ArrayLiteralContext): ir.Expression = {
     val elements = ctx.expr().asScala.map(_.accept(this)).toList.toSeq
+    // TODO: The current type determination may be too naive
+    // but this does not affect code generation as the generator does not use it.
+    // Here we determine the type of the array by inspecting the first expression in the array literal,
+    // but when an array literal contains a double or a cast and the first value appears to be an integer,
+    // then the array literal type should probably be typed as DoubleType and not IntegerType, which means
+    // we need a function that types all the expressions and types it as the most general type.
     val dataType = elements.headOption.map(_.dataType).getOrElse(ir.UnresolvedType)
     ir.ArrayExpr(elements, dataType)
   }

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
@@ -281,7 +281,7 @@ class ExpressionGeneratorTest
         Seq(ir.UnresolvedAttribute("a"), ir.UnresolvedAttribute("b"))) generates "ARRAY_REMOVE(a, b)"
     }
 
-    "ARRAY_REMOVE([2, 3, 4.00::DOUBLE, 4, NULL], 4)" in {
+    "ARRAY_REMOVE([2, 3, 4::DOUBLE, 4, NULL], 4)" in {
       ir.CallFunction(
         "ARRAY_REMOVE",
         Seq(
@@ -289,7 +289,7 @@ class ExpressionGeneratorTest
             Seq(
               ir.Literal(2),
               ir.Literal(3),
-              ir.Cast(ir.Literal(4.00), ir.DoubleType),
+              ir.Cast(ir.Literal(4), ir.DoubleType),
               ir.Literal(4),
               ir.Literal(null)),
             ir.IntegerType),

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
@@ -286,12 +286,7 @@ class ExpressionGeneratorTest
         "ARRAY_REMOVE",
         Seq(
           ir.ArrayExpr(
-            Seq(
-              ir.Literal(2),
-              ir.Literal(3),
-              ir.Cast(ir.Literal(4), ir.DoubleType),
-              ir.Literal(4),
-              ir.Literal(null)),
+            Seq(ir.Literal(2), ir.Literal(3), ir.Cast(ir.Literal(4), ir.DoubleType), ir.Literal(4), ir.Literal(null)),
             ir.IntegerType),
           ir.Literal(4))) generates "ARRAY_REMOVE(ARRAY(2, 3, CAST(4 AS DOUBLE), 4, NULL), 4)"
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
@@ -281,6 +281,21 @@ class ExpressionGeneratorTest
         Seq(ir.UnresolvedAttribute("a"), ir.UnresolvedAttribute("b"))) generates "ARRAY_REMOVE(a, b)"
     }
 
+    "ARRAY_REMOVE([2, 3, 4.00::DOUBLE, 4, NULL], 4)" in {
+      ir.CallFunction(
+        "ARRAY_REMOVE",
+        Seq(
+          ir.ArrayExpr(
+            Seq(
+              ir.Literal(2),
+              ir.Literal(3),
+              ir.Cast(ir.Literal(4.00), ir.DoubleType),
+              ir.Literal(4),
+              ir.Literal(null)),
+            ir.IntegerType),
+          ir.Literal(4))) generates "ARRAY_REMOVE(ARRAY(2, 3, CAST(4 AS DOUBLE), 4, NULL), 4)"
+    }
+
     "ARRAY_REPEAT(a, b)" in {
       ir.CallFunction(
         "ARRAY_REPEAT",

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
@@ -502,4 +502,19 @@ class SnowflakeExpressionBuilderSpec
       exampleExpr("&{ab_c}.&bc_d", _.expr(), Dot(Id("$ab_c"), Id("$bc_d")))
     }
   }
+
+  "translate :: casts" should {
+    "ARRAY_REMOVE([2, 3, 4.00::DOUBLE, 4, NULL], 4)" in {
+      exampleExpr(
+        "ARRAY_REMOVE([2, 3, 4.00::DOUBLE, 4, NULL], 4)",
+        _.expr(),
+        CallFunction(
+          "ARRAY_REMOVE",
+          Seq(
+            ArrayExpr(
+              Seq(Literal(2), Literal(3), Cast(Literal(4.00), DoubleType), Literal(4), Literal(null)),
+              IntegerType),
+            Literal(4))))
+    }
+  }
 }

--- a/tests/resources/functional/snowflake/cast/test_colon_cast.sql
+++ b/tests/resources/functional/snowflake/cast/test_colon_cast.sql
@@ -1,6 +1,6 @@
 -- snowflake sql:
 SELECT
-    ARRAY_REMOVE([2, 3, 4.00::DOUBLE, 4, NULL], 4)
+    ARRAY_REMOVE([2, 3, 4::DOUBLE, 4, NULL], 4)
 
 -- databricks sql:
 SELECT

--- a/tests/resources/functional/snowflake/cast/test_colon_cast.sql
+++ b/tests/resources/functional/snowflake/cast/test_colon_cast.sql
@@ -1,0 +1,7 @@
+-- snowflake sql:
+SELECT
+    ARRAY_REMOVE([2, 3, 4.00::DOUBLE, 4, NULL], 4)
+
+-- databricks sql:
+SELECT
+    ARRAY_REMOVE(ARRAY(2, 3, CAST(4 AS DOUBLE), 4, NULL), 4);


### PR DESCRIPTION
Here we correct the ANTLR grammar and IR generation for Snowflake arrayliterals of the form:

```sql
[2, 3, 4.00::DOUBLE, 4, NULL]
```
The existing grammar only accepted literal values for the array, but in fact, because we must allow casts, the elements of the array need to be parsed as expressions.

The current type determination in visitArrayLiteral may be too naive but does not affect code generation as the generator does not use it. It only determines the type of the array by looking at the first expression in the array literal, but when an array literal contains a double (as above) and the first value appears to be an integer, then the array literal type should probably be typed as DoubleType and not IntegerType. We will need a function that determines the highest base type that
covers all the values, if this ever becomes relevant. The code is commented so that we do not forget this.


closes: #978 