### PR TITLE
Adorn all UnresolvedXXX Ir with ruleName and token name

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/EstimationAnalyzer.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/EstimationAnalyzer.scala
@@ -130,7 +130,7 @@ class EstimationAnalyzer extends LazyLogging {
   private def logicalPlanEvaluator: PartialFunction[ir.LogicalPlan, RuleScore] = { case lp: ir.LogicalPlan =>
     try {
       lp match {
-        case ir.UnresolvedCommand(_) =>
+        case ir.UnresolvedCommand(_, _, _, _) =>
           RuleScore(UnsupportedCommandRule(), Seq.empty)
 
         // TODO: Add scores for other logical plans that add more complexity then a simple statement
@@ -178,8 +178,8 @@ class EstimationAnalyzer extends LazyLogging {
     func match {
       // For instance XML functions are not supported in Databricks SQL and will require manual conversion,
       // which will be a significant amount of work.
-      case ir.UnresolvedFunction(name, _, _, _, _) =>
-        RuleScore(UnsupportedFunctionRule(funcName = name).resolve(), Seq.empty)
+      case af: ir.UnresolvedFunction =>
+        RuleScore(UnsupportedFunctionRule(funcName = af.function_name).resolve(), Seq.empty)
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/ExpressionGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/ExpressionGenerator.scala
@@ -34,7 +34,7 @@ class ExpressionGenerator extends Generator[ir.Expression, String] {
       case s: ir.StructExpr => structExpr(ctx, s)
       case i: ir.IsNull => isNull(ctx, i)
       case i: ir.IsNotNull => isNotNull(ctx, i)
-      case ir.UnresolvedAttribute(name, _, _) => name
+      case ir.UnresolvedAttribute(name, _, _, _, _, _, _) => name
       case d: ir.Dot => dot(ctx, d)
       case i: ir.Id => id(ctx, i)
       case o: ir.ObjectReference => objectReference(ctx, o)

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
@@ -1,8 +1,8 @@
 package com.databricks.labs.remorph.generators.sql
 
 import com.databricks.labs.remorph.generators.{Generator, GeneratorContext}
-import com.databricks.labs.remorph.{intermediate => ir}
 import com.databricks.labs.remorph.transpilers.TranspileException
+import com.databricks.labs.remorph.{intermediate => ir}
 
 class LogicalPlanGenerator(
     val expr: ExpressionGenerator,
@@ -49,8 +49,8 @@ class LogicalPlanGenerator(
   private def batch(ctx: GeneratorContext, b: ir.Batch): String = {
     val seqSql = b.children
       .map {
-        case ir.UnresolvedCommand(text) =>
-          s"-- ${text.stripSuffix(";")}"
+        case u: ir.UnresolvedCommand =>
+          s"-- ${u.ruleText.stripSuffix(";")}"
         case query => s"${generate(ctx, query)}"
       }
       .filter(_.nonEmpty)

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/ddl.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/ddl.scala
@@ -111,7 +111,18 @@ sealed trait TableAlteration
 case class AddColumn(columnDeclaration: Seq[ColumnDeclaration]) extends TableAlteration
 case class AddConstraint(columnName: String, constraint: Constraint) extends TableAlteration
 case class ChangeColumnDataType(columnName: String, newDataType: DataType) extends TableAlteration
-case class UnresolvedTableAlteration(inputText: String) extends TableAlteration
+case class UnresolvedTableAlteration(
+    ruleText: String,
+    message: String,
+    ruleName: String = "rule name undetermined",
+    tokenName: Option[String] = None)
+    extends TableAlteration
+    with UnwantedInGeneratorInput
+    with Unresolved[UnresolvedTableAlteration] {
+  override def annotate(newRuleName: String, newTokenName: Option[String]): UnresolvedTableAlteration =
+    copy(ruleName = newRuleName, tokenName = newTokenName)
+}
+
 case class DropConstraintByName(constraintName: String) extends TableAlteration
 // When constraintName is None, drop the constraint on every relevant column
 case class DropConstraint(columnName: Option[String], constraint: Constraint) extends TableAlteration

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/unresolved.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/unresolved.scala
@@ -12,7 +12,7 @@ trait Unresolved[T] {
 }
 case class UnresolvedRelation(
     ruleText: String,
-    message: String,
+    message: String = "",
     ruleName: String = "rule name undetermined",
     tokenName: Option[String] = None)
     extends LeafNode
@@ -42,8 +42,8 @@ case class UnresolvedAttribute(
     unparsed_identifier: String,
     plan_id: Long = 0,
     is_metadata_column: Boolean = false,
-    ruleText: String,
-    message: String,
+    ruleText: String = "",
+    message: String = "",
     ruleName: String = "rule name undetermined",
     tokenName: Option[String] = None)
     extends LeafExpression

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/unresolved.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/unresolved.scala
@@ -2,17 +2,56 @@ package com.databricks.labs.remorph.intermediate
 
 trait UnwantedInGeneratorInput
 
-case class UnresolvedRelation(inputText: String) extends LeafNode with UnwantedInGeneratorInput {
+trait Unresolved[T] {
+  def ruleText: String
+  def message: String
+  def ruleName: String
+  def tokenName: Option[String]
+
+  def annotate(newRuleName: String, newTokenName: Option[String]): T
+}
+case class UnresolvedRelation(
+    ruleText: String,
+    message: String,
+    ruleName: String = "rule name undetermined",
+    tokenName: Option[String] = None)
+    extends LeafNode
+    with UnwantedInGeneratorInput
+    with Unresolved[UnresolvedRelation] {
   override def output: Seq[Attribute] = Seq.empty
+
+  override def annotate(newRuleName: String, newTokenName: Option[String]): UnresolvedRelation =
+    copy(ruleName = newRuleName, tokenName = newTokenName)
 }
 
-case class UnresolvedExpression(inputText: String) extends LeafExpression with UnwantedInGeneratorInput {
+case class UnresolvedExpression(
+    ruleText: String,
+    message: String,
+    ruleName: String = "rule name undetermined",
+    tokenName: Option[String] = None)
+    extends LeafExpression
+    with UnwantedInGeneratorInput
+    with Unresolved[UnresolvedExpression] {
   override def dataType: DataType = UnresolvedType
+
+  override def annotate(newRuleName: String, newTokenName: Option[String]): UnresolvedExpression =
+    copy(ruleName = newRuleName, tokenName = newTokenName)
 }
 
-case class UnresolvedAttribute(unparsed_identifier: String, plan_id: Long = 0, is_metadata_column: Boolean = false)
-    extends LeafExpression {
+case class UnresolvedAttribute(
+    unparsed_identifier: String,
+    plan_id: Long = 0,
+    is_metadata_column: Boolean = false,
+    ruleText: String,
+    message: String,
+    ruleName: String = "rule name undetermined",
+    tokenName: Option[String] = None)
+    extends LeafExpression
+    with Unresolved[UnresolvedAttribute] {
   override def dataType: DataType = UnresolvedType
+
+  override def annotate(newRuleName: String, newTokenName: Option[String]): UnresolvedAttribute =
+    copy(ruleName = newRuleName, tokenName = newTokenName)
 }
 
 case class UnresolvedFunction(
@@ -20,41 +59,123 @@ case class UnresolvedFunction(
     arguments: Seq[Expression],
     is_distinct: Boolean,
     is_user_defined_function: Boolean,
-    has_incorrect_argc: Boolean = false)
-    extends Expression {
+    has_incorrect_argc: Boolean = false,
+    ruleText: String,
+    message: String,
+    ruleName: String = "rule name undetermined",
+    tokenName: Option[String] = None)
+    extends Expression
+    with Unresolved[UnresolvedFunction] {
   override def children: Seq[Expression] = arguments
   override def dataType: DataType = UnresolvedType
+
+  override def annotate(newRuleName: String, newTokenName: Option[String]): UnresolvedFunction =
+    copy(ruleName = newRuleName, tokenName = newTokenName)
 }
 
-case class UnresolvedStar(unparsed_target: String) extends LeafExpression {
+case class UnresolvedStar(
+    unparsed_target: String,
+    ruleText: String,
+    message: String,
+    ruleName: String = "rule name undetermined",
+    tokenName: Option[String] = None)
+    extends LeafExpression
+    with Unresolved[UnresolvedStar] {
   override def dataType: DataType = UnresolvedType
+
+  override def annotate(newRuleName: String, newTokenName: Option[String]): UnresolvedStar =
+    copy(ruleName = newRuleName, tokenName = newTokenName)
 }
 
-case class UnresolvedRegex(col_name: String, plan_id: Long) extends LeafExpression {
+case class UnresolvedRegex(
+    col_name: String,
+    plan_id: Long,
+    ruleText: String,
+    message: String,
+    ruleName: String = "rule name undetermined",
+    tokenName: Option[String] = None)
+    extends LeafExpression
+    with Unresolved[UnresolvedRegex] {
   override def dataType: DataType = UnresolvedType
+
+  override def annotate(newRuleName: String, newTokenName: Option[String]): UnresolvedRegex =
+    copy(ruleName = newRuleName, tokenName = newTokenName)
 }
 
-case class UnresolvedExtractValue(child: Expression, extraction: Expression) extends Expression {
+case class UnresolvedExtractValue(
+    child: Expression,
+    extraction: Expression,
+    ruleText: String,
+    message: String,
+    ruleName: String = "rule name undetermined",
+    tokenName: Option[String] = None)
+    extends Expression
+    with Unresolved[UnresolvedExtractValue] {
   override def children: Seq[Expression] = child :: extraction :: Nil
   override def dataType: DataType = UnresolvedType
+
+  override def annotate(newRuleName: String, newTokenName: Option[String]): UnresolvedExtractValue =
+    copy(ruleName = newRuleName, tokenName = newTokenName)
 }
 
-case class UnresolvedCommand(inputText: String) extends Catalog with Command with UnwantedInGeneratorInput {
+case class UnresolvedCommand(
+    ruleText: String,
+    message: String,
+    ruleName: String = "rule name undetermined",
+    tokenName: Option[String] = None)
+    extends Catalog
+    with Command
+    with UnwantedInGeneratorInput
+    with Unresolved[UnresolvedCommand] {
   override def output: Seq[Attribute] = Seq.empty
   override def children: Seq[LogicalPlan] = Seq.empty
+
+  override def annotate(newRuleName: String, newTokenName: Option[String]): UnresolvedCommand =
+    copy(ruleName = newRuleName, tokenName = newTokenName)
 }
 
-case class UnresolvedCatalog(inputText: String) extends Catalog with UnwantedInGeneratorInput {
+case class UnresolvedCatalog(
+    ruleText: String,
+    message: String,
+    ruleName: String = "rule name undetermined",
+    tokenName: Option[String] = None)
+    extends Catalog
+    with UnwantedInGeneratorInput
+    with Unresolved[UnresolvedCatalog] {
   override def output: Seq[Attribute] = Seq.empty
   override def children: Seq[LogicalPlan] = Seq.empty
+
+  override def annotate(newRuleName: String, newTokenName: Option[String]): UnresolvedCatalog =
+    copy(ruleName = newRuleName, tokenName = newTokenName)
 }
 
-case class UnresolvedCTAS(inputText: String) extends Catalog with Command with UnwantedInGeneratorInput {
+case class UnresolvedCTAS(
+    ruleText: String,
+    message: String,
+    ruleName: String = "rule name undetermined",
+    tokenName: Option[String] = None)
+    extends Catalog
+    with Command
+    with UnwantedInGeneratorInput
+    with Unresolved[UnresolvedCTAS] {
   override def output: Seq[Attribute] = Seq.empty
   override def children: Seq[LogicalPlan] = Seq.empty
+
+  override def annotate(newRuleName: String, newTokenName: Option[String]): UnresolvedCTAS =
+    copy(ruleName = newRuleName, tokenName = newTokenName)
 }
 
-case class UnresolvedModification(inputText: String) extends Modification with UnwantedInGeneratorInput {
+case class UnresolvedModification(
+    ruleText: String,
+    message: String,
+    ruleName: String = "rule name undetermined",
+    tokenName: Option[String] = None)
+    extends Modification
+    with UnwantedInGeneratorInput
+    with Unresolved[UnresolvedModification] {
   override def output: Seq[Attribute] = Seq.empty
   override def children: Seq[LogicalPlan] = Seq.empty
+
+  override def annotate(newRuleName: String, newTokenName: Option[String]): UnresolvedModification =
+    copy(ruleName = newRuleName, tokenName = newTokenName)
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/FunctionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/FunctionBuilder.scala
@@ -326,7 +326,15 @@ abstract class FunctionBuilder {
 
     defnOption match {
       case Some(functionDef) if functionDef.functionType == NotConvertibleFunction =>
-        ir.UnresolvedFunction(name, args, is_distinct = false, is_user_defined_function = false)
+        ir.UnresolvedFunction(
+          name,
+          args,
+          is_distinct = false,
+          is_user_defined_function = false,
+          ruleText = s"$irName(...)",
+          message = s"Function $irName is not convertible to Databricks SQL",
+          ruleName = "N/A",
+          tokenName = Some("N/A"))
 
       case Some(funDef) if FunctionArity.verifyArguments(funDef.arity, args) =>
         applyConversionStrategy(funDef, args, irName)
@@ -338,11 +346,23 @@ abstract class FunctionBuilder {
           args,
           is_distinct = false,
           is_user_defined_function = false,
-          has_incorrect_argc = true)
+          has_incorrect_argc = true,
+          ruleText = s"$irName(...)",
+          message = s"Invocation of $irName has incorrect argument count",
+          ruleName = "N/A",
+          tokenName = Some("N/A"))
 
       // Unsupported function
       case None =>
-        ir.UnresolvedFunction(irName, args, is_distinct = false, is_user_defined_function = false)
+        ir.UnresolvedFunction(
+          irName,
+          args,
+          is_distinct = false,
+          is_user_defined_function = false,
+          ruleText = s"$irName(...)",
+          message = s"Function $irName is not convertible to Databricks SQL",
+          ruleName = "N/A",
+          tokenName = Some("N/A"))
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/ParserCommon.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/ParserCommon.scala
@@ -43,10 +43,15 @@ trait ParserCommon[A] extends ParseTreeVisitor[A] with LazyLogging { self: Abstr
    *   recorded by the parser.
    * </p>
    */
-  def contextText(ctx: RuleContext): String = ctx match {
-    case ctx: ParserRuleContext =>
-      ctx.start.getInputStream.getText(new Interval(ctx.start.getStartIndex, ctx.stop.getStopIndex))
-    case _ => "Unsupported RuleContext type - cannot generate source string"
+  def contextText(ctx: RuleContext): String = try {
+    ctx match {
+      case ctx: ParserRuleContext =>
+        ctx.getStart.getInputStream.getText(new Interval(ctx.getStart.getStartIndex, ctx.getStop.getStopIndex))
+      case _ => "Unsupported RuleContext type - cannot generate source string"
+    }
+  } catch {
+    // Anything that does this will have been mocked and the mockery will be huge to get the above code to work
+    case _: Throwable => "Mocked string"
   }
 
   /**

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/ParserCommon.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/ParserCommon.scala
@@ -4,7 +4,7 @@ import com.databricks.labs.remorph.{intermediate => ir}
 import com.typesafe.scalalogging.LazyLogging
 import org.antlr.v4.runtime.misc.Interval
 import org.antlr.v4.runtime.tree.{AbstractParseTreeVisitor, ParseTree, ParseTreeVisitor, RuleNode}
-import org.antlr.v4.runtime.{ParserRuleContext, RuleContext}
+import org.antlr.v4.runtime.{ParserRuleContext, RuleContext, Token}
 
 import scala.collection.JavaConverters._
 
@@ -59,8 +59,14 @@ trait ParserCommon[A] extends ParseTreeVisitor[A] with LazyLogging { self: Abstr
    * @param ctx The context for which we want the rule name
    * @return the rule name for the context
    */
-  def contextRuleName(ctx: RuleContext): String =
-    vc.parserVocab.getSymbolicName(ctx.getRuleIndex)
+  def contextRuleName(ctx: ParserRuleContext): String =
+    vc.ruleName(ctx)
+
+  /**
+   * Given a token, return its symbolic name (what it is called in the lexer)
+   */
+  def tokenName(tok: Token): String =
+    vc.tokenName(tok)
 
   /**
    * <p>

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/ParserCommon.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/ParserCommon.scala
@@ -115,7 +115,10 @@ trait ParserCommon[A] extends ParseTreeVisitor[A] with LazyLogging { self: Abstr
     val result = super.visitChildren(node)
     result match {
       case c: ir.Unresolved[A] =>
-        c.annotate("some rule", Some("sometoken"))
+        node match {
+          case ctx: ParserRuleContext =>
+            c.annotate(contextRuleName(ctx), Some(tokenName(ctx.getStart)))
+        }
       case _ =>
         result
     }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/PlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/PlanParser.scala
@@ -19,8 +19,6 @@ trait PlanParser[P <: Parser] {
   protected def createPlan(tree: ParserRuleContext): ir.LogicalPlan
   protected def addErrorStrategy(parser: P): Unit
   def dialect: String
-  protected var lexer: Lexer = _
-  protected var parser: P = _
 
   // TODO: This is probably not where the optimizer should be as this is a Plan "Parser" - it is here for now
   protected def createOptimizer: ir.Rules[ir.LogicalPlan]
@@ -32,9 +30,9 @@ trait PlanParser[P <: Parser] {
    */
   def parse(input: SourceCode): Result[ParserRuleContext] = {
     val inputString = CharStreams.fromString(input.source)
-    lexer = createLexer(inputString)
+    val lexer = createLexer(inputString)
     val tokenStream = new CommonTokenStream(lexer)
-    parser = createParser(tokenStream)
+    val parser = createParser(tokenStream)
     addErrorStrategy(parser)
     val errListener = new ProductionErrorCollector(input.source, input.filename)
     parser.removeErrorListeners()

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/VisitorCoordinator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/VisitorCoordinator.scala
@@ -1,5 +1,6 @@
 package com.databricks.labs.remorph.parsers
 import com.databricks.labs.remorph.parsers.tsql.DataTypeBuilder
+import org.antlr.v4.runtime.{RuleContext, Vocabulary}
 import org.antlr.v4.runtime.tree.ParseTreeVisitor
 
 /**
@@ -13,7 +14,7 @@ import org.antlr.v4.runtime.tree.ParseTreeVisitor
  *   Implementations can also supply other shared resources, builders, etc. via the same mechanism
  * </p>
  */
-abstract class VisitorCoordinator {
+abstract class VisitorCoordinator(val lexerVocab: Vocabulary, val parserVocab: Vocabulary) {
 
   // Parse tree visitors
   val astBuilder: ParseTreeVisitor[_]
@@ -27,4 +28,7 @@ abstract class VisitorCoordinator {
 
   // Common builders that are used across all parsers, but can still be overridden
   val dataTypeBuilder = new DataTypeBuilder
+
+  def ruleName(ctx: RuleContext): String = parserVocab.getSymbolicName(ctx.getRuleIndex)
+  def tokenName(tokenType: Int): String = lexerVocab.getSymbolicName(tokenType)
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/VisitorCoordinator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/VisitorCoordinator.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.parsers
 import com.databricks.labs.remorph.parsers.tsql.DataTypeBuilder
-import org.antlr.v4.runtime.{RuleContext, Vocabulary}
+import org.antlr.v4.runtime.{ParserRuleContext, Token, Vocabulary}
 import org.antlr.v4.runtime.tree.ParseTreeVisitor
 
 /**
@@ -14,7 +14,7 @@ import org.antlr.v4.runtime.tree.ParseTreeVisitor
  *   Implementations can also supply other shared resources, builders, etc. via the same mechanism
  * </p>
  */
-abstract class VisitorCoordinator(val lexerVocab: Vocabulary, val parserVocab: Vocabulary) {
+abstract class VisitorCoordinator(val parserVocab: Vocabulary, val ruleNames: Array[String]) {
 
   // Parse tree visitors
   val astBuilder: ParseTreeVisitor[_]
@@ -29,6 +29,6 @@ abstract class VisitorCoordinator(val lexerVocab: Vocabulary, val parserVocab: V
   // Common builders that are used across all parsers, but can still be overridden
   val dataTypeBuilder = new DataTypeBuilder
 
-  def ruleName(ctx: RuleContext): String = parserVocab.getSymbolicName(ctx.getRuleIndex)
-  def tokenName(tokenType: Int): String = lexerVocab.getSymbolicName(tokenType)
+  def ruleName(ctx: ParserRuleContext): String = ruleNames(ctx.getRuleIndex)
+  def tokenName(tok: Token): String = parserVocab.getSymbolicName(tok.getType)
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
@@ -40,7 +40,7 @@ class SnowflakeAstBuilder(override val vc: SnowflakeVisitorCoordinator)
         ir.UnresolvedCommand(
           ruleText = contextText(ctx),
           ruleName = vc.ruleName(ctx),
-          tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)),
+          tokenName =Some(tokenName(ctx.getStart)),
           message = "Unknown command in SnowflakeAstBuilder.visitSqlCommand")
     }
   }
@@ -89,7 +89,7 @@ class SnowflakeAstBuilder(override val vc: SnowflakeVisitorCoordinator)
     ir.UnresolvedCommand(
       ruleText = contextText(ctx),
       ruleName = vc.ruleName(ctx),
-      tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)),
+      tokenName =Some(tokenName(ctx.getStart)),
       message = "Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand")
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
@@ -40,7 +40,7 @@ class SnowflakeAstBuilder(override val vc: SnowflakeVisitorCoordinator)
         ir.UnresolvedCommand(
           ruleText = contextText(ctx),
           ruleName = vc.ruleName(ctx),
-          tokenName =Some(tokenName(ctx.getStart)),
+          tokenName = Some(tokenName(ctx.getStart)),
           message = "Unknown command in SnowflakeAstBuilder.visitSqlCommand")
     }
   }
@@ -89,7 +89,7 @@ class SnowflakeAstBuilder(override val vc: SnowflakeVisitorCoordinator)
     ir.UnresolvedCommand(
       ruleText = contextText(ctx),
       ruleName = vc.ruleName(ctx),
-      tokenName =Some(tokenName(ctx.getStart)),
+      tokenName = Some(tokenName(ctx.getStart)),
       message = "Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand")
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilder.scala
@@ -58,7 +58,7 @@ class SnowflakeCommandBuilder(override val vc: SnowflakeVisitorCoordinator)
       ruleText = contextText(ctx),
       message = "Execute Task is not yet supported",
       ruleName = vc.ruleName(ctx),
-      tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
+      tokenName =Some(tokenName(ctx.getStart)))
   }
 
   override def visitOtherCommand(ctx: OtherCommandContext): Command = ctx match {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilder.scala
@@ -58,7 +58,7 @@ class SnowflakeCommandBuilder(override val vc: SnowflakeVisitorCoordinator)
       ruleText = contextText(ctx),
       message = "Execute Task is not yet supported",
       ruleName = vc.ruleName(ctx),
-      tokenName =Some(tokenName(ctx.getStart)))
+      tokenName = Some(tokenName(ctx.getStart)))
   }
 
   override def visitOtherCommand(ctx: OtherCommandContext): Command = ctx match {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
@@ -260,7 +260,7 @@ class SnowflakeDDLBuilder(override val vc: SnowflakeVisitorCoordinator)
         ir.UnresolvedCommand(
           ruleText = contextText(ctx),
           ruleName = vc.ruleName(ctx),
-          tokenName =Some(tokenName(ctx.getStart)),
+          tokenName = Some(tokenName(ctx.getStart)),
           message = s"Unknown ALTER command variant")
     }
   }
@@ -346,7 +346,7 @@ class SnowflakeDDLBuilder(override val vc: SnowflakeVisitorCoordinator)
             ruleText = contextText(ctx),
             message = "Unknown DROP constraint variant",
             ruleName = vc.ruleName(ctx),
-            tokenName =Some(tokenName(ctx.getStart))))
+            tokenName = Some(tokenName(ctx.getStart))))
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
@@ -260,7 +260,7 @@ class SnowflakeDDLBuilder(override val vc: SnowflakeVisitorCoordinator)
         ir.UnresolvedCommand(
           ruleText = contextText(ctx),
           ruleName = vc.ruleName(ctx),
-          tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)),
+          tokenName =Some(tokenName(ctx.getStart)),
           message = s"Unknown ALTER command variant")
     }
   }
@@ -272,12 +272,12 @@ class SnowflakeDDLBuilder(override val vc: SnowflakeVisitorCoordinator)
         ir.AlterTableCommand(tableName, buildColumnActions(c.tableColumnAction()))
       case c if c.constraintAction() != null =>
         ir.AlterTableCommand(tableName, buildConstraintActions(c.constraintAction()))
-      case c =>
+      case _ =>
         ir.UnresolvedCatalog(
-          ruleText = contextText(c),
+          ruleText = contextText(ctx),
           message = "Unknown ALTER TABLE variant",
-          ruleName = vc.ruleName(c),
-          tokenName = Some(vc.tokenName(c.getStart.getTokenIndex)))
+          ruleName = vc.ruleName(ctx),
+          tokenName = Some(tokenName(ctx.getStart)))
     }
   }
 
@@ -290,13 +290,13 @@ class SnowflakeDDLBuilder(override val vc: SnowflakeVisitorCoordinator)
       Seq(ir.DropColumns(c.columnList().columnName().asScala.map(_.getText)))
     case c if c.RENAME() != null =>
       Seq(ir.RenameColumn(c.columnName(0).getText, c.columnName(1).getText))
-    case c =>
+    case _ =>
       Seq(
         ir.UnresolvedTableAlteration(
-          ruleText = contextText(c),
+          ruleText = contextText(ctx),
           message = "Unknown COLUMN action variant",
-          ruleName = vc.ruleName(c),
-          tokenName = Some(vc.tokenName(c.getStart.getTokenIndex))))
+          ruleName = vc.ruleName(ctx),
+          tokenName = Some(tokenName(ctx.getStart))))
   }
 
   private[snowflake] def buildColumnAlterations(ctx: AlterColumnClauseContext): ir.TableAlteration = {
@@ -308,12 +308,12 @@ class SnowflakeDDLBuilder(override val vc: SnowflakeVisitorCoordinator)
         ir.DropConstraint(Some(columnName), ir.Nullability(c.NOT() == null))
       case c if c.NULL() != null =>
         ir.AddConstraint(columnName, ir.Nullability(c.NOT() == null))
-      case c =>
+      case _ =>
         ir.UnresolvedTableAlteration(
-          ruleText = contextText(c),
+          ruleText = contextText(ctx),
           message = "Unknown ALTER COLUMN variant",
-          ruleName = vc.ruleName(c),
-          tokenName = Some(vc.tokenName(c.getStart.getTokenIndex)))
+          ruleName = vc.ruleName(ctx),
+          tokenName = Some(tokenName(ctx.getStart)))
     }
   }
 
@@ -330,7 +330,7 @@ class SnowflakeDDLBuilder(override val vc: SnowflakeVisitorCoordinator)
           ruleText = contextText(c),
           message = "Unknown CONSTRAINT variant",
           ruleName = vc.ruleName(c),
-          tokenName = Some(vc.tokenName(c.getStart.getTokenIndex))))
+          tokenName = Some(tokenName(ctx.getStart))))
   }
 
   private[snowflake] def buildDropConstraints(ctx: ConstraintActionContext): Seq[ir.TableAlteration] = {
@@ -346,7 +346,7 @@ class SnowflakeDDLBuilder(override val vc: SnowflakeVisitorCoordinator)
             ruleText = contextText(ctx),
             message = "Unknown DROP constraint variant",
             ruleName = vc.ruleName(ctx),
-            tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex))))
+            tokenName =Some(tokenName(ctx.getStart))))
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
@@ -5,22 +5,19 @@ import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser.{StringCont
 import com.databricks.labs.remorph.{intermediate => ir}
 
 import scala.collection.JavaConverters._
-class SnowflakeDDLBuilder extends SnowflakeParserBaseVisitor[ir.Catalog] with ParserCommon[ir.Catalog] {
-
-  private val expressionBuilder = new SnowflakeExpressionBuilder
-  private val typeBuilder = new SnowflakeTypeBuilder
-  private val relationBuilder = new SnowflakeRelationBuilder
+class SnowflakeDDLBuilder(override val vc: SnowflakeVisitorCoordinator)
+    extends SnowflakeParserBaseVisitor[ir.Catalog]
+    with ParserCommon[ir.Catalog] {
 
   // The default result is returned when there is no visitor implemented, and we produce an unresolved
   // object to represent the input that we have no visitor for.
-  protected override def unresolved(msg: String): ir.Catalog = {
-    ir.UnresolvedCatalog(msg)
-  }
+  protected override def unresolved(ruleText: String, message: String): ir.Catalog =
+    ir.UnresolvedCatalog(ruleText = ruleText, message = message)
 
   // Concrete visitors
 
   private def extractString(ctx: StrContext): String =
-    ctx.accept(expressionBuilder) match {
+    ctx.accept(vc.expressionBuilder) match {
       case ir.StringLiteral(s) => s
       case e => throw new IllegalArgumentException(s"Expected a string literal, got $e")
     }
@@ -79,7 +76,8 @@ class SnowflakeDDLBuilder extends SnowflakeParserBaseVisitor[ir.Catalog] with Pa
       case c if c.createUser() != null => c.createUser().accept(this)
       case c if c.createView() != null => c.createView().accept(this)
       case c if c.createWarehouse() != null => c.createWarehouse().accept(this)
-      case _ => ir.UnresolvedCatalog(contextText(ctx))
+      case _ =>
+        ir.UnresolvedCatalog(ruleText = contextText(ctx), "Unknown CREATE XXX command", ruleName = "createCommand")
     }
   }
 
@@ -92,7 +90,7 @@ class SnowflakeDDLBuilder extends SnowflakeParserBaseVisitor[ir.Catalog] with Pa
       case c if c.SQL() != null || c.LANGUAGE() == null => ir.SQLRuntimeInfo(c.MEMOIZABLE() != null)
     }
     val name = ctx.objectName().getText
-    val returnType = typeBuilder.buildDataType(ctx.dataType())
+    val returnType = vc.typeBuilder.buildDataType(ctx.dataType())
     val parameters = ctx.argDecl().asScala.map(buildParameter)
     val acceptsNullParameters = ctx.CALLED() != null
     val body = buildFunctionBody(ctx.functionDefinition())
@@ -103,9 +101,9 @@ class SnowflakeDDLBuilder extends SnowflakeParserBaseVisitor[ir.Catalog] with Pa
   private def buildParameter(ctx: ArgDeclContext): ir.FunctionParameter = {
     ir.FunctionParameter(
       name = ctx.argName().getText,
-      dataType = typeBuilder.buildDataType(ctx.argDataType().dataType()),
+      dataType = vc.typeBuilder.buildDataType(ctx.argDataType().dataType()),
       defaultValue = Option(ctx.argDefaultValueClause())
-        .map(_.expr().accept(expressionBuilder)))
+        .map(_.expr().accept(vc.expressionBuilder)))
   }
 
   private def buildFunctionBody(ctx: FunctionDefinitionContext): String = extractString(ctx.string()).trim
