### PR TITLE
Enhance the Snow ARRAY_SORT function support

### DIFF
--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/rules/SnowflakeCallMapperSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/rules/SnowflakeCallMapperSpec.scala
@@ -138,7 +138,69 @@ class SnowflakeCallMapperSpec extends AnyWordSpec with Matchers {
         ir.Cast(ir.Literal("2020-04-15 08:00:00"), ir.TimestampType),
         ir.Literal.True)
 
+      ir.CallFunction(
+        "ARRAY_SORT",
+        Seq(
+          ir.CreateArray(
+            Seq(ir.Literal(0), ir.Literal(2), ir.Literal(4), ir.Literal.Null, ir.Literal(5), ir.Literal.Null)),
+          ir.Literal.True,
+          ir.Literal.True)) becomes ir.SortArray(
+        ir.CreateArray(
+          Seq(ir.Literal(0), ir.Literal(2), ir.Literal(4), ir.Literal.Null, ir.Literal(5), ir.Literal.Null)),
+        None)
+
+      ir.CallFunction(
+        "ARRAY_SORT",
+        Seq(
+          ir.CreateArray(
+            Seq(ir.Literal(0), ir.Literal(2), ir.Literal(4), ir.Literal.Null, ir.Literal(5), ir.Literal.Null)),
+          ir.Literal.False,
+          ir.Literal.False)) becomes ir.SortArray(
+        ir.CreateArray(
+          Seq(ir.Literal(0), ir.Literal(2), ir.Literal(4), ir.Literal.Null, ir.Literal(5), ir.Literal.Null)),
+        Some(ir.Literal.False))
+
+      ir.CallFunction(
+        "ARRAY_SORT",
+        Seq(
+          ir.CreateArray(
+            Seq(ir.Literal(0), ir.Literal(2), ir.Literal(4), ir.Literal.Null, ir.Literal(5), ir.Literal.Null)),
+          ir.Literal.True,
+          ir.Literal.False)) becomes ir.ArraySort(
+        ir.CreateArray(
+          Seq(ir.Literal(0), ir.Literal(2), ir.Literal(4), ir.Literal.Null, ir.Literal(5), ir.Literal.Null)),
+        ir.LambdaFunction(
+          ir.Case(
+            None,
+            Seq(
+              ir.WhenBranch(ir.And(ir.IsNull(ir.Id("left")), ir.IsNull(ir.Id("right"))), ir.Literal(0)),
+              ir.WhenBranch(ir.IsNull(ir.Id("left")), ir.Literal(1)),
+              ir.WhenBranch(ir.IsNull(ir.Id("right")), ir.Literal(-1)),
+              ir.WhenBranch(ir.LessThan(ir.Id("left"), ir.Id("right")), ir.Literal(-1)),
+              ir.WhenBranch(ir.GreaterThan(ir.Id("left"), ir.Id("right")), ir.Literal(1))),
+            Some(ir.Literal(0))),
+          Seq(ir.UnresolvedNamedLambdaVariable(Seq("left")), ir.UnresolvedNamedLambdaVariable(Seq("right")))))
     }
+
+    ir.CallFunction(
+      "ARRAY_SORT",
+      Seq(
+        ir.CreateArray(
+          Seq(ir.Literal(0), ir.Literal(2), ir.Literal(4), ir.Literal.Null, ir.Literal(5), ir.Literal.Null)),
+        ir.Literal.False,
+        ir.Literal.True)) becomes ir.ArraySort(
+      ir.CreateArray(Seq(ir.Literal(0), ir.Literal(2), ir.Literal(4), ir.Literal.Null, ir.Literal(5), ir.Literal.Null)),
+      ir.LambdaFunction(
+        ir.Case(
+          None,
+          Seq(
+            ir.WhenBranch(ir.And(ir.IsNull(ir.Id("left")), ir.IsNull(ir.Id("right"))), ir.Literal(0)),
+            ir.WhenBranch(ir.IsNull(ir.Id("left")), ir.Literal(-1)),
+            ir.WhenBranch(ir.IsNull(ir.Id("right")), ir.Literal(1)),
+            ir.WhenBranch(ir.LessThan(ir.Id("left"), ir.Id("right")), ir.Literal(1)),
+            ir.WhenBranch(ir.GreaterThan(ir.Id("left"), ir.Id("right")), ir.Literal(-1))),
+          Some(ir.Literal(0))),
+        Seq(ir.UnresolvedNamedLambdaVariable(Seq("left")), ir.UnresolvedNamedLambdaVariable(Seq("right")))))
 
     "ARRAY_SLICE index shift" in {
       ir.CallFunction("ARRAY_SLICE", Seq(ir.Id("arr1"), ir.IntLiteral(0), ir.IntLiteral(2))) becomes ir.Slice(


### PR DESCRIPTION
It has been decided that only Boolean literals will be supported in the Boolean parameters for now. This PR makes the required changes to accommodate this.

Added corresponding test cases.