### PR TITLE
SNOWFLAKE: Correctly specify search conditions in Snowflake

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeLexer.g4
@@ -460,7 +460,7 @@ NOTIFY                                         : 'NOTIFY';
 NOTIFY_USERS                                   : 'NOTIFY_USERS';
 NOVALIDATE                                     : 'NOVALIDATE';
 NULLS                                          : 'NULLS';
-NULL_                                          : 'NULL';
+NULL                                           : 'NULL';
 NULL_IF                                        : 'NULL_IF';
 NUMBER                                         : 'NUMBER';
 OAUTH                                          : 'OAUTH';

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -3167,12 +3167,6 @@ expr
 withinGroup: WITHIN GROUP L_PAREN orderByClause R_PAREN
     ;
 
-likeExpression
-    : op = (LIKE | ILIKE) pat = expr (ESCAPE escapeChar = expr)?           # likeExprSinglePattern
-    | op = (LIKE | ILIKE) (ANY | ALL) exprListInParentheses (ESCAPE expr)? # likeExprMultiplePatterns
-    | RLIKE expr                                                           # likeExprRLike
-    ;
-
 iffExpr: IFF L_PAREN searchCondition COMMA expr COMMA expr R_PAREN
     ;
 
@@ -3550,13 +3544,16 @@ searchCondition
     ;
 
 predicate
-    : EXISTS L_PAREN subquery R_PAREN                                     # predExists
-    | expr comparisonOperator (ALL | SOME | ANY) L_PAREN subquery R_PAREN # predBinop
-    | IS NOT? NULL                                                        # predIsNull
-    | IN L_PAREN (subquery | exprList) R_PAREN                            # predIn
-    | likeExpression                                                      # predLike
-    | BETWEEN expr AND expr                                               # predBetween
-    | expr                                                                # predExpr
+    : EXISTS L_PAREN subquery R_PAREN                                                # predExists
+    | expr comparisonOperator expr                                                   # predBinop
+    | expr comparisonOperator (ALL | SOME | ANY) L_PAREN subquery R_PAREN            # predASA
+    | expr IS NOT? NULL                                                              # predIsNull
+    | expr NOT? IN L_PAREN (subquery | exprList) R_PAREN                             # predIn
+    | expr NOT? BETWEEN expr AND expr                                                # predBetween
+    | expr NOT? op = (LIKE | ILIKE) expr (ESCAPE expr)?                              # predLikeSinglePattern
+    | expr NOT? op = (LIKE | ILIKE) (ANY | ALL) exprListInParentheses (ESCAPE expr)? # predLikeMultiplePatterns
+    | expr NOT? RLIKE expr                                                           # predRLike
+    | expr                                                                           # predExpr
     ;
 
 whereClause: WHERE searchCondition

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -3148,13 +3148,13 @@ expr
     | caseExpression                            # exprCase
     | iffExpr                                   # exprIff
     | sign expr                                 # exprSign
+    | op = NOT+ expr                            # exprNot
+    | expr AND expr                             # exprAnd
+    | expr OR expr                              # exprOr
     | expr op = (STAR | DIVIDE | MODULE) expr   # exprPrecedence0
     | expr op = (PLUS | MINUS | PIPE_PIPE) expr # exprPrecedence1
     | expr comparisonOperator expr              # exprComparison
     | expr COLON_COLON dataType                 # exprAscribe
-    | op = NOT+ expr                            # exprNot
-    | expr AND expr                             # exprAnd
-    | expr OR expr                              # exprOr
     | expr withinGroup                          # exprWithinGroup
     | expr overClause                           # exprOver
     | castExpr                                  # exprCast

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
@@ -279,9 +279,9 @@ class SnowflakeDDLBuilder extends SnowflakeParserBaseVisitor[ir.Catalog] with Pa
     ctx match {
       case c if c.dataType() != null =>
         ir.ChangeColumnDataType(columnName, typeBuilder.buildDataType(c.dataType()))
-      case c if c.DROP() != null && c.NULL_() != null =>
+      case c if c.DROP() != null && c.NULL() != null =>
         ir.DropConstraint(Some(columnName), ir.Nullability(c.NOT() == null))
-      case c if c.NULL_() != null =>
+      case c if c.NULL() != null =>
         ir.AddConstraint(columnName, ir.Nullability(c.NOT() == null))
       case c => ir.UnresolvedTableAlteration(c.getText)
     }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilder.scala