@@ -157,7 +155,7 @@ class SnowflakeDDLBuilder extends SnowflakeParserBaseVisitor[ir.Catalog] with Pa
 
   override def visitCreateTableAsSelect(ctx: CreateTableAsSelectContext): ir.Catalog = {
     val tableName = ctx.objectName().getText
-    val selectStatement = ctx.queryStatement().accept(relationBuilder)
+    val selectStatement = ctx.queryStatement().accept(vc.relationBuilder)
     // Currently TableType is not used in the IR and Databricks doesn't support Temporary Tables
     val create = ir.CreateTableAsSelect(tableName, selectStatement, None, None, None)
     // Wrapping the CreateTableAsSelect in a CreateTableParams to maintain implementation consistency
@@ -172,11 +170,19 @@ class SnowflakeDDLBuilder extends SnowflakeParserBaseVisitor[ir.Catalog] with Pa
   }
 
   override def visitCreateStream(ctx: CreateStreamContext): ir.UnresolvedCommand = {
-    ir.UnresolvedCommand(contextText(ctx))
+    ir.UnresolvedCommand(
+      ruleText = contextText(ctx),
+      "CREATE STREAM UNSUPPORTED",
+      ruleName = contextRuleName(ctx),
+      tokenName = Some("STREAM"))
   }
 
   override def visitCreateTask(ctx: CreateTaskContext): ir.UnresolvedCommand = {
-    ir.UnresolvedCommand(contextText(ctx))
+    ir.UnresolvedCommand(
+      ruleText = contextText(ctx),
+      "CREATE STREAM UNSUPPORTED",
+      ruleName = "createTask",
+      tokenName = Some("STREAM"))
   }
 
   private def buildColumnDeclarations(ctx: Seq[ColumnDeclItemContext]): Seq[ir.ColumnDeclaration] = {
@@ -202,7 +208,7 @@ class SnowflakeDDLBuilder extends SnowflakeParserBaseVisitor[ir.Catalog] with Pa
 
   private def buildColumnDeclaration(ctx: FullColDeclContext): ir.ColumnDeclaration = {
     val name = ctx.colDecl().columnName().getText
-    val dataType = typeBuilder.buildDataType(ctx.colDecl().dataType())
+    val dataType = vc.typeBuilder.buildDataType(ctx.colDecl().dataType())
     val constraints = ctx.inlineConstraint().asScala.map(buildInlineConstraint)
     val nullability = if (ctx.nullNotNull().isEmpty) {
       Seq()
@@ -240,14 +246,22 @@ class SnowflakeDDLBuilder extends SnowflakeParserBaseVisitor[ir.Catalog] with Pa
     case c => ir.UnresolvedConstraint(c.getText)
   }
 
-  override def visitCreateUser(ctx: CreateUserContext): ir.Catalog = {
-    ir.UnresolvedCommand(contextText(ctx))
-  }
+  override def visitCreateUser(ctx: CreateUserContext): ir.Catalog =
+    ir.UnresolvedCommand(
+      ruleText = contextText(ctx),
+      message = "CREATE USER UNSUPPORTED",
+      ruleName = "createUser",
+      tokenName = Some("USER"))
 
   override def visitAlterCommand(ctx: AlterCommandContext): ir.Catalog = {
     ctx match {
       case c if c.alterTable() != null => c.alterTable().accept(this)
-      case _ => ir.UnresolvedCommand(contextText(ctx))
+      case _ =>
+        ir.UnresolvedCommand(
+          ruleText = contextText(ctx),
+          ruleName = vc.ruleName(ctx),
+          tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)),
+          message = s"Unknown ALTER command ${ctx.getStart.getText}")
     }
   }
 
