### PR TITLE
Add rule name and token name to syntax error reporting

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/errors.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/errors.scala
@@ -11,7 +11,9 @@ case class ParsingError(
     charPositionInLine: Int,
     msg: String,
     offendingTokenWidth: Int,
-    offendingTokenText: String)
+    offendingTokenText: String,
+    offendingTokenName: String,
+    ruleName: String)
     extends RemorphError
 
 object ParsingError {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlErrorHandlerSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlErrorHandlerSpec.scala
@@ -30,10 +30,15 @@ class TSqlErrorHandlerSpec extends AnyFlatSpec with Matchers {
   "ErrorCollector" should "collect syntax errors correctly" in {
     val errorCollector = new ProductionErrorCollector("sourceCode", "fileName")
     val token = new CommonToken(1)
-    val recognizer: Null = null
-    val e: Null = null
-    errorCollector.syntaxError(recognizer, token, 1, 1, "msg", e)
-    errorCollector.errors.head shouldBe ParsingError(1, 1, "msg", 1, null)
+    errorCollector.syntaxError(null, token, 1, 1, "msg", null)
+    errorCollector.errors.head shouldBe ParsingError(
+      1,
+      1,
+      "msg",
+      1,
+      null,
+      "unresolved token name",
+      "unresolved rule name")
   }
 
   it should "format errors correctly" in {
@@ -42,7 +47,7 @@ class TSqlErrorHandlerSpec extends AnyFlatSpec with Matchers {
     token.setLine(1)
     token.setCharPositionInLine(1)
     token.setText("text")
-    errorCollector.errors += ParsingError(1, 1, "msg", 4, "text")
+    errorCollector.errors += ParsingError(1, 1, "msg", 4, "text", "unresolved token name", "unresolved rule name")
     errorCollector.formatErrors.head should include("Token: text")
   }
 
@@ -52,7 +57,7 @@ class TSqlErrorHandlerSpec extends AnyFlatSpec with Matchers {
     token.setLine(1)
     token.setCharPositionInLine(1)
     token.setText("text")
-    errorCollector.errors += ParsingError(1, 1, "msg", 4, "text")
+    errorCollector.errors += ParsingError(1, 1, "msg", 4, "text", "unresolved token name", "unresolved rule name")
     errorCollector.errorsAsJson should include("\"line\":1")
   }
 
@@ -62,7 +67,7 @@ class TSqlErrorHandlerSpec extends AnyFlatSpec with Matchers {
     token.setLine(1)
     token.setCharPositionInLine(1)
     token.setText("text")
-    errorCollector.errors += ParsingError(1, 1, "msg", 4, "text")
+    errorCollector.errors += ParsingError(1, 1, "msg", 4, "text", "unresolved token name", "unresolved rule name")
     errorCollector.errorCount shouldBe 1
   }
 
@@ -75,7 +80,7 @@ class TSqlErrorHandlerSpec extends AnyFlatSpec with Matchers {
     token.setStartIndex(40)
     token.setStopIndex(44)
     token.setText("error")
-    errorCollector.errors += ParsingError(1, 40, "msg", 5, "error")
+    errorCollector.errors += ParsingError(1, 40, "msg", 5, "error", "unresolved token name", "unresolved rule name")
 
     // Call the method
     val formattedErrors = errorCollector.formatErrors
@@ -91,7 +96,7 @@ class TSqlErrorHandlerSpec extends AnyFlatSpec with Matchers {
     token.setLine(1)
     token.setCharPositionInLine(1)
     token.setText("text")
-    errorCollector.errors += ParsingError(1, 1, "msg", 4, "text")
+    errorCollector.errors += ParsingError(1, 1, "msg", 4, "text", "unresolved token name", "unresolved rule name")
 
     // Capture the logs
     val logger: Logger = LogManager.getLogger("com.databricks.labs.remorph.parsers.ErrorCollector")
@@ -138,7 +143,8 @@ class TSqlErrorHandlerSpec extends AnyFlatSpec with Matchers {
     errorCollector.syntaxError(null, token, 10, 5, "Syntax error message", null)
 
     errorCollector.errorCount shouldBe 1
-    errorCollector.errors should contain(ParsingError(10, 5, "Syntax error message", 9, "errorText"))
+    errorCollector.errors should contain(
+      ParsingError(10, 5, "Syntax error message", 9, "errorText", "unresolved token name", "unresolved rule name"))
   }
 
   def captureStdErr[T](block: => T): (T, String) = {


### PR DESCRIPTION
In order that our various coverage tests and conversion metrics are able to report on which rules and tokens are most commonly found to yield errors, we must adorn the syntax error class with those items. 

With this improvement, we can provide coverage and estimation reports that indicate where the most common errors are being found. From there we can indicate solving which errors might be likely to progress a conversion the quickest and in terms of coverage, addressing which errors would increase coverage the most.