@@ -66,7 +66,7 @@ class SnowflakeDMLBuilder
   override def visitMergeStatement(ctx: MergeStatementContext): ir.Modification = {
     val target = ctx.tableRef().accept(relationBuilder)
     val relation = ctx.tableSource().accept(relationBuilder)
-    val predicate = ctx.predicate().accept(expressionBuilder)
+    val predicate = ctx.searchCondition().accept(expressionBuilder)
     val matchedActions = ctx
       .mergeCond()
       .mergeCondMatch()
@@ -89,7 +89,7 @@ class SnowflakeDMLBuilder
 
   private def buildMatchAction(ctx: MergeCondMatchContext): ir.MergeAction = {
     val condition = ctx match {
-      case c if c.predicate() != null => Some(c.predicate().accept(expressionBuilder))
+      case c if c.searchCondition() != null => Some(c.searchCondition().accept(expressionBuilder))
       case _ => None
     }
 
@@ -112,7 +112,7 @@ class SnowflakeDMLBuilder
 
   private def buildNotMatchAction(ctx: MergeCondNotMatchContext): ir.MergeAction = {
     val condition = ctx match {
-      case c if c.predicate() != null => Some(c.predicate().accept(expressionBuilder))
+      case c if c.searchCondition() != null => Some(c.searchCondition().accept(expressionBuilder))
       case _ => None
     }
     ctx match {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilder.scala
@@ -45,7 +45,7 @@ class SnowflakeDMLBuilder
 
   override def visitDeleteStatement(ctx: DeleteStatementContext): ir.Modification = {
     val target = ctx.tableRef().accept(relationBuilder)
-    val where = Option(ctx.predicate()).map(_.accept(expressionBuilder))
+    val where = Option(ctx.searchCondition()).map(_.accept(expressionBuilder))
     Option(ctx.tablesOrQueries()) match {
       case Some(value) =>
         val relation = relationBuilder.visit(value)
@@ -59,7 +59,7 @@ class SnowflakeDMLBuilder
     val set = expressionBuilder.visitMany(ctx.setColumnValue())
     val sources =
       Option(ctx.tableSources()).map(t => relationBuilder.visitMany(t.tableSource()).foldLeft(target)(crossJoin))
-    val where = Option(ctx.predicate()).map(_.accept(expressionBuilder))
+    val where = Option(ctx.searchCondition()).map(_.accept(expressionBuilder))
     ir.UpdateTable(target, sources, set, where, None, None)
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -593,7 +593,7 @@ class SnowflakeExpressionBuilder()
   }
 
   override def visitPredASA(ctx: PredASAContext): ir.Expression = {
-    ir.UnresolvedExpression(getTextFromParserRuleContext(ctx)) // TODO: build ASA
+    ir.UnresolvedExpression(contextText(ctx)) // TODO: build ASA
   }
 
   override def visitPredBetween(ctx: PredBetweenContext): ir.Expression = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -596,7 +596,7 @@ class SnowflakeExpressionBuilder()
     val lowerBound = ctx.expr(1).accept(this)
     val upperBound = ctx.expr(2).accept(this)
     val expression = ctx.expr(0).accept(this)
-    val between = ir.And(ir.GreaterThanOrEqual(expression, lowerBound), ir.LessThanOrEqual(expression, upperBound))
+    val between = ir.Between(expression, lowerBound, upperBound)
     Option(ctx.NOT()).fold[ir.Expression](between)(_ => ir.Not(between))
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
@@ -98,12 +98,12 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.LogicalPlan
       ir.Filter(input, conditionRule(c).accept(expressionBuilder))
     }
   private def buildHaving(ctx: HavingClauseContext, input: ir.LogicalPlan): ir.LogicalPlan =
-    buildFilter[HavingClauseContext](ctx, _.predicate(), input)
+    buildFilter[HavingClauseContext](ctx, _.searchCondition(), input)
 
   private def buildQualify(ctx: QualifyClauseContext, input: ir.LogicalPlan): ir.LogicalPlan =
     buildFilter[QualifyClauseContext](ctx, _.expr(), input)
   private def buildWhere(ctx: WhereClauseContext, from: ir.LogicalPlan): ir.LogicalPlan =
-    buildFilter[WhereClauseContext](ctx, _.predicate(), from)
+    buildFilter[WhereClauseContext](ctx, _.searchCondition(), from)
 
   private def buildGroupBy(ctx: GroupByClauseContext, input: ir.LogicalPlan): ir.LogicalPlan = {
     Option(ctx).fold(input) { c =>
@@ -263,7 +263,7 @@ class SnowflakeRelationBuilder extends SnowflakeParserBaseVisitor[ir.LogicalPlan
     ir.Join(
       left,
       right.objectRef().accept(this),
-      Option(right.predicate()).map(_.accept(expressionBuilder)),
+      Option(right.searchCondition()).map(_.accept(expressionBuilder)),
       joinType,
       usingColumns,
       ir.JoinDataType(is_left_struct = false, is_right_struct = false))

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -299,7 +299,7 @@ class TSqlExpressionBuilder(vc: TSqlVisitorCoordinator)
     val lowerBound = ctx.expression(1).accept(this)
     val upperBound = ctx.expression(2).accept(this)
     val expression = ctx.expression(0).accept(this)
-    val between = ir.And(ir.GreaterThanOrEqual(expression, lowerBound), ir.LessThanOrEqual(expression, upperBound))
+    val between = ir.Between(expression, lowerBound, upperBound)
     Option(ctx.NOT()).fold[ir.Expression](between)(_ => ir.Not(between))
   }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilderSpec.scala
@@ -397,7 +397,7 @@ class SnowflakeDDLBuilderSpec
       verify(alterColumnClause).columnName()
       verify(alterColumnClause).dataType()
       verify(alterColumnClause).DROP()
-      verify(alterColumnClause).NULL_()
+      verify(alterColumnClause).NULL()
       verify(alterColumnClause).getText
       verifyNoMoreInteractions(alterColumnClause)
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
@@ -1,7 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
 import com.databricks.labs.remorph.intermediate._
-import org.scalatest.Checkpoints.Checkpoint
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -10,6 +9,9 @@ class SnowflakeExprSpec extends AnyWordSpec with SnowflakeParserTestCommon with 
   override protected def astBuilder: SnowflakeExpressionBuilder = new SnowflakeExpressionBuilder
 
   private def example(input: String, expectedAst: Expression): Unit = exampleExpr(input, _.expr(), expectedAst)
+
+  private def searchConditionExample(input: String, expectedAst: Expression): Unit =
+    exampleExpr(input, _.searchCondition(), expectedAst)
 
   "SnowflakeExpressionBuilder" should {
     "do something" should {
@@ -121,113 +123,106 @@ class SnowflakeExprSpec extends AnyWordSpec with SnowflakeParserTestCommon with 
       }
     }
 
-    def exprAndPredicateExample(query: String, expectedAst: Expression): Unit = {
-      val cp = new Checkpoint()
-      cp(exampleExpr(query, _.expr(), expectedAst))
-      cp(exampleExpr(query, _.predicate(), expectedAst))
-      cp.reportAll()
-    }
-
     "translate IN expressions" should {
       "col1 IN (SELECT * FROM t)" in {
-        exprAndPredicateExample(
+        searchConditionExample(
           "col1 IN (SELECT * FROM t)",
           In(Id("col1"), Seq(ScalarSubquery(Project(namedTable("t"), Seq(Star(None)))))))
       }
       "col1 NOT IN (SELECT * FROM t)" in {
-        exprAndPredicateExample(
+        searchConditionExample(
           "col1 NOT IN (SELECT * FROM t)",
           Not(In(Id("col1"), Seq(ScalarSubquery(Project(namedTable("t"), Seq(Star(None))))))))
       }
       "col1 IN (1, 2, 3)" in {
-        exprAndPredicateExample("col1 IN (1, 2, 3)", In(Id("col1"), Seq(Literal(1), Literal(2), Literal(3))))
+        searchConditionExample("col1 IN (1, 2, 3)", In(Id("col1"), Seq(Literal(1), Literal(2), Literal(3))))
       }
       "col1 NOT IN ('foo', 'bar')" in {
-        exprAndPredicateExample("col1 NOT IN ('foo', 'bar')", Not(In(Id("col1"), Seq(Literal("foo"), Literal("bar")))))
+        searchConditionExample("col1 NOT IN ('foo', 'bar')", Not(In(Id("col1"), Seq(Literal("foo"), Literal("bar")))))
       }
     }
 
     "translate BETWEEN expressions" should {
       "col1 BETWEEN 3.14 AND 42" in {
-        exprAndPredicateExample("col1 BETWEEN 3.14 AND 42", Between(Id("col1"), Literal(3.14), Literal(42)))
+        searchConditionExample("col1 BETWEEN 3.14 AND 42", Between(Id("col1"), Literal(3.14), Literal(42)))
       }
       "col1 NOT BETWEEN 3.14 AND 42" in {
-        exprAndPredicateExample("col1 NOT BETWEEN 3.14 AND 42", Not(Between(Id("col1"), Literal(3.14), Literal(42))))
+        searchConditionExample("col1 NOT BETWEEN 3.14 AND 42", Not(Between(Id("col1"), Literal(3.14), Literal(42))))
       }
     }
 
     "translate LIKE expressions" should {
       "col1 LIKE '%foo'" in {
-        exprAndPredicateExample("col1 LIKE '%foo'", Like(Id("col1"), Literal("%foo"), None))
+        searchConditionExample("col1 LIKE '%foo'", Like(Id("col1"), Literal("%foo"), None))
       }
       "col1 ILIKE '%foo'" in {
-        exprAndPredicateExample("col1 ILIKE '%foo'", ILike(Id("col1"), Literal("%foo"), None))
+        searchConditionExample("col1 ILIKE '%foo'", ILike(Id("col1"), Literal("%foo"), None))
       }
       "col1 NOT LIKE '%foo'" in {
-        exprAndPredicateExample("col1 NOT LIKE '%foo'", Not(Like(Id("col1"), Literal("%foo"), None)))
+        searchConditionExample("col1 NOT LIKE '%foo'", Not(Like(Id("col1"), Literal("%foo"), None)))
       }
       "col1 NOT ILIKE '%foo'" in {
-        exprAndPredicateExample("col1 NOT ILIKE '%foo'", Not(ILike(Id("col1"), Literal("%foo"), None)))
+        searchConditionExample("col1 NOT ILIKE '%foo'", Not(ILike(Id("col1"), Literal("%foo"), None)))
       }
       "col1 LIKE '%foo' ESCAPE '^'" in {
-        exprAndPredicateExample("col1 LIKE '%foo' ESCAPE '^'", Like(Id("col1"), Literal("%foo"), Some(Literal('^'))))
+        searchConditionExample("col1 LIKE '%foo' ESCAPE '^'", Like(Id("col1"), Literal("%foo"), Some(Literal('^'))))
       }
       "col1 ILIKE '%foo' ESCAPE '^'" in {
-        exprAndPredicateExample("col1 ILIKE '%foo' ESCAPE '^'", ILike(Id("col1"), Literal("%foo"), Some(Literal('^'))))
+        searchConditionExample("col1 ILIKE '%foo' ESCAPE '^'", ILike(Id("col1"), Literal("%foo"), Some(Literal('^'))))
       }
       "col1 NOT LIKE '%foo' ESCAPE '^'" in {
-        exprAndPredicateExample(
+        searchConditionExample(
           "col1 NOT LIKE '%foo' ESCAPE '^'",
           Not(Like(Id("col1"), Literal("%foo"), Some(Literal('^')))))
       }
       "col1 NOT ILIKE '%foo' ESCAPE '^'" in {
-        exprAndPredicateExample(
+        searchConditionExample(
           "col1 NOT ILIKE '%foo' ESCAPE '^'",
           Not(ILike(Id("col1"), Literal("%foo"), Some(Literal('^')))))
       }
       "col1 LIKE ANY ('%foo', 'bar%', '%qux%')" in {
-        exprAndPredicateExample(
+        searchConditionExample(
           "col1 LIKE ANY ('%foo', 'bar%', '%qux%')",
           LikeAny(Id("col1"), Seq(Literal("%foo"), Literal("bar%"), Literal("%qux%"))))
       }
       "col1 LIKE ALL ('%foo', 'bar^%', '%qux%') ESCAPE '^'" in {
-        exprAndPredicateExample(
+        searchConditionExample(
           "col1 LIKE ALL ('%foo', 'bar^%', '%qux%') ESCAPE '^'",
           LikeAll(Id("col1"), Seq(Literal("%foo"), Literal("bar\\^%"), Literal("%qux%"))))
       }
       "col1 ILIKE ANY ('%foo', 'bar^%', '%qux%') ESCAPE '^'" in {
-        exprAndPredicateExample(
+        searchConditionExample(
           "col1 ILIKE ANY ('%foo', 'bar^%', '%qux%') ESCAPE '^'",
           ILikeAny(Id("col1"), Seq(Literal("%foo"), Literal("bar\\^%"), Literal("%qux%"))))
       }
       "col1 ILIKE ALL ('%foo', 'bar%', '%qux%')" in {
-        exprAndPredicateExample(
+        searchConditionExample(
           "col1 ILIKE ALL ('%foo', 'bar%', '%qux%')",
           ILikeAll(Id("col1"), Seq(Literal("%foo"), Literal("bar%"), Literal("%qux%"))))
       }
       "col1 RLIKE '[a-z][A-Z]*'" in {
-        exprAndPredicateExample("col1 RLIKE '[a-z][A-Z]*'", RLike(Id("col1"), Literal("[a-z][A-Z]*")))
+        searchConditionExample("col1 RLIKE '[a-z][A-Z]*'", RLike(Id("col1"), Literal("[a-z][A-Z]*")))
       }
       "col1 NOT RLIKE '[a-z][A-Z]*'" in {
-        exprAndPredicateExample("col1 NOT RLIKE '[a-z][A-Z]*'", Not(RLike(Id("col1"), Literal("[a-z][A-Z]*"))))
+        searchConditionExample("col1 NOT RLIKE '[a-z][A-Z]*'", Not(RLike(Id("col1"), Literal("[a-z][A-Z]*"))))
       }
     }
 
     "translate IS [NOT] NULL expressions" should {
       "col1 IS NULL" in {
-        exprAndPredicateExample("col1 IS NULL", IsNull(Id("col1")))
+        searchConditionExample("col1 IS NULL", IsNull(Id("col1")))
       }
       "col1 IS NOT NULL" in {
-        exprAndPredicateExample("col1 IS NOT NULL", IsNotNull(Id("col1")))
+        searchConditionExample("col1 IS NOT NULL", IsNotNull(Id("col1")))
       }
     }
 
     "translate DISTINCT expressions" in {
-      exprAndPredicateExample("DISTINCT col1", Distinct(Id("col1")))
+      searchConditionExample("DISTINCT col1", Distinct(Id("col1")))
     }
 
     "translate WITHIN GROUP expressions" in {
-      exprAndPredicateExample(
+      searchConditionExample(
         "ARRAY_AGG(col1) WITHIN GROUP (ORDER BY col2)",
         WithinGroup(CallFunction("ARRAY_AGG", Seq(Id("col1"))), Seq(SortOrder(Id("col2"), Ascending, NullsLast))))
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
@@ -463,7 +463,7 @@ class SnowflakeExpressionBuilderSpec
       verify(literal).FLOAT()
       verify(literal).REAL()
       verify(literal).trueFalse()
-      verify(literal).NULL_()
+      verify(literal).NULL()
       verify(literal).jsonLiteral()
       verify(literal).arrayLiteral()
       verifyNoMoreInteractions(literal)


### PR DESCRIPTION
Here we reimplement predicates as true search conditions with left recursion rules which correctly cover all variants of serach conditions and predicates.


closes: #273 