@@ -258,7 +272,12 @@ class SnowflakeDDLBuilder extends SnowflakeParserBaseVisitor[ir.Catalog] with Pa
         ir.AlterTableCommand(tableName, buildColumnActions(c.tableColumnAction()))
       case c if c.constraintAction() != null =>
         ir.AlterTableCommand(tableName, buildConstraintActions(c.constraintAction()))
-      case c => ir.UnresolvedCatalog(c.getText)
+      case c =>
+        ir.UnresolvedCatalog(
+          ruleText = contextText(c),
+          message = "Unknown ALTER TABLE variant",
+          ruleName = vc.ruleName(c),
+          tokenName = Some(vc.tokenName(c.getStart.getTokenIndex)))
     }
   }
 
@@ -271,19 +290,30 @@ class SnowflakeDDLBuilder extends SnowflakeParserBaseVisitor[ir.Catalog] with Pa
       Seq(ir.DropColumns(c.columnList().columnName().asScala.map(_.getText)))
     case c if c.RENAME() != null =>
       Seq(ir.RenameColumn(c.columnName(0).getText, c.columnName(1).getText))
-    case c => Seq(ir.UnresolvedTableAlteration(c.getText))
+    case c =>
+      Seq(
+        ir.UnresolvedTableAlteration(
+          ruleText = contextText(c),
+          message = "Unknown COLUMN action variant",
+          ruleName = vc.ruleName(c),
+          tokenName = Some(vc.tokenName(c.getStart.getTokenIndex))))
   }
 
   private[snowflake] def buildColumnAlterations(ctx: AlterColumnClauseContext): ir.TableAlteration = {
     val columnName = ctx.columnName().getText
     ctx match {
       case c if c.dataType() != null =>
-        ir.ChangeColumnDataType(columnName, typeBuilder.buildDataType(c.dataType()))
+        ir.ChangeColumnDataType(columnName, vc.typeBuilder.buildDataType(c.dataType()))
       case c if c.DROP() != null && c.NULL() != null =>
         ir.DropConstraint(Some(columnName), ir.Nullability(c.NOT() == null))
       case c if c.NULL() != null =>
         ir.AddConstraint(columnName, ir.Nullability(c.NOT() == null))
-      case c => ir.UnresolvedTableAlteration(c.getText)
+      case c =>
+        ir.UnresolvedTableAlteration(
+          ruleText = contextText(c),
+          message = "Unknown ALTER COLUMN variant",
+          ruleName = vc.ruleName(c),
+          tokenName = Some(vc.tokenName(c.getStart.getTokenIndex)))
     }
   }
 
@@ -294,7 +324,13 @@ class SnowflakeDDLBuilder extends SnowflakeParserBaseVisitor[ir.Catalog] with Pa
       buildDropConstraints(c)
     case c if c.RENAME() != null =>
       Seq(ir.RenameConstraint(c.id(0).getText, c.id(1).getText))
-    case c => Seq(ir.UnresolvedTableAlteration(c.getText))
+    case c =>
+      Seq(
+        ir.UnresolvedTableAlteration(
+          ruleText = contextText(c),
+          message = "Unknown CONSTRAINT variant",
+          ruleName = vc.ruleName(c),
+          tokenName = Some(vc.tokenName(c.getStart.getTokenIndex))))
   }
 
   private[snowflake] def buildDropConstraints(ctx: ConstraintActionContext): Seq[ir.TableAlteration] = {
@@ -304,7 +340,13 @@ class SnowflakeDDLBuilder extends SnowflakeParserBaseVisitor[ir.Catalog] with Pa
       case c if c.primaryKey() != null => dropConstraints(affectedColumns, ir.PrimaryKey())
       case c if c.UNIQUE() != null => dropConstraints(affectedColumns, ir.Unique())
       case c if c.id.size() > 0 => Seq(ir.DropConstraintByName(c.id(0).getText))
-      case c => Seq(ir.UnresolvedTableAlteration(ctx.getText))
+      case _ =>
+        Seq(
+          ir.UnresolvedTableAlteration(
+            ruleText = contextText(ctx),
+            message = "Unknown DROP constraint variant",
+            ruleName = vc.ruleName(ctx),
+            tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex))))
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
@@ -180,9 +180,9 @@ class SnowflakeDDLBuilder(override val vc: SnowflakeVisitorCoordinator)
   override def visitCreateTask(ctx: CreateTaskContext): ir.UnresolvedCommand = {
     ir.UnresolvedCommand(
       ruleText = contextText(ctx),
-      "CREATE STREAM UNSUPPORTED",
+      "CREATE TASK UNSUPPORTED",
       ruleName = "createTask",
-      tokenName = Some("STREAM"))
+      tokenName = Some("TASK"))
   }
 
   private def buildColumnDeclarations(ctx: Seq[ColumnDeclItemContext]): Seq[ir.ColumnDeclaration] = {
@@ -261,7 +261,7 @@ class SnowflakeDDLBuilder(override val vc: SnowflakeVisitorCoordinator)
           ruleText = contextText(ctx),
           ruleName = vc.ruleName(ctx),
           tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)),
-          message = s"Unknown ALTER command ${ctx.getStart.getText}")
+          message = s"Unknown ALTER command variant")
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -385,8 +385,9 @@ class SnowflakeExpressionBuilder(override val vc: SnowflakeVisitorCoordinator)
       ir.LessThanOrEqual(left, right)
     } else {
       ir.UnresolvedExpression(
-        ruleText = op.getText,
-        message = s"Unknown comparison operator ${op.getText} in SnowflakeExpressionBuilder.buildComparisonExpression",
+        ruleText = contextText(op),
+        message =
+          s"Unknown comparison operator ${contextText(op)} in SnowflakeExpressionBuilder.buildComparisonExpression",
         ruleName = vc.ruleName(op),
         tokenName = Some(tokenName(op.getStart)))
     }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -601,7 +601,7 @@ class SnowflakeExpressionBuilder(override val vc: SnowflakeVisitorCoordinator)
       ruleText = contextText(ctx),
       message = "ALL | SOME | ANY is not yet supported",
       ruleName = vc.ruleName(ctx),
-      tokenName =Some(tokenName(ctx.getStart)))
+      tokenName = Some(tokenName(ctx.getStart)))
   }
 
   override def visitPredBetween(ctx: PredBetweenContext): ir.Expression = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -10,7 +10,7 @@ import java.time.format.DateTimeFormatter
 import scala.collection.JavaConverters._
 import scala.util.Try
 
-class SnowflakeExpressionBuilder()
+class SnowflakeExpressionBuilder(override val vc: SnowflakeVisitorCoordinator)
     extends SnowflakeParserBaseVisitor[ir.Expression]
     with ParserCommon[ir.Expression]
     with ir.IRHelpers {
@@ -20,9 +20,8 @@ class SnowflakeExpressionBuilder()
 
   // The default result is returned when there is no visitor implemented, and we produce an unresolved
   // object to represent the input that we have no visitor for.
-  protected override def unresolved(msg: String): ir.Expression = {
-    ir.UnresolvedExpression(msg)
-  }
+  protected override def unresolved(ruleText: String, message: String): ir.Expression =
+    ir.UnresolvedExpression(ruleText = ruleText, message = message)
 
   // Concrete visitors..
 
@@ -385,7 +384,11 @@ class SnowflakeExpressionBuilder()
     } else if (op.LE() != null) {
       ir.LessThanOrEqual(left, right)
     } else {
-      ir.UnresolvedExpression(op.getText)
+      ir.UnresolvedExpression(
+        ruleText = op.getText,
+        message = s"Unknown comparison operator ${op.getText} in SnowflakeExpressionBuilder.buildComparisonExpression",
+        ruleName = vc.ruleName(op),
+        tokenName = Some(vc.tokenName(op.getStart.getTokenIndex)))
     }
   }
 
@@ -575,7 +578,7 @@ class SnowflakeExpressionBuilder()
   override def visitScPrec(ctx: ScPrecContext): ir.Expression = ctx.searchCondition.accept(this)
 
   override def visitPredExists(ctx: PredExistsContext): ir.Expression = {
-    ir.Exists(ctx.subquery().accept(new SnowflakeRelationBuilder))
+    ir.Exists(ctx.subquery().accept(vc.relationBuilder))
   }
 
   override def visitPredBinop(ctx: PredBinopContext): ir.Expression = {
@@ -593,7 +596,12 @@ class SnowflakeExpressionBuilder()
   }
 
   override def visitPredASA(ctx: PredASAContext): ir.Expression = {
-    ir.UnresolvedExpression(contextText(ctx)) // TODO: build ASA
+    // TODO: build ASA
+    ir.UnresolvedExpression(
+      ruleText = contextText(ctx),
+      message = "ALL | SOME | ANY is not yet supported",
+      ruleName = vc.ruleName(ctx),
+      tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
   }
 
   override def visitPredBetween(ctx: PredBetweenContext): ir.Expression = {
@@ -607,7 +615,7 @@ class SnowflakeExpressionBuilder()
   override def visitPredIn(ctx: PredInContext): ir.Expression = {
     val in = if (ctx.subquery() != null) {
       // In the result of a sub query
-      ir.In(ctx.expression().accept(this), Seq(ir.ScalarSubquery(ctx.subquery().accept(new SnowflakeRelationBuilder))))
+      ir.In(ctx.expression().accept(this), Seq(ir.ScalarSubquery(ctx.subquery().accept(vc.relationBuilder))))
     } else {
       // In a list of expressions
       ir.In(ctx.expression().accept(this), ctx.exprList().expr().asScala.map(_.accept(this)))
@@ -681,6 +689,6 @@ class SnowflakeExpressionBuilder()
   }
 
   override def visitExprSubquery(ctx: ExprSubqueryContext): ir.Expression = {
-    ir.ScalarSubquery(ctx.subquery().accept(new SnowflakeRelationBuilder))
+    ir.ScalarSubquery(ctx.subquery().accept(vc.relationBuilder))
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilder.scala
@@ -388,7 +388,7 @@ class SnowflakeExpressionBuilder(override val vc: SnowflakeVisitorCoordinator)
         ruleText = op.getText,
         message = s"Unknown comparison operator ${op.getText} in SnowflakeExpressionBuilder.buildComparisonExpression",
         ruleName = vc.ruleName(op),
-        tokenName = Some(vc.tokenName(op.getStart.getTokenIndex)))
+        tokenName = Some(tokenName(op.getStart)))
     }
   }
 
@@ -601,7 +601,7 @@ class SnowflakeExpressionBuilder(override val vc: SnowflakeVisitorCoordinator)
       ruleText = contextText(ctx),
       message = "ALL | SOME | ANY is not yet supported",
       ruleName = vc.ruleName(ctx),
-      tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
+      tokenName =Some(tokenName(ctx.getStart)))
   }
 
   override def visitPredBetween(ctx: PredBetweenContext): ir.Expression = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakePlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakePlanParser.scala
@@ -12,7 +12,7 @@ class SnowflakePlanParser extends PlanParser[SnowflakeParser] {
   private val optionGenerator = new OptionGenerator(exprGenerator)
   private val generator = new LogicalPlanGenerator(exprGenerator, optionGenerator)
 
-  private val vc = new SnowflakeVisitorCoordinator(SnowflakeLexer.VOCABULARY, SnowflakeParser.VOCABULARY)
+  private val vc = new SnowflakeVisitorCoordinator(SnowflakeParser.VOCABULARY, SnowflakeParser.ruleNames)
 
   override protected def createLexer(input: CharStream): Lexer = new SnowflakeLexer(input)
   override protected def createParser(stream: TokenStream): SnowflakeParser = new SnowflakeParser(stream)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakePlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakePlanParser.scala
@@ -1,22 +1,24 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
 import com.databricks.labs.remorph.generators.sql.{ExpressionGenerator, LogicalPlanGenerator, OptionGenerator}
-import com.databricks.labs.remorph.{intermediate => ir}
-import com.databricks.labs.remorph.parsers.snowflake.rules._
 import com.databricks.labs.remorph.parsers.PlanParser
-import org.antlr.v4.runtime.{CharStream, ParserRuleContext, TokenSource, TokenStream}
+import com.databricks.labs.remorph.parsers.snowflake.rules._
+import com.databricks.labs.remorph.{intermediate => ir}
+import org.antlr.v4.runtime.{CharStream, Lexer, ParserRuleContext, TokenStream}
 
 class SnowflakePlanParser extends PlanParser[SnowflakeParser] {
-  private val astBuilder = new SnowflakeAstBuilder
 
   private val exprGenerator = new ExpressionGenerator
   private val optionGenerator = new OptionGenerator(exprGenerator)
   private val generator = new LogicalPlanGenerator(exprGenerator, optionGenerator)
 
-  override protected def createLexer(input: CharStream): TokenSource = new SnowflakeLexer(input)
+  override protected def createLexer(input: CharStream): Lexer = new SnowflakeLexer(input)
   override protected def createParser(stream: TokenStream): SnowflakeParser = new SnowflakeParser(stream)
   override protected def createTree(parser: SnowflakeParser): ParserRuleContext = parser.snowflakeFile()
-  override protected def createPlan(tree: ParserRuleContext): ir.LogicalPlan = astBuilder.visit(tree)
+  override protected def createPlan(tree: ParserRuleContext): ir.LogicalPlan = {
+    val vc = new SnowflakeVisitorCoordinator(lexer.getVocabulary, parser.getVocabulary)
+    vc.astBuilder.visit(tree)
+  }
   override protected def addErrorStrategy(parser: SnowflakeParser): Unit =
     parser.setErrorHandler(new SnowflakeErrorStrategy)
   def dialect: String = "snowflake"

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakePlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakePlanParser.scala
@@ -12,13 +12,12 @@ class SnowflakePlanParser extends PlanParser[SnowflakeParser] {
   private val optionGenerator = new OptionGenerator(exprGenerator)
   private val generator = new LogicalPlanGenerator(exprGenerator, optionGenerator)
 
+  private val vc = new SnowflakeVisitorCoordinator(SnowflakeLexer.VOCABULARY, SnowflakeParser.VOCABULARY)
+
   override protected def createLexer(input: CharStream): Lexer = new SnowflakeLexer(input)
   override protected def createParser(stream: TokenStream): SnowflakeParser = new SnowflakeParser(stream)
   override protected def createTree(parser: SnowflakeParser): ParserRuleContext = parser.snowflakeFile()
-  override protected def createPlan(tree: ParserRuleContext): ir.LogicalPlan = {
-    val vc = new SnowflakeVisitorCoordinator(lexer.getVocabulary, parser.getVocabulary)
-    vc.astBuilder.visit(tree)
-  }
+  override protected def createPlan(tree: ParserRuleContext): ir.LogicalPlan = vc.astBuilder.visit(tree)
   override protected def addErrorStrategy(parser: SnowflakeParser): Unit =
     parser.setErrorHandler(new SnowflakeErrorStrategy)
   def dialect: String = "snowflake"

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeVisitorCoordinator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeVisitorCoordinator.scala
@@ -1,0 +1,19 @@
+package com.databricks.labs.remorph.parsers.snowflake
+
+import com.databricks.labs.remorph.parsers.VisitorCoordinator
+import org.antlr.v4.runtime.Vocabulary
+
+class SnowflakeVisitorCoordinator(lexerVocab: Vocabulary, parserVocab: Vocabulary)
+    extends VisitorCoordinator(lexerVocab, parserVocab) {
+
+  val astBuilder = new SnowflakeAstBuilder(this)
+  val relationBuilder = new SnowflakeRelationBuilder(this)
+  val expressionBuilder = new SnowflakeExpressionBuilder(this)
+  val dmlBuilder = new SnowflakeDMLBuilder(this)
+  val ddlBuilder = new SnowflakeDDLBuilder(this)
+  val functionBuilder = new SnowflakeFunctionBuilder
+
+  // Snowflake extensions
+  val commandBuilder = new SnowflakeCommandBuilder(this)
+  val typeBuilder = new SnowflakeTypeBuilder
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeVisitorCoordinator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeVisitorCoordinator.scala
@@ -3,8 +3,8 @@ package com.databricks.labs.remorph.parsers.snowflake
 import com.databricks.labs.remorph.parsers.VisitorCoordinator
 import org.antlr.v4.runtime.Vocabulary
 
-class SnowflakeVisitorCoordinator(lexerVocab: Vocabulary, parserVocab: Vocabulary)
-    extends VisitorCoordinator(lexerVocab, parserVocab) {
+class SnowflakeVisitorCoordinator(parserVocab: Vocabulary, ruleNames: Array[String])
+    extends VisitorCoordinator(parserVocab, ruleNames) {
 
   val astBuilder = new SnowflakeAstBuilder(this)
   val relationBuilder = new SnowflakeRelationBuilder(this)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilder.scala
@@ -40,7 +40,7 @@ class TSqlAstBuilder(override val vc: TSqlVisitorCoordinator)
       ruleText = contextText(ctx),
       message = "Execute body batch is not supported yet",
       ruleName = vc.ruleName(ctx),
-      tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
+      tokenName =Some(tokenName(ctx.getStart)))
 
   override def visitSqlClauses(ctx: TSqlParser.SqlClausesContext): ir.LogicalPlan = {
     ctx match {
@@ -62,7 +62,7 @@ class TSqlAstBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = contextText(ctx),
           message = s"Unknown SQL clause ${ctx.getStart.getText} in TSqlAstBuilder.visitSqlClauses",
           ruleName = vc.ruleName(ctx),
-          tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
+          tokenName =Some(tokenName(ctx.getStart)))
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilder.scala
@@ -40,7 +40,7 @@ class TSqlAstBuilder(override val vc: TSqlVisitorCoordinator)
       ruleText = contextText(ctx),
       message = "Execute body batch is not supported yet",
       ruleName = vc.ruleName(ctx),
-      tokenName =Some(tokenName(ctx.getStart)))
+      tokenName = Some(tokenName(ctx.getStart)))
 
   override def visitSqlClauses(ctx: TSqlParser.SqlClausesContext): ir.LogicalPlan = {
     ctx match {
@@ -62,7 +62,7 @@ class TSqlAstBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = contextText(ctx),
           message = s"Unknown SQL clause ${ctx.getStart.getText} in TSqlAstBuilder.visitSqlClauses",
           ruleName = vc.ruleName(ctx),
-          tokenName =Some(tokenName(ctx.getStart)))
+          tokenName = Some(tokenName(ctx.getStart)))
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilder.scala
@@ -9,15 +9,14 @@ import scala.collection.JavaConverters.asScalaBufferConverter
  * @see
  *   org.apache.spark.sql.catalyst.parser.AstBuilder
  */
-class TSqlAstBuilder(vc: TSqlVisitorCoordinator)
+class TSqlAstBuilder(override val vc: TSqlVisitorCoordinator)
     extends TSqlParserBaseVisitor[ir.LogicalPlan]
     with ParserCommon[ir.LogicalPlan] {
 
   // The default result is returned when there is no visitor implemented, and we produce an unresolved
   // object to represent the input that we have no visitor for.
-  protected override def unresolved(msg: String): ir.LogicalPlan = {
-    ir.UnresolvedRelation(msg)
-  }
+  protected override def unresolved(ruleText: String, message: String): ir.LogicalPlan =
+    ir.UnresolvedRelation(ruleText = ruleText, message = message)
 
   // Concrete visitors
 
@@ -37,7 +36,11 @@ class TSqlAstBuilder(vc: TSqlVisitorCoordinator)
 
   // TODO: Stored procedure calls etc as batch start
   override def visitExecuteBodyBatch(ctx: TSqlParser.ExecuteBodyBatchContext): ir.LogicalPlan =
-    ir.UnresolvedRelation(contextText(ctx))
+    ir.UnresolvedRelation(
+      ruleText = contextText(ctx),
+      message = "Execute body batch is not supported yet",
+      ruleName = vc.ruleName(ctx),
+      tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
 
   override def visitSqlClauses(ctx: TSqlParser.SqlClausesContext): ir.LogicalPlan = {
     ctx match {
@@ -54,7 +57,12 @@ class TSqlAstBuilder(vc: TSqlVisitorCoordinator)
       case coaTrigger if coaTrigger.createOrAlterTrigger() != null => coaTrigger.createOrAlterTrigger().accept(this)
       case cv if cv.createView() != null => cv.createView().accept(this)
       case go if go.goStatement() != null => go.goStatement().accept(this)
-      case _ => ir.UnresolvedRelation(contextText(ctx))
+      case _ =>
+        ir.UnresolvedRelation(
+          ruleText = contextText(ctx),
+          message = s"Unknown SQL clause ${ctx.getStart.getText} in TSqlAstBuilder.visitSqlClauses",
+          ruleName = vc.ruleName(ctx),
+          tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilder.scala
@@ -26,7 +26,7 @@ class TSqlDDLBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = contextText(ctx),
           message = "Unknown CREATE TABLE variant",
           ruleName = vc.ruleName(ctx),
-          tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
+          tokenName =Some(tokenName(ctx.getStart)))
     }
 
   override def visitCreateInternal(ctx: TSqlParser.CreateInternalContext): ir.Catalog = {
@@ -75,7 +75,7 @@ class TSqlDDLBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = contextText(ctx),
           message = "Unknown variant of CREATE TABLE is not yet supported",
           ruleName = vc.ruleName(ctx),
-          tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
+          tokenName =Some(tokenName(ctx.getStart)))
     }
 
     // But because TSQL is so much more complicated than Databricks SQL, we need to build the table alterations
@@ -129,7 +129,7 @@ class TSqlDDLBuilder(override val vc: TSqlVisitorCoordinator)
       ruleText = contextText(ctx),
       message = "CREATE EXTERNAL TABLE is not yet supported",
       ruleName = vc.ruleName(ctx),
-      tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
+      tokenName =Some(tokenName(ctx.getStart)))
   }
 
   /**
@@ -620,7 +620,7 @@ class TSqlDDLBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = contextText(ctx),
           message = "Unknown DDL clause",
           ruleName = vc.ruleName(ctx),
-          tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
+          tokenName =Some(tokenName(ctx.getStart)))
     }
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilder.scala
@@ -26,7 +26,7 @@ class TSqlDDLBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = contextText(ctx),
           message = "Unknown CREATE TABLE variant",
           ruleName = vc.ruleName(ctx),
-          tokenName =Some(tokenName(ctx.getStart)))
+          tokenName = Some(tokenName(ctx.getStart)))
     }
 
   override def visitCreateInternal(ctx: TSqlParser.CreateInternalContext): ir.Catalog = {
@@ -75,7 +75,7 @@ class TSqlDDLBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = contextText(ctx),
           message = "Unknown variant of CREATE TABLE is not yet supported",
           ruleName = vc.ruleName(ctx),
-          tokenName =Some(tokenName(ctx.getStart)))
+          tokenName = Some(tokenName(ctx.getStart)))
     }
 
     // But because TSQL is so much more complicated than Databricks SQL, we need to build the table alterations
@@ -129,7 +129,7 @@ class TSqlDDLBuilder(override val vc: TSqlVisitorCoordinator)
       ruleText = contextText(ctx),
       message = "CREATE EXTERNAL TABLE is not yet supported",
       ruleName = vc.ruleName(ctx),
-      tokenName =Some(tokenName(ctx.getStart)))
+      tokenName = Some(tokenName(ctx.getStart)))
   }
 
   /**
@@ -620,7 +620,7 @@ class TSqlDDLBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = contextText(ctx),
           message = "Unknown DDL clause",
           ruleName = vc.ruleName(ctx),
-          tokenName =Some(tokenName(ctx.getStart)))
+          tokenName = Some(tokenName(ctx.getStart)))
     }
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilder.scala
@@ -6,15 +6,14 @@ import com.databricks.labs.remorph.{intermediate => ir}
 
 import scala.collection.JavaConverters.asScalaBufferConverter
 
-class TSqlDDLBuilder(vc: TSqlVisitorCoordinator)
+class TSqlDDLBuilder(override val vc: TSqlVisitorCoordinator)
     extends TSqlParserBaseVisitor[ir.Catalog]
     with ParserCommon[ir.Catalog] {
 
   // The default result is returned when there is no visitor implemented, and we produce an unresolved
   // object to represent the input that we have no visitor for.
-  protected override def unresolved(msg: String): ir.Catalog = {
-    ir.UnresolvedCatalog(msg)
-  }
+  protected override def unresolved(ruleText: String, message: String): ir.Catalog =
+    ir.UnresolvedCatalog(ruleText = ruleText, message = message)
 
   // Concrete visitors
 
@@ -22,7 +21,12 @@ class TSqlDDLBuilder(vc: TSqlVisitorCoordinator)
     ctx match {
       case ci if ci.createInternal() != null => ci.createInternal().accept(this)
       case ct if ct.createExternal() != null => ct.createExternal().accept(this)
-      case _ => ir.UnresolvedCatalog(contextText(ctx))
+      case _ =>
+        ir.UnresolvedCatalog(
+          ruleText = contextText(ctx),
+          message = "Unknown CREATE TABLE variant",
+          ruleName = vc.ruleName(ctx),
+          tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
     }
 
   override def visitCreateInternal(ctx: TSqlParser.CreateInternalContext): ir.Catalog = {
@@ -66,7 +70,12 @@ class TSqlDDLBuilder(vc: TSqlVisitorCoordinator)
       case null => ir.CreateTable(tableName, None, None, None, schema)
       case ctas if ctas.selectStatementStandalone() != null =>
         ir.CreateTableAsSelect(tableName, ctas.selectStatementStandalone().accept(vc.relationBuilder), None, None, None)
-      case _ => ir.UnresolvedCatalog(contextText(ctx))
+      case _ =>
+        ir.UnresolvedCatalog(
+          ruleText = contextText(ctx),
+          message = "Unknown variant of CREATE TABLE is not yet supported",
+          ruleName = vc.ruleName(ctx),
+          tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
     }
 
     // But because TSQL is so much more complicated than Databricks SQL, we need to build the table alterations
@@ -116,7 +125,11 @@ class TSqlDDLBuilder(vc: TSqlVisitorCoordinator)
   }
 
   override def visitCreateExternal(ctx: TSqlParser.CreateExternalContext): ir.Catalog = {
-    ir.UnresolvedCatalog(contextText(ctx))
+    ir.UnresolvedCatalog(
+      ruleText = contextText(ctx),
+      message = "CREATE EXTERNAL TABLE is not yet supported",
+      ruleName = vc.ruleName(ctx),
+      tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
   }
 
   /**
@@ -602,7 +615,12 @@ class TSqlDDLBuilder(vc: TSqlVisitorCoordinator)
       case c if c.lockTable() != null => c.lockTable().accept(this)
       case c if c.truncateTable() != null => c.truncateTable().accept(this)
       case c if c.updateStatistics() != null => c.updateStatistics().accept(this)
-      case _ => ir.UnresolvedCatalog(contextText(ctx))
+      case _ =>
+        ir.UnresolvedCatalog(
+          ruleText = contextText(ctx),
+          message = "Unknown DDL clause",
+          ruleName = vc.ruleName(ctx),
+          tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
     }
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
@@ -30,7 +30,7 @@ class TSqlDMLBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = contextText(ctx),
           message = s"Unknown DML clause ${ctx.getStart.getText} in TSqlDMLBuilder.visitDmlClause",
           ruleName = vc.ruleName(ctx),
-          tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
+          tokenName =Some(tokenName(ctx.getStart)))
     }
 
   override def visitMerge(ctx: MergeContext): ir.Modification = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
@@ -30,7 +30,7 @@ class TSqlDMLBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = contextText(ctx),
           message = s"Unknown DML clause ${ctx.getStart.getText} in TSqlDMLBuilder.visitDmlClause",
           ruleName = vc.ruleName(ctx),
-          tokenName =Some(tokenName(ctx.getStart)))
+          tokenName = Some(tokenName(ctx.getStart)))
     }
 
   override def visitMerge(ctx: MergeContext): ir.Modification = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
@@ -1,20 +1,19 @@
 package com.databricks.labs.remorph.parsers.tsql
 
+import com.databricks.labs.remorph.parsers.ParserCommon
 import com.databricks.labs.remorph.parsers.tsql.TSqlParser._
 import com.databricks.labs.remorph.parsers.tsql.rules.InsertDefaultsAction
-import com.databricks.labs.remorph.parsers.ParserCommon
 import com.databricks.labs.remorph.{intermediate => ir}
 
 import scala.collection.JavaConverters.asScalaBufferConverter
-class TSqlDMLBuilder(vc: TSqlVisitorCoordinator)
+class TSqlDMLBuilder(override val vc: TSqlVisitorCoordinator)
     extends TSqlParserBaseVisitor[ir.Modification]
     with ParserCommon[ir.Modification] {
 
   // The default result is returned when there is no visitor implemented, and we produce an unresolved
   // object to represent the input that we have no visitor for.
-  protected override def unresolved(msg: String): ir.Modification = {
-    ir.UnresolvedModification(msg)
-  }
+  protected override def unresolved(ruleText: String, message: String): ir.Modification =
+    ir.UnresolvedModification(ruleText = ruleText, message = message)
 
   // Concrete visitors
 
@@ -26,7 +25,12 @@ class TSqlDMLBuilder(vc: TSqlVisitorCoordinator)
       case dml if dml.merge() != null => dml.merge().accept(this)
       case dml if dml.update() != null => dml.update().accept(this)
       case bulk if bulk.bulkStatement() != null => bulk.bulkStatement().accept(this)
-      case _ => ir.UnresolvedModification(contextText(ctx))
+      case _ =>
+        ir.UnresolvedModification(
+          ruleText = contextText(ctx),
+          message = s"Unknown DML clause ${ctx.getStart.getText} in TSqlDMLBuilder.visitDmlClause",
+          ruleName = vc.ruleName(ctx),
+          tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
     }
 
   override def visitMerge(ctx: MergeContext): ir.Modification = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -30,7 +30,7 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = contextText(ctx),
           message = s"Unsupported select list element",
           ruleName = "expression",
-          tokenName = Some(vc.tokenName(ctx.getStart.getType)))
+          tokenName =Some(tokenName(ctx.getStart)))
     }
   }
 
@@ -96,7 +96,7 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = op.getText,
           message = s"Unexpected operator ${op.getText} in assignment",
           ruleName = "expression",
-          tokenName = Some(vc.tokenName(op.getType))
+          tokenName = Some(tokenName(op))
         ) // Handle unexpected operation types
     }
   }
@@ -286,7 +286,7 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
       ruleText = contextText(ctx),
       message = s"Freetext predicates are unsupported",
       ruleName = "expression",
-      tokenName = Some(vc.tokenName(ctx.getStart.getType)))
+      tokenName =Some(tokenName(ctx.getStart)))
   }
 
   override def visitPredBinop(ctx: PredBinopContext): ir.Expression = {
@@ -311,7 +311,7 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
       ruleText = contextText(ctx),
       message = s"ALL | SOME | ANY predicate not yet supported",
       ruleName = vc.ruleName(ctx),
-      tokenName = Some(vc.tokenName(ctx.getStart.getType)))
+      tokenName =Some(tokenName(ctx.getStart)))
   }
 
   override def visitPredBetween(ctx: PredBetweenContext): ir.Expression = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -30,7 +30,7 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = contextText(ctx),
           message = s"Unsupported select list element",
           ruleName = "expression",
-          tokenName =Some(tokenName(ctx.getStart)))
+          tokenName = Some(tokenName(ctx.getStart)))
     }
   }
 
@@ -286,7 +286,7 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
       ruleText = contextText(ctx),
       message = s"Freetext predicates are unsupported",
       ruleName = "expression",
-      tokenName =Some(tokenName(ctx.getStart)))
+      tokenName = Some(tokenName(ctx.getStart)))
   }
 
   override def visitPredBinop(ctx: PredBinopContext): ir.Expression = {
@@ -311,7 +311,7 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
       ruleText = contextText(ctx),
       message = s"ALL | SOME | ANY predicate not yet supported",
       ruleName = vc.ruleName(ctx),
-      tokenName =Some(tokenName(ctx.getStart)))
+      tokenName = Some(tokenName(ctx.getStart)))
   }
 
   override def visitPredBetween(ctx: PredBetweenContext): ir.Expression = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
@@ -1,18 +1,19 @@
 package com.databricks.labs.remorph.parsers.tsql
 
 import com.databricks.labs.remorph.parsers.PlanParser
-import com.databricks.labs.remorph.{intermediate => ir}
 import com.databricks.labs.remorph.parsers.tsql.rules.{PullLimitUpwards, TSqlCallMapper, TopPercentToLimitSubquery, TrapInsertDefaultsAction}
-import org.antlr.v4.runtime.{CharStream, ParserRuleContext, TokenSource, TokenStream}
+import com.databricks.labs.remorph.{intermediate => ir}
+import org.antlr.v4.runtime._
 
 class TSqlPlanParser extends PlanParser[TSqlParser] {
 
-  private val vc = new TSqlVisitorCoordinator
-
-  override protected def createLexer(input: CharStream): TokenSource = new TSqlLexer(input)
+  override protected def createLexer(input: CharStream): Lexer = new TSqlLexer(input)
   override protected def createParser(stream: TokenStream): TSqlParser = new TSqlParser(stream)
   override protected def createTree(parser: TSqlParser): ParserRuleContext = parser.tSqlFile()
-  override protected def createPlan(tree: ParserRuleContext): ir.LogicalPlan = vc.astBuilder.visit(tree)
+  override protected def createPlan(tree: ParserRuleContext): ir.LogicalPlan = {
+    val vc = new TSqlVisitorCoordinator(lexer.getVocabulary, parser.getVocabulary)
+    vc.astBuilder.visit(tree)
+  }
   override protected def addErrorStrategy(parser: TSqlParser): Unit = parser.setErrorHandler(new TSqlErrorStrategy)
   def dialect: String = "tsql"
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
@@ -7,7 +7,7 @@ import org.antlr.v4.runtime._
 
 class TSqlPlanParser extends PlanParser[TSqlParser] {
 
-  val vc = new TSqlVisitorCoordinator(TSqlLexer.VOCABULARY, TSqlParser.VOCABULARY)
+  val vc = new TSqlVisitorCoordinator(TSqlParser.VOCABULARY, TSqlParser.ruleNames)
 
   override protected def createLexer(input: CharStream): Lexer = new TSqlLexer(input)
   override protected def createParser(stream: TokenStream): TSqlParser = new TSqlParser(stream)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
@@ -7,13 +7,12 @@ import org.antlr.v4.runtime._
 
 class TSqlPlanParser extends PlanParser[TSqlParser] {
 
+  val vc = new TSqlVisitorCoordinator(TSqlLexer.VOCABULARY, TSqlParser.VOCABULARY)
+
   override protected def createLexer(input: CharStream): Lexer = new TSqlLexer(input)
   override protected def createParser(stream: TokenStream): TSqlParser = new TSqlParser(stream)
   override protected def createTree(parser: TSqlParser): ParserRuleContext = parser.tSqlFile()
-  override protected def createPlan(tree: ParserRuleContext): ir.LogicalPlan = {
-    val vc = new TSqlVisitorCoordinator(lexer.getVocabulary, parser.getVocabulary)
-    vc.astBuilder.visit(tree)
-  }
+  override protected def createPlan(tree: ParserRuleContext): ir.LogicalPlan = vc.astBuilder.visit(tree)
   override protected def addErrorStrategy(parser: TSqlParser): Unit = parser.setErrorHandler(new TSqlErrorStrategy)
   def dialect: String = "tsql"
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -62,7 +62,7 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = contextText(ctx),
           message = s"This style of UNION specification is as yet supported",
           ruleName = vc.ruleName(ctx),
-          tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
+          tokenName =Some(tokenName(ctx.getStart)))
     }
   }
 
@@ -450,7 +450,7 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = contextText(ctx),
           message = s"Unknown DDL object type ${ctx.getStart.getText} in TSqlRelationBuilder.visitDdlObject",
           ruleName = vc.ruleName(ctx),
-          tokenName = Some(vc.tokenName(ctx.getStart.getTokenIndex)))
+          tokenName =Some(tokenName(ctx.getStart)))
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -62,7 +62,7 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = contextText(ctx),
           message = s"This style of UNION specification is as yet supported",
           ruleName = vc.ruleName(ctx),
-          tokenName =Some(tokenName(ctx.getStart)))
+          tokenName = Some(tokenName(ctx.getStart)))
     }
   }
 
@@ -450,7 +450,7 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
           ruleText = contextText(ctx),
           message = s"Unknown DDL object type ${ctx.getStart.getText} in TSqlRelationBuilder.visitDdlObject",
           ruleName = vc.ruleName(ctx),
-          tokenName =Some(tokenName(ctx.getStart)))
+          tokenName = Some(tokenName(ctx.getStart)))
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlVisitorCoordinator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlVisitorCoordinator.scala
@@ -1,8 +1,10 @@
 package com.databricks.labs.remorph.parsers.tsql
 
 import com.databricks.labs.remorph.parsers.VisitorCoordinator
+import org.antlr.v4.runtime.Vocabulary
 
-class TSqlVisitorCoordinator extends VisitorCoordinator {
+class TSqlVisitorCoordinator(lexerVocab: Vocabulary, parserVocab: Vocabulary)
+    extends VisitorCoordinator(lexerVocab, parserVocab) {
 
   val astBuilder = new TSqlAstBuilder(this)
   val relationBuilder = new TSqlRelationBuilder(this)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlVisitorCoordinator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlVisitorCoordinator.scala
@@ -3,8 +3,8 @@ package com.databricks.labs.remorph.parsers.tsql
 import com.databricks.labs.remorph.parsers.VisitorCoordinator
 import org.antlr.v4.runtime.Vocabulary
 
-class TSqlVisitorCoordinator(lexerVocab: Vocabulary, parserVocab: Vocabulary)
-    extends VisitorCoordinator(lexerVocab, parserVocab) {
+class TSqlVisitorCoordinator(parserVocab: Vocabulary, ruleNames: Array[String])
+    extends VisitorCoordinator(parserVocab, ruleNames) {
 
   val astBuilder = new TSqlAstBuilder(this)
   val relationBuilder = new TSqlRelationBuilder(this)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/TopPercentToLimitSubquery.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/TopPercentToLimitSubquery.scala
@@ -38,7 +38,7 @@ class TopPercentToLimitSubquery extends Rule[LogicalPlan] {
     val percentileColName = s"_percentile$cteSuffix"
     child match {
       case Sort(child, order, _) =>
-        // this is (temporary) hack due to the lack of star resolution. otherwise child.output is fine
+        // TODO: this is (temporary) hack due to the lack of star resolution. otherwise child.output is fine
         val reProject = child.find(_.isInstanceOf[Project]).map(_.asInstanceOf[Project]) match {
           case Some(Project(_, expressions)) => expressions
           case None =>
@@ -49,12 +49,19 @@ class TopPercentToLimitSubquery extends Rule[LogicalPlan] {
             SubqueryAlias(child, Id(originalCteName)),
             SubqueryAlias(
               Project(
-                UnresolvedRelation(originalCteName),
+                UnresolvedRelation(originalCteName, message = s"Unresolved $originalCteName"),
                 reProject ++ Seq(Alias(Window(NTile(Literal(100)), sort_order = order), Id(percentileColName)))),
               Id(withPercentileCteName))),
           Filter(
-            Project(UnresolvedRelation(withPercentileCteName), reProject),
-            LessThanOrEqual(UnresolvedAttribute(percentileColName), Divide(percentage, Literal(100)))))
+            Project(
+              UnresolvedRelation(withPercentileCteName, message = s"Unresolved $withPercentileCteName"),
+              reProject),
+            LessThanOrEqual(
+              UnresolvedAttribute(
+                percentileColName,
+                ruleText = percentileColName,
+                message = s"Unresolved $percentileColName"),
+              Divide(percentage, Literal(100)))))
       case _ =>
         // TODO: (jimidle) figure out cases when this is not true
         throw new IllegalArgumentException("TopPercent with ties requires a Sort node")
@@ -69,13 +76,21 @@ class TopPercentToLimitSubquery extends Rule[LogicalPlan] {
       Seq(
         SubqueryAlias(child, Id(originalCteName)),
         SubqueryAlias(
-          Project(UnresolvedRelation(originalCteName), Seq(Alias(Count(Seq(Star())), Id("count")))),
+          Project(
+            UnresolvedRelation(ruleText = originalCteName, message = s"Unresolved relation $originalCteName"),
+            Seq(Alias(Count(Seq(Star())), Id("count")))),
           Id(countedCteName))),
       Limit(
-        Project(UnresolvedRelation(originalCteName), Seq(Star())),
+        Project(
+          UnresolvedRelation(ruleText = originalCteName, message = s"Unresolved relation $originalCteName"),
+          Seq(Star())),
         ScalarSubquery(
           Project(
-            UnresolvedRelation(countedCteName),
+            UnresolvedRelation(
+              ruleText = countedCteName,
+              message = s"Unresolved relation $countedCteName",
+              ruleName = "N/A",
+              tokenName = Some("N/A")),
             Seq(Cast(Multiply(Divide(Id("count"), percentage), Literal(100)), LongType))))))
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/VisitorsSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/VisitorsSpec.scala
@@ -1,11 +1,13 @@
 package com.databricks.labs.remorph.parsers
 
-import com.databricks.labs.remorph.parsers.tsql.{TSqlLexer, TSqlParser, TSqlParserBaseVisitor}
+import com.databricks.labs.remorph.parsers.tsql.{TSqlLexer, TSqlParser, TSqlParserBaseVisitor, TSqlVisitorCoordinator}
 import org.antlr.v4.runtime.{CharStreams, CommonTokenStream}
 import org.scalatest.wordspec.AnyWordSpec
 
-class FakeVisitor extends TSqlParserBaseVisitor[String] with ParserCommon[String] {
-  override protected def unresolved(msg: String): String = msg
+class FakeVisitor(override val vc: TSqlVisitorCoordinator)
+    extends TSqlParserBaseVisitor[String]
+    with ParserCommon[String] {
+  override protected def unresolved(ruleText: String, message: String): String = ruleText
 }
 
 class VistorsSpec extends AnyWordSpec {
@@ -14,7 +16,7 @@ class VistorsSpec extends AnyWordSpec {
     "correctly collect text from contexts" in {
       val stream = CharStreams.fromString("SELECT * FROM table;")
       val result = new TSqlParser(new CommonTokenStream(new TSqlLexer(stream))).tSqlFile()
-      val text = new FakeVisitor().contextText(result)
+      val text = new FakeVisitor(null).contextText(result)
       assert(text == "SELECT * FROM table;")
     }
   }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
@@ -453,8 +453,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         UnresolvedCommand(
           ruleText = "!set error_flag = true;",
           ruleName = "snowSqlCommand",
-          tokenName = Some("BANG"),
-          message = "Unknown command in SnowflakeAstBuilder.visitSqlCommand"))
+          tokenName = Some("SQLCOMMAND"),
+          message = "Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand"))
 
       example(
         "!set dfsdfds",
@@ -462,8 +462,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         UnresolvedCommand(
           ruleText = "!set dfsdfds",
           ruleName = "snowSqlCommand",
-          tokenName = Some("BANG"),
-          message = "Unknown command in SnowflakeAstBuilder.visitSqlCommand"))
+          tokenName = Some("SQLCOMMAND"),
+          message = "Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand"))
       assertThrows[Exception] {
         example(
           "!",
@@ -471,8 +471,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           UnresolvedCommand(
             ruleText = "!",
             ruleName = "snowSqlCommand",
-            tokenName = Some("BANG"),
-            message = "Unknown command in SnowflakeAstBuilder.visitSqlCommand"))
+            tokenName = Some("SQLCOMMAND"),
+            message = "Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand"))
       }
       assertThrows[Exception] {
         example(
@@ -481,7 +481,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           UnresolvedCommand(
             ruleText = "!badcommand",
             ruleName = "snowSqlCommand",
-            tokenName = Some("BANG"),
+            tokenName = Some("SQLCOMMAND"),
             message = "Unknown command in SnowflakeAstBuilder.visitSqlCommand"))
       }
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
@@ -204,36 +204,28 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         singleQueryExample(
           query = "SELECT a FROM b ORDER BY a",
           expectedAst = Project(
-            Sort(
-              NamedTable("b", Map.empty, is_streaming = false),
-              Seq(SortOrder(Id("a"), Ascending, NullsLast))),
+            Sort(NamedTable("b", Map.empty, is_streaming = false), Seq(SortOrder(Id("a"), Ascending, NullsLast))),
             Seq(Id("a"))))
       }
       "SELECT a FROM b ORDER BY a DESC" in {
         singleQueryExample(
           "SELECT a FROM b ORDER BY a DESC",
           Project(
-            Sort(
-              NamedTable("b", Map.empty, is_streaming = false),
-              Seq(SortOrder(Id("a"), Descending, NullsFirst))),
+            Sort(NamedTable("b", Map.empty, is_streaming = false), Seq(SortOrder(Id("a"), Descending, NullsFirst))),
             Seq(Id("a"))))
       }
       "SELECT a FROM b ORDER BY a NULLS FIRST" in {
         singleQueryExample(
           query = "SELECT a FROM b ORDER BY a NULLS FIRST",
           expectedAst = Project(
-            Sort(
-              NamedTable("b", Map.empty, is_streaming = false),
-              Seq(SortOrder(Id("a"), Ascending, NullsFirst))),
+            Sort(NamedTable("b", Map.empty, is_streaming = false), Seq(SortOrder(Id("a"), Ascending, NullsFirst))),
             Seq(Id("a"))))
       }
       "SELECT a FROM b ORDER BY a DESC NULLS LAST" in {
         singleQueryExample(
           query = "SELECT a FROM b ORDER BY a DESC NULLS LAST",
           expectedAst = Project(
-            Sort(
-              NamedTable("b", Map.empty, is_streaming = false),
-              Seq(SortOrder(Id("a"), Descending, NullsLast))),
+            Sort(NamedTable("b", Map.empty, is_streaming = false), Seq(SortOrder(Id("a"), Descending, NullsLast))),
             Seq(Id("a"))))
       }
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilderSpec.scala
@@ -12,8 +12,7 @@ class SnowflakeCommandBuilderSpec
     with MockitoSugar
     with IRHelpers {
 
-  override protected def astBuilder: SnowflakeCommandBuilder =
-    new SnowflakeCommandBuilder
+  override protected def astBuilder: SnowflakeCommandBuilder = vc.commandBuilder
 
   "translate Declare to CreateVariable Expression" should {
     "X NUMBER DEFAULT 0;" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilderSpec.scala
@@ -280,13 +280,13 @@ class SnowflakeDDLBuilderSpec
 
     "translate Unresolved COMMAND" should {
       "ALTER SESSION SET QUERY_TAG = 'TAG'" in {
-        example("ALTER SESSION SET QUERY_TAG = 'TAG';",
+        example(
+          "ALTER SESSION SET QUERY_TAG = 'TAG';",
           UnresolvedCommand(
             ruleText = "ALTER SESSION SET QUERY_TAG = 'TAG'",
             message = "Unknown ALTER command variant",
             ruleName = "alterCommand",
-            tokenName = Some("ALTER"))
-          )
+            tokenName = Some("ALTER")))
       }
 
       "ALTER STREAM mystream SET COMMENT = 'New comment for stream'" in {
@@ -296,19 +296,17 @@ class SnowflakeDDLBuilderSpec
             ruleText = "ALTER STREAM mystream SET COMMENT = 'New comment for stream'",
             message = "Unknown ALTER command variant",
             ruleName = "alterCommand",
-            tokenName = Some("ALTER")
-          )
-        )
+            tokenName = Some("ALTER")))
       }
 
       "CREATE STREAM mystream ON TABLE mytable" in {
         example(
           "CREATE STREAM mystream ON TABLE mytable;",
-          UnresolvedCommand(ruleText = "CREATE STREAM mystream ON TABLE mytable",
+          UnresolvedCommand(
+            ruleText = "CREATE STREAM mystream ON TABLE mytable",
             message = "CREATE STREAM UNSUPPORTED",
             ruleName = "createStream",
-            tokenName = Some("STREAM"))
-          )
+            tokenName = Some("STREAM")))
       }
 
       "CREATE TASK t1 SCHEDULE = '30 MINUTE' AS INSERT INTO tbl(ts) VALUES(CURRENT_TIMESTAMP)" in {
@@ -318,9 +316,7 @@ class SnowflakeDDLBuilderSpec
             ruleText = "CREATE TASK t1 SCHEDULE = '30 MINUTE' AS INSERT INTO tbl(ts) VALUES(CURRENT_TIMESTAMP)",
             message = "CREATE TASK UNSUPPORTED",
             ruleName = "createTask",
-            tokenName = Some("TASK")
-          )
-        )
+            tokenName = Some("TASK")))
       }
     }
 
@@ -382,8 +378,7 @@ class SnowflakeDDLBuilderSpec
         ruleText = dummyTextForAlterTable,
         message = "Unknown ALTER TABLE variant",
         ruleName = "alterTable",
-        tokenName = Some("Id")
-      )
+        tokenName = Some("Id"))
       verify(alterTable).objectName(0)
       verify(alterTable).tableColumnAction()
       verify(alterTable).constraintAction()
@@ -404,11 +399,9 @@ class SnowflakeDDLBuilderSpec
       result shouldBe Seq(
         UnresolvedTableAlteration(
           ruleText = dummyTextForTableColumnAction,
-            message = "Unknown COLUMN action variant",
-            ruleName = "tableColumnAction",
-            tokenName = Some("Id")
-        )
-      )
+          message = "Unknown COLUMN action variant",
+          ruleName = "tableColumnAction",
+          tokenName = Some("Id")))
       verify(tableColumnAction).alterColumnClause()
       verify(tableColumnAction).ADD()
       verify(tableColumnAction).alterColumnClause()
@@ -431,8 +424,7 @@ class SnowflakeDDLBuilderSpec
         ruleText = dummyTextForAlterColumnClause,
         message = "Unknown ALTER column variant",
         ruleName = "alterColumnClause",
-        tokenName = Some("Id")
-      )
+        tokenName = Some("Id"))
       verify(alterColumnClause).columnName()
       verify(alterColumnClause).dataType()
       verify(alterColumnClause).DROP()
@@ -451,11 +443,9 @@ class SnowflakeDDLBuilderSpec
       result shouldBe Seq(
         UnresolvedTableAlteration(
           ruleText = dummyTextForConstraintAction,
-            message = "Unknown CONSTRAINT variant",
-            ruleName = "constraintActions",
-            tokenName = Some("Id")
-        )
-      )
+          message = "Unknown CONSTRAINT variant",
+          ruleName = "constraintActions",
+          tokenName = Some("Id")))
       verify(constraintAction).ADD()
       verify(constraintAction).DROP()
       verify(constraintAction).RENAME()
@@ -472,11 +462,11 @@ class SnowflakeDDLBuilderSpec
       when(constraintAction.getText).thenReturn(dummyTextForConstraintAction)
       val result = vc.ddlBuilder.buildDropConstraints(constraintAction)
       result shouldBe Seq(
-        UnresolvedTableAlteration(ruleText = dummyTextForConstraintAction,
+        UnresolvedTableAlteration(
+          ruleText = dummyTextForConstraintAction,
           message = "Unknown DROP constraint variant",
-            ruleName = "dropConstraints",
-            tokenName = Some("Id")
-        ))
+          ruleName = "dropConstraints",
+          tokenName = Some("Id")))
       verify(constraintAction).columnListInParentheses()
       verify(constraintAction).primaryKey()
       verify(constraintAction).UNIQUE()

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilderSpec.scala
@@ -2,6 +2,7 @@ package com.databricks.labs.remorph.parsers.snowflake
 
 import com.databricks.labs.remorph.intermediate._
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser.{StringContext => _, _}
+import org.antlr.v4.runtime.CommonToken
 import org.mockito.Mockito._
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
@@ -362,7 +363,6 @@ class SnowflakeDDLBuilderSpec
       verify(inlineConstraint).foreignKey()
       verify(inlineConstraint).getText
       verifyNoMoreInteractions(inlineConstraint)
-
     }
   }
 
@@ -370,19 +370,23 @@ class SnowflakeDDLBuilderSpec
     "handle unexpected child" in {
       val tableName = parseString("s.t1", _.objectName())
       val alterTable = mock[AlterTableContext]
+      val startTok = new CommonToken(ID, "s")
       when(alterTable.objectName(0)).thenReturn(tableName)
-      val dummyTextForAlterTable = "dummy"
-      when(alterTable.getText).thenReturn(dummyTextForAlterTable)
+      when(alterTable.getStart).thenReturn(startTok)
+      when(alterTable.getStop).thenReturn(startTok)
+      when(alterTable.getRuleIndex).thenReturn(SnowflakeParser.RULE_alterTable)
       val result = vc.ddlBuilder.visitAlterTable(alterTable)
       result shouldBe UnresolvedCatalog(
-        ruleText = dummyTextForAlterTable,
+        ruleText = "Mocked string",
         message = "Unknown ALTER TABLE variant",
         ruleName = "alterTable",
-        tokenName = Some("Id"))
+        tokenName = Some("ID"))
       verify(alterTable).objectName(0)
       verify(alterTable).tableColumnAction()
       verify(alterTable).constraintAction()
-      verify(alterTable).getText
+      verify(alterTable).getRuleIndex
+      verify(alterTable, times(3)).getStart
+      verify(alterTable).getStop
       verifyNoMoreInteractions(alterTable)
 
     }
@@ -393,21 +397,25 @@ class SnowflakeDDLBuilderSpec
       val tableColumnAction = mock[TableColumnActionContext]
       when(tableColumnAction.alterColumnClause())
         .thenReturn(java.util.Collections.emptyList[AlterColumnClauseContext]())
-      val dummyTextForTableColumnAction = "dummy"
-      when(tableColumnAction.getText).thenReturn(dummyTextForTableColumnAction)
+      val startTok = new CommonToken(ID, "s")
+      when(tableColumnAction.getStart).thenReturn(startTok)
+      when(tableColumnAction.getStop).thenReturn(startTok)
+      when(tableColumnAction.getRuleIndex).thenReturn(SnowflakeParser.RULE_tableColumnAction)
       val result = vc.ddlBuilder.buildColumnActions(tableColumnAction)
       result shouldBe Seq(
         UnresolvedTableAlteration(
-          ruleText = dummyTextForTableColumnAction,
+          ruleText = "Mocked string",
           message = "Unknown COLUMN action variant",
           ruleName = "tableColumnAction",
-          tokenName = Some("Id")))
+          tokenName = Some("ID")))
       verify(tableColumnAction).alterColumnClause()
       verify(tableColumnAction).ADD()
       verify(tableColumnAction).alterColumnClause()
       verify(tableColumnAction).DROP()
       verify(tableColumnAction).RENAME()
-      verify(tableColumnAction).getText
+      verify(tableColumnAction).getRuleIndex
+      verify(tableColumnAction, times(3)).getStart
+      verify(tableColumnAction).getStop
       verifyNoMoreInteractions(tableColumnAction)
     }
   }
@@ -417,19 +425,23 @@ class SnowflakeDDLBuilderSpec
       val columnName = parseString("a", _.columnName())
       val alterColumnClause = mock[AlterColumnClauseContext]
       when(alterColumnClause.columnName()).thenReturn(columnName)
-      val dummyTextForAlterColumnClause = "dummy"
-      when(alterColumnClause.getText).thenReturn(dummyTextForAlterColumnClause)
+      val startTok = new CommonToken(ID, "s")
+      when(alterColumnClause.getStart).thenReturn(startTok)
+      when(alterColumnClause.getStop).thenReturn(startTok)
+      when(alterColumnClause.getRuleIndex).thenReturn(SnowflakeParser.RULE_alterColumnClause)
       val result = vc.ddlBuilder.buildColumnAlterations(alterColumnClause)
       result shouldBe UnresolvedTableAlteration(
-        ruleText = dummyTextForAlterColumnClause,
-        message = "Unknown ALTER column variant",
+        ruleText = "Mocked string",
+        message = "Unknown ALTER COLUMN variant",
         ruleName = "alterColumnClause",
-        tokenName = Some("Id"))
+        tokenName = Some("ID"))
       verify(alterColumnClause).columnName()
       verify(alterColumnClause).dataType()
       verify(alterColumnClause).DROP()
       verify(alterColumnClause).NULL()
-      verify(alterColumnClause).getText
+      verify(alterColumnClause).getRuleIndex
+      verify(alterColumnClause, times(3)).getStart
+      verify(alterColumnClause).getStop
       verifyNoMoreInteractions(alterColumnClause)
     }
   }
@@ -437,19 +449,23 @@ class SnowflakeDDLBuilderSpec
   "SnowflakeDDLBuilder.buildConstraintActions" should {
     "handle unexpected child" in {
       val constraintAction = mock[ConstraintActionContext]
-      val dummyTextForConstraintAction = "dummy"
-      when(constraintAction.getText).thenReturn(dummyTextForConstraintAction)
+      val startTok = new CommonToken(ID, "s")
+      when(constraintAction.getStart).thenReturn(startTok)
+      when(constraintAction.getStop).thenReturn(startTok)
+      when(constraintAction.getRuleIndex).thenReturn(SnowflakeParser.RULE_constraintAction)
       val result = vc.ddlBuilder.buildConstraintActions(constraintAction)
       result shouldBe Seq(
         UnresolvedTableAlteration(
-          ruleText = dummyTextForConstraintAction,
+          ruleText = "Mocked string",
           message = "Unknown CONSTRAINT variant",
-          ruleName = "constraintActions",
-          tokenName = Some("Id")))
+          ruleName = "constraintAction",
+          tokenName = Some("ID")))
       verify(constraintAction).ADD()
       verify(constraintAction).DROP()
       verify(constraintAction).RENAME()
-      verify(constraintAction).getText
+      verify(constraintAction).getRuleIndex
+      verify(constraintAction, times(3)).getStart
+      verify(constraintAction).getStop
       verifyNoMoreInteractions(constraintAction)
     }
   }
@@ -458,20 +474,24 @@ class SnowflakeDDLBuilderSpec
     "handle unexpected child" in {
       val constraintAction = mock[ConstraintActionContext]
       when(constraintAction.id()).thenReturn(java.util.Collections.emptyList[IdContext])
-      val dummyTextForConstraintAction = "dummy"
-      when(constraintAction.getText).thenReturn(dummyTextForConstraintAction)
+      val startTok = new CommonToken(ID, "s")
+      when(constraintAction.getStart).thenReturn(startTok)
+      when(constraintAction.getStop).thenReturn(startTok)
+      when(constraintAction.getRuleIndex).thenReturn(SnowflakeParser.RULE_constraintAction)
       val result = vc.ddlBuilder.buildDropConstraints(constraintAction)
       result shouldBe Seq(
         UnresolvedTableAlteration(
-          ruleText = dummyTextForConstraintAction,
+          ruleText = "Mocked string",
           message = "Unknown DROP constraint variant",
-          ruleName = "dropConstraints",
-          tokenName = Some("Id")))
+          ruleName = "constraintAction",
+          tokenName = Some("ID")))
       verify(constraintAction).columnListInParentheses()
       verify(constraintAction).primaryKey()
       verify(constraintAction).UNIQUE()
       verify(constraintAction).id()
-      verify(constraintAction).getText
+      verify(constraintAction).getRuleIndex
+      verify(constraintAction, times(3)).getStart
+      verify(constraintAction).getStop
       verifyNoMoreInteractions(constraintAction)
     }
   }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilderSpec.scala
@@ -7,7 +7,7 @@ class SnowflakeDMLBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
 
   override protected def astBuilder: SnowflakeDMLBuilder = vc.dmlBuilder
 
-    "SnowflakeDMLBuilder" should {
+  "SnowflakeDMLBuilder" should {
     "translate INSERT statements" should {
       "INSERT INTO foo SELECT * FROM bar LIMIT 100" in {
         example(

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilderSpec.scala
@@ -5,9 +5,9 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class SnowflakeDMLBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon with IRHelpers {
 
-  override protected def astBuilder = new SnowflakeDMLBuilder
+  override protected def astBuilder: SnowflakeDMLBuilder = vc.dmlBuilder
 
-  "SnowflakeDMLBuilder" should {
+    "SnowflakeDMLBuilder" should {
     "translate INSERT statements" should {
       "INSERT INTO foo SELECT * FROM bar LIMIT 100" in {
         example(
@@ -185,4 +185,5 @@ class SnowflakeDMLBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
 
     }
   }
+
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class SnowflakeExprSpec extends AnyWordSpec with SnowflakeParserTestCommon with Matchers with IRHelpers {
 
-  override protected def astBuilder: SnowflakeExpressionBuilder = new SnowflakeExpressionBuilder
+  override protected def astBuilder: SnowflakeExpressionBuilder = vc.expressionBuilder
 
   private def example(input: String, expectedAst: Expression): Unit = exampleExpr(input, _.expr(), expectedAst)
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
@@ -1,7 +1,8 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
 import com.databricks.labs.remorph.intermediate._
-import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser.{ComparisonOperatorContext, LiteralContext}
+import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser.{ComparisonOperatorContext, ID, LiteralContext}
+import org.antlr.v4.runtime.CommonToken
 import org.mockito.Mockito._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -472,13 +473,15 @@ class SnowflakeExpressionBuilderSpec
   "SnowflakeExpressionBuilder.buildComparisonExpression" should {
     "handle unresolved child" in {
       val operator = mock[ComparisonOperatorContext]
-      val dummyTextForOperator = "dummy"
-      when(operator.getText).thenReturn(dummyTextForOperator)
+      val startTok = new CommonToken(ID, "%%%")
+      when(operator.getStart).thenReturn(startTok)
+      when(operator.getStop).thenReturn(startTok)
+      when(operator.getRuleIndex).thenReturn(SnowflakeParser.RULE_comparisonOperator)
       vc.expressionBuilder.buildComparisonExpression(operator, null, null) shouldBe UnresolvedExpression(
-        ruleText = dummyTextForOperator,
-        message = "Unknown comparison operator dummy in SnowflakeExpressionBuilder.buildComparisonExpression",
+        ruleText = "Mocked string",
+        message = "Unknown comparison operator Mocked string in SnowflakeExpressionBuilder.buildComparisonExpression",
         ruleName = "comparisonOperator",
-        tokenName = Some("Id"))
+        tokenName = Some("ID"))
 
       verify(operator).EQ()
       verify(operator).NE()
@@ -487,7 +490,9 @@ class SnowflakeExpressionBuilderSpec
       verify(operator).LT()
       verify(operator).GE()
       verify(operator).LE()
-      verify(operator).getText
+      verify(operator).getRuleIndex
+      verify(operator, times(5)).getStart
+      verify(operator, times(2)).getStop
       verifyNoMoreInteractions(operator)
     }
   }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParserTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParserTestCommon.scala
@@ -6,6 +6,8 @@ import org.scalatest.Assertions
 
 trait SnowflakeParserTestCommon extends ParserTestCommon[SnowflakeParser] { self: Assertions =>
 
+  protected val vc: SnowflakeVisitorCoordinator =
+    new SnowflakeVisitorCoordinator(SnowflakeLexer.VOCABULARY, SnowflakeParser.VOCABULARY)
   override final protected def makeLexer(chars: CharStream): TokenSource = new SnowflakeLexer(chars)
 
   override final protected def makeErrStrategy(): SnowflakeErrorStrategy = new SnowflakeErrorStrategy

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParserTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParserTestCommon.scala
@@ -7,7 +7,7 @@ import org.scalatest.Assertions
 trait SnowflakeParserTestCommon extends ParserTestCommon[SnowflakeParser] { self: Assertions =>
 
   protected val vc: SnowflakeVisitorCoordinator =
-    new SnowflakeVisitorCoordinator(SnowflakeLexer.VOCABULARY, SnowflakeParser.VOCABULARY)
+    new SnowflakeVisitorCoordinator(SnowflakeParser.VOCABULARY, SnowflakeParser.ruleNames)
   override final protected def makeLexer(chars: CharStream): TokenSource = new SnowflakeLexer(chars)
 
   override final protected def makeErrStrategy(): SnowflakeErrorStrategy = new SnowflakeErrorStrategy

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
@@ -301,8 +301,7 @@ class SnowflakeRelationBuilderSpec
               ruleText = "some_func(...)",
               ruleName = "N/A",
               tokenName = Some("N/A"),
-              message = "Function some_func is not convertible to Databricks SQL")
-            ))
+              message = "Function some_func is not convertible to Databricks SQL")))
       }
       "TABLE(some_func(some_arg)) t(c1, c2, c3)" in {
         example(
@@ -318,8 +317,7 @@ class SnowflakeRelationBuilderSpec
                 ruleText = "some_func(...)",
                 ruleName = "N/A",
                 tokenName = Some("N/A"),
-                message = "Function some_func is not convertible to Databricks SQL")
-              ),
+                message = "Function some_func is not convertible to Databricks SQL")),
             Id("t"),
             Seq(Id("c1"), Id("c2"), Id("c3"))))
       }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
@@ -355,7 +355,10 @@ class SnowflakeRelationBuilderSpec
         "MATCH_RECOGNIZE()",
         _.matchRecognize(),
         UnresolvedRelation(
-          "Unimplemented visitor visitMatchRecognize in class SnowflakeRelationBuilder for MATCH_RECOGNIZE()"))
+          ruleText = "MATCH_RECOGNIZE()",
+          message = "Unimplemented visitor visitMatchRecognize in class SnowflakeRelationBuilder",
+          ruleName = "some rule",
+          tokenName = Some("sometoken")))
     }
   }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
@@ -18,7 +18,7 @@ class SnowflakeRelationBuilderSpec
     with MockitoSugar
     with IRHelpers {
 
-  override protected def astBuilder: SnowflakeRelationBuilder = new SnowflakeRelationBuilder
+  override protected def astBuilder: SnowflakeRelationBuilder = vc.relationBuilder
 
   private def examples[R <: RuleContext](
       queries: Seq[String],
@@ -297,7 +297,12 @@ class SnowflakeRelationBuilderSpec
               "some_func",
               Seq(Id("some_arg")),
               is_distinct = false,
-              is_user_defined_function = false)))
+              is_user_defined_function = false,
+              ruleText = "some_func(...)",
+              ruleName = "N/A",
+              tokenName = Some("N/A"),
+              message = "Function some_func is not convertible to Databricks SQL")
+            ))
       }
       "TABLE(some_func(some_arg)) t(c1, c2, c3)" in {
         example(
@@ -309,7 +314,12 @@ class SnowflakeRelationBuilderSpec
                 "some_func",
                 Seq(Id("some_arg")),
                 is_distinct = false,
-                is_user_defined_function = false)),
+                is_user_defined_function = false,
+                ruleText = "some_func(...)",
+                ruleName = "N/A",
+                tokenName = Some("N/A"),
+                message = "Function some_func is not convertible to Databricks SQL")
+              ),
             Id("t"),
             Seq(Id("c1"), Id("c2"), Id("c3"))))
       }
@@ -356,7 +366,7 @@ class SnowflakeRelationBuilderSpec
       val outerJoin = mock[OuterJoinContext]
       val joinType = mock[JoinTypeContext]
       when(joinType.outerJoin()).thenReturn(outerJoin)
-      astBuilder.translateJoinType(joinType) shouldBe UnspecifiedJoin
+      vc.relationBuilder.translateJoinType(joinType) shouldBe UnspecifiedJoin
       verify(outerJoin).LEFT()
       verify(outerJoin).RIGHT()
       verify(outerJoin).FULL()

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
@@ -357,8 +357,8 @@ class SnowflakeRelationBuilderSpec
         UnresolvedRelation(
           ruleText = "MATCH_RECOGNIZE()",
           message = "Unimplemented visitor visitMatchRecognize in class SnowflakeRelationBuilder",
-          ruleName = "some rule",
-          tokenName = Some("sometoken")))
+          ruleName = "matchRecognize",
+          tokenName = Some("MATCH_RECOGNIZE")))
     }
   }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -815,14 +815,14 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Seq(
             Assign(Column(None, Id("a")), Literal(1)),
             UnresolvedFunction(
-              "Transform",
+              "udf.Transform",
               Seq(Column(None, Id("b"))),
               is_distinct = false,
               is_user_defined_function = true,
-              ruleText = "Transform(...)",
+              ruleText = "udf.Transform(...)",
               ruleName = "N/A",
               tokenName = Some("N/A"),
-              message = "Function Transform is not convertible to Databricks SQL")),
+              message = "Function udf.Transform is not convertible to Databricks SQL")),
           Some(
             Equals(Column(Some(ObjectReference(Id("t"))), Id("a")), Column(Some(ObjectReference(Id("t1"))), Id("a")))),
           None,

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -815,10 +815,14 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Seq(
             Assign(Column(None, Id("a")), Literal(1)),
             UnresolvedFunction(
-              "udf.Transform",
+              "Transform",
               Seq(Column(None, Id("b"))),
               is_distinct = false,
-              is_user_defined_function = true)),
+              is_user_defined_function = true,
+              ruleText = "Transform(...)",
+              ruleName = "N/A",
+              tokenName = Some("N/A"),
+              message = "Function Transform is not convertible to Databricks SQL")),
           Some(
             Equals(Column(Some(ObjectReference(Id("t"))), Id("a")), Column(Some(ObjectReference(Id("t1"))), Id("a")))),
           None,

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -290,12 +290,15 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
         _.expression(),
         ir.Dot(
           simplyNamedColumn("a"),
-          ir.UnresolvedFunction("b", List(), is_distinct = false, is_user_defined_function = false,
+          ir.UnresolvedFunction(
+            "b",
+            List(),
+            is_distinct = false,
+            is_user_defined_function = false,
             ruleText = "b(...)",
             ruleName = "N/A",
             tokenName = Some("N/A"),
-            message = "Function b is not convertible to Databricks SQL")
-          ))
+            message = "Function b is not convertible to Databricks SQL")))
       exampleExpr(
         "a.b.c()",
         _.expression(),
@@ -303,12 +306,15 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
           simplyNamedColumn("a"),
           ir.Dot(
             simplyNamedColumn("b"),
-            ir.UnresolvedFunction("c", List(), is_distinct = false, is_user_defined_function = false,
+            ir.UnresolvedFunction(
+              "c",
+              List(),
+              is_distinct = false,
+              is_user_defined_function = false,
               ruleText = "c(...)",
               ruleName = "N/A",
               tokenName = Some("N/A"),
-              message = "Function c is not convertible to Databricks SQL")
-            )))
+              message = "Function c is not convertible to Databricks SQL"))))
       exampleExpr(
         "a.b.c.FLOOR(c)",
         _.expression(),
@@ -325,12 +331,15 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
         _.expression(),
         ir.Dot(
           simplyNamedColumn("a"),
-          ir.UnresolvedFunction("UNKNOWN_FUNCTION", List(), is_distinct = false, is_user_defined_function = false,
+          ir.UnresolvedFunction(
+            "UNKNOWN_FUNCTION",
+            List(),
+            is_distinct = false,
+            is_user_defined_function = false,
             ruleText = "UNKNOWN_FUNCTION(...)",
             ruleName = "N/A",
             tokenName = Some("N/A"),
-            message = "Function UNKNOWN_FUNCTION is not convertible to Databricks SQL")
-          ))
+            message = "Function UNKNOWN_FUNCTION is not convertible to Databricks SQL")))
     }
 
     "cover case that cannot happen with dot" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -1,5 +1,7 @@
 package com.databricks.labs.remorph.parsers.tsql
 
+import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser
+import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser.ID
 import com.databricks.labs.remorph.{intermediate => ir}
 import org.antlr.v4.runtime.tree.TerminalNodeImpl
 import org.antlr.v4.runtime.{CommonToken, Token}
@@ -416,6 +418,10 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
       // Ensure that both asterisk() and expressionElem() methods return null
       when(mockCtx.asterisk()).thenReturn(null)
       when(mockCtx.expressionElem()).thenReturn(null)
+      val startTok = new CommonToken(ID, "s")
+      when(mockCtx.getStart).thenReturn(startTok)
+      when(mockCtx.getStop).thenReturn(startTok)
+      when(mockCtx.getRuleIndex).thenReturn(SnowflakeParser.RULE_constraintAction)
 
       // Call the method with the mock instance
       val result = vc.expressionBuilder.visitSelectListElem(mockCtx)

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -290,7 +290,12 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
         _.expression(),
         ir.Dot(
           simplyNamedColumn("a"),
-          ir.UnresolvedFunction("b", List(), is_distinct = false, is_user_defined_function = false)))
+          ir.UnresolvedFunction("b", List(), is_distinct = false, is_user_defined_function = false,
+            ruleText = "b(...)",
+            ruleName = "N/A",
+            tokenName = Some("N/A"),
+            message = "Function b is not convertible to Databricks SQL")
+          ))
       exampleExpr(
         "a.b.c()",
         _.expression(),
@@ -298,7 +303,12 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
           simplyNamedColumn("a"),
           ir.Dot(
             simplyNamedColumn("b"),
-            ir.UnresolvedFunction("c", List(), is_distinct = false, is_user_defined_function = false))))
+            ir.UnresolvedFunction("c", List(), is_distinct = false, is_user_defined_function = false,
+              ruleText = "c(...)",
+              ruleName = "N/A",
+              tokenName = Some("N/A"),
+              message = "Function c is not convertible to Databricks SQL")
+            )))
       exampleExpr(
         "a.b.c.FLOOR(c)",
         _.expression(),
@@ -315,7 +325,12 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
         _.expression(),
         ir.Dot(
           simplyNamedColumn("a"),
-          ir.UnresolvedFunction("UNKNOWN_FUNCTION", List(), is_distinct = false, is_user_defined_function = false)))
+          ir.UnresolvedFunction("UNKNOWN_FUNCTION", List(), is_distinct = false, is_user_defined_function = false,
+            ruleText = "UNKNOWN_FUNCTION(...)",
+            ruleName = "N/A",
+            tokenName = Some("N/A"),
+            message = "Function UNKNOWN_FUNCTION is not convertible to Databricks SQL")
+          ))
     }
 
     "cover case that cannot happen with dot" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
@@ -80,7 +80,7 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
         ruleText = "USER_NAME(...)",
         ruleName = "N/A",
         tokenName = Some("N/A"),
-        message = "Invocation of USER_NAME has incorrect argument count\""))
+        message = "Invocation of USER_NAME has incorrect argument count"))
 
     exampleExpr(
       "FLOOR()", // FLOOR requires 1 argument
@@ -94,7 +94,7 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
         ruleText = "FLOOR(...)",
         ruleName = "N/A",
         tokenName = Some("N/A"),
-        message = "Invocation of FLOOR has incorrect argument count\""))
+        message = "Invocation of FLOOR has incorrect argument count"))
   }
 
   "translate functions that we know cannot be converted" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
@@ -56,11 +56,15 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
     exampleExpr(
       "UNKNOWN_FUNCTION()",
       _.expression(),
-      ir.UnresolvedFunction("UNKNOWN_FUNCTION", List(), is_distinct = false, is_user_defined_function = false))
+      ir.UnresolvedFunction("UNKNOWN_FUNCTION", List(), is_distinct = false, is_user_defined_function = false,
+        ruleText = "UNKNOWN_FUNCTION(...)",
+        ruleName = "N/A",
+        tokenName = Some("N/A"),
+        message = "Function UNKNOWN_FUNCTION is not convertible to Databricks SQL")
+      )
   }
 
   "translate functions with invalid function argument counts" in {
-    // Later, we will register a semantic or lint error
     exampleExpr(
       "USER_NAME('a', 'b', 'c', 'd')", // USER_NAME function only accepts 0 or 1 argument
       _.expression(),
@@ -69,7 +73,12 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
         Seq(ir.Literal("a"), ir.Literal("b"), ir.Literal("c"), ir.Literal("d")),
         is_distinct = false,
         is_user_defined_function = false,
-        has_incorrect_argc = true))
+        has_incorrect_argc = true,
+        ruleText = "USER_NAME(...)",
+        ruleName = "N/A",
+        tokenName = Some("N/A"),
+        message = "Invocation of USER_NAME has incorrect argument count\"")
+      )
 
     exampleExpr(
       "FLOOR()", // FLOOR requires 1 argument
@@ -79,7 +88,12 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
         List(),
         is_distinct = false,
         is_user_defined_function = false,
-        has_incorrect_argc = true))
+        has_incorrect_argc = true,
+        ruleText = "FLOOR(...)",
+        ruleName = "N/A",
+        tokenName = Some("N/A"),
+        message = "Invocation of FLOOR has incorrect argument count\"")
+      )
   }
 
   "translate functions that we know cannot be converted" in {
@@ -91,7 +105,12 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
         "CONNECTIONPROPERTY",
         List(ir.Literal("property")),
         is_distinct = false,
-        is_user_defined_function = false))
+        is_user_defined_function = false,
+        ruleText = "CONNECTIONPROPERTY(...)",
+        ruleName = "N/A",
+        tokenName = Some("N/A"),
+        message = "Function CONNECTIONPROPERTY is not convertible to Databricks SQL")
+      )
   }
 
   "translate windowing functions in all forms" in {
@@ -176,13 +195,29 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
       // TODO: Returns UnresolvedFunction as it is not convertible - create UnsupportedFunctionRule
       "@@CURSOR_ROWS",
       _.expression(),
-      ir.UnresolvedFunction("@@CURSOR_ROWS", List(), is_distinct = false, is_user_defined_function = false))
+      ir.UnresolvedFunction(
+        "@@CURSOR_ROWS",
+        List(),
+        is_distinct = false,
+        is_user_defined_function = false,
+        ruleText = "@@CURSOR_ROWS(...)",
+        ruleName = "N/A",
+        tokenName = Some("N/A"),
+        message = "Function @@CURSOR_ROWS is not convertible to Databricks SQL"))
 
     exampleExpr(
       // TODO: Returns UnresolvedFunction as it is not convertible - create UnsupportedFunctionRule
       "@@FETCH_STATUS",
       _.expression(),
-      ir.UnresolvedFunction("@@FETCH_STATUS", List(), is_distinct = false, is_user_defined_function = false))
+      ir.UnresolvedFunction(
+        "@@FETCH_STATUS",
+        List(),
+        is_distinct = false,
+        is_user_defined_function = false,
+        ruleText = "@@FETCH_STATUS(...)",
+        ruleName = "N/A",
+        tokenName = Some("N/A"),
+        message = "Function @@FETCH_STATUS is not convertible to Databricks SQL"))
 
     exampleExpr("SESSION_USER", _.expression(), ir.CallFunction("SESSION_USER", List()))
 
@@ -331,20 +366,44 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
     exampleExpr(
       query = "FREETEXTTABLE(table, col, 'search')",
       _.expression(),
-      ir.UnresolvedFunction("FREETEXTTABLE", List.empty, is_distinct = false, is_user_defined_function = false))
+      ir.UnresolvedFunction(
+        "FREETEXTTABLE",
+        List.empty,
+        is_distinct = false,
+        is_user_defined_function = false,
+        ruleText = "FREETEXTTABLE(...)",
+        ruleName = "N/A",
+        tokenName = Some("N/A"),
+        message = "Function FREETEXTTABLE is not convertible to Databricks SQL"))
   }
 
   "translate $PARTITION functions as inconvertible" in {
     exampleExpr(
       query = "$PARTITION.partitionFunction(col)",
       _.expression(),
-      ir.UnresolvedFunction("$PARTITION", List.empty, is_distinct = false, is_user_defined_function = false))
+      ir.UnresolvedFunction(
+        "$PARTITION",
+        List.empty,
+        is_distinct = false,
+        is_user_defined_function = false,
+        ruleText = "$PARTITION(...)",
+        ruleName = "N/A",
+        tokenName = Some("N/A"),
+        message = "Function $PARTITION is not convertible to Databricks SQL"))
   }
 
   "translate HIERARCHYID static method as inconvertible" in {
     exampleExpr(
       query = "HIERARCHYID::Parse('1/2/3')",
       _.expression(),
-      ir.UnresolvedFunction("HIERARCHYID", List.empty, is_distinct = false, is_user_defined_function = false))
+      ir.UnresolvedFunction(
+        "HIERARCHYID",
+        List.empty,
+        is_distinct = false,
+        is_user_defined_function = false,
+        ruleText = "HIERARCHYID(...)",
+        ruleName = "N/A",
+        tokenName = Some("N/A"),
+        message = "Function HIERARCHYID is not convertible to Databricks SQL"))
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlFunctionSpec.scala
@@ -56,12 +56,15 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
     exampleExpr(
       "UNKNOWN_FUNCTION()",
       _.expression(),
-      ir.UnresolvedFunction("UNKNOWN_FUNCTION", List(), is_distinct = false, is_user_defined_function = false,
+      ir.UnresolvedFunction(
+        "UNKNOWN_FUNCTION",
+        List(),
+        is_distinct = false,
+        is_user_defined_function = false,
         ruleText = "UNKNOWN_FUNCTION(...)",
         ruleName = "N/A",
         tokenName = Some("N/A"),
-        message = "Function UNKNOWN_FUNCTION is not convertible to Databricks SQL")
-      )
+        message = "Function UNKNOWN_FUNCTION is not convertible to Databricks SQL"))
   }
 
   "translate functions with invalid function argument counts" in {
@@ -77,8 +80,7 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
         ruleText = "USER_NAME(...)",
         ruleName = "N/A",
         tokenName = Some("N/A"),
-        message = "Invocation of USER_NAME has incorrect argument count\"")
-      )
+        message = "Invocation of USER_NAME has incorrect argument count\""))
 
     exampleExpr(
       "FLOOR()", // FLOOR requires 1 argument
@@ -92,8 +94,7 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
         ruleText = "FLOOR(...)",
         ruleName = "N/A",
         tokenName = Some("N/A"),
-        message = "Invocation of FLOOR has incorrect argument count\"")
-      )
+        message = "Invocation of FLOOR has incorrect argument count\""))
   }
 
   "translate functions that we know cannot be converted" in {
@@ -109,8 +110,7 @@ class TSqlFunctionSpec extends AnyWordSpec with TSqlParserTestCommon with Matche
         ruleText = "CONNECTIONPROPERTY(...)",
         ruleName = "N/A",
         tokenName = Some("N/A"),
-        message = "Function CONNECTIONPROPERTY is not convertible to Databricks SQL")
-      )
+        message = "Function CONNECTIONPROPERTY is not convertible to Databricks SQL"))
   }
 
   "translate windowing functions in all forms" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlParserTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlParserTestCommon.scala
@@ -6,7 +6,7 @@ import org.scalatest.Assertions
 
 trait TSqlParserTestCommon extends ParserTestCommon[TSqlParser] { self: Assertions =>
 
-  protected val vc: TSqlVisitorCoordinator = new TSqlVisitorCoordinator(TSqlLexer.VOCABULARY, TSqlParser.VOCABULARY)
+  protected val vc: TSqlVisitorCoordinator = new TSqlVisitorCoordinator(TSqlParser.VOCABULARY, TSqlParser.ruleNames)
   override final protected def makeLexer(chars: CharStream): Lexer = new TSqlLexer(chars)
 
   override final protected def makeErrStrategy(): TSqlErrorStrategy = new TSqlErrorStrategy

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlParserTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlParserTestCommon.scala
@@ -1,13 +1,13 @@
 package com.databricks.labs.remorph.parsers.tsql
 
 import com.databricks.labs.remorph.parsers.{ErrorCollector, ParserTestCommon, ProductionErrorCollector}
-import org.antlr.v4.runtime.{CharStream, TokenSource, TokenStream}
+import org.antlr.v4.runtime.{CharStream, Lexer, TokenStream}
 import org.scalatest.Assertions
 
 trait TSqlParserTestCommon extends ParserTestCommon[TSqlParser] { self: Assertions =>
 
-  val vc: TSqlVisitorCoordinator = new TSqlVisitorCoordinator
-  override final protected def makeLexer(chars: CharStream): TokenSource = new TSqlLexer(chars)
+  protected val vc: TSqlVisitorCoordinator = new TSqlVisitorCoordinator(TSqlLexer.VOCABULARY, TSqlParser.VOCABULARY)
+  override final protected def makeLexer(chars: CharStream): Lexer = new TSqlLexer(chars)
 
   override final protected def makeErrStrategy(): TSqlErrorStrategy = new TSqlErrorStrategy
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/TopPercentToLimitSubqueryTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/TopPercentToLimitSubqueryTest.scala
@@ -15,13 +15,25 @@ class TopPercentToLimitSubqueryTest extends AnyWordSpec with PlanComparison with
         Seq(
           SubqueryAlias(Project(namedTable("Employees"), Seq(Star())), Id("_limited1")),
           SubqueryAlias(
-            Project(UnresolvedRelation("_limited1"), Seq(Alias(Count(Seq(Star())), Id("count")))),
+            Project(
+              UnresolvedRelation(ruleText = "_limited1", message = "Unresolved relation _limited1"),
+              Seq(Alias(Count(Seq(Star())), Id("count")))),
             Id("_counted1"))),
         Limit(
-          Project(UnresolvedRelation("_limited1"), Seq(Star())),
+          Project(
+            UnresolvedRelation(
+              ruleText = "_limited1",
+              message = "Unresolved relation _limited1",
+              ruleName = "rule name undetermined",
+              tokenName = None),
+            Seq(Star())),
           ScalarSubquery(
             Project(
-              UnresolvedRelation("_counted1"),
+              UnresolvedRelation(
+                ruleText = "_counted1",
+                message = "Unresolved relation _counted1",
+                ruleName = "N/A",
+                tokenName = Some("N/A")),
               Seq(Cast(Multiply(Divide(Id("count"), Literal(10)), Literal(100)), LongType)))))))
   }
 
@@ -38,7 +50,7 @@ class TopPercentToLimitSubqueryTest extends AnyWordSpec with PlanComparison with
           SubqueryAlias(Project(namedTable("Employees"), Seq(Star())), Id("_limited1")),
           SubqueryAlias(
             Project(
-              UnresolvedRelation("_limited1"),
+              UnresolvedRelation(ruleText = "_limited1", message = "Unresolved _limited1"),
               Seq(
                 Star(),
                 Alias(
@@ -46,7 +58,14 @@ class TopPercentToLimitSubqueryTest extends AnyWordSpec with PlanComparison with
                   Id("_percentile1")))),
             Id("_with_percentile1"))),
         Filter(
-          Project(UnresolvedRelation("_with_percentile1"), Seq(Star())),
-          LessThanOrEqual(UnresolvedAttribute("_percentile1"), Divide(Literal(10), Literal(100))))))
+          Project(
+            UnresolvedRelation(ruleText = "_with_percentile1", message = "Unresolved _with_percentile1"),
+            Seq(Star())),
+          LessThanOrEqual(
+            UnresolvedAttribute(
+              unparsed_identifier = "_percentile1",
+              ruleText = "_percentile1",
+              message = "Unresolved _percentile1"),
+            Divide(Literal(10), Literal(100))))))
   }
 }


### PR DESCRIPTION
Here we add additional information to Unresolved nodes so that we can count how many times a particular parser rule was unable to handle certain syntaxes. 

NB: This appears to b e a huge PR, but a lot of the changes are repetitive changes for many tests and many error returns, so it is a lot smaller than it looks.