### PR TITLE
Return `Result` out of generators, instead of throwing exceptions

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/Result.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/Result.scala
@@ -1,4 +1,13 @@
-package com.databricks.labs.remorph.transpilers
+package com.databricks.labs.remorph
+
+sealed trait WorkflowStage
+object WorkflowStage {
+  case object PARSE extends WorkflowStage
+  case object PLAN extends WorkflowStage
+  case object OPTIMIZE extends WorkflowStage
+  case object GENERATE extends WorkflowStage
+}
+
 
 sealed trait Result[+A] {
   def map[B](f: A => B): Result[B]

--- a/core/src/main/scala/com/databricks/labs/remorph/Result.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/Result.scala
@@ -1,5 +1,7 @@
 package com.databricks.labs.remorph
 
+import com.databricks.labs.remorph.intermediate.RemorphError
+
 sealed trait WorkflowStage
 object WorkflowStage {
   case object PARSE extends WorkflowStage
@@ -8,10 +10,10 @@ object WorkflowStage {
   case object GENERATE extends WorkflowStage
 }
 
-
 sealed trait Result[+A] {
   def map[B](f: A => B): Result[B]
   def flatMap[B](f: A => Result[B]): Result[B]
+  def isSuccess: Boolean
 }
 
 object Result {
@@ -19,11 +21,16 @@ object Result {
     override def map[B](f: A => B): Result[B] = Success(f(output))
 
     override def flatMap[B](f: A => Result[B]): Result[B] = f(output)
+
+    override def isSuccess: Boolean = true
   }
 
-  case class Failure(stage: WorkflowStage, errorJson: String) extends Result[Nothing] {
+  case class Failure(stage: WorkflowStage, error: RemorphError) extends Result[Nothing] {
     override def map[B](f: Nothing => B): Result[B] = this
 
     override def flatMap[B](f: Nothing => Result[B]): Result[B] = this
+
+    override def isSuccess: Boolean = false
   }
+
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
@@ -3,32 +3,29 @@ package com.databricks.labs.remorph.coverage
 import com.databricks.labs.remorph.queries.ExampleQuery
 import com.databricks.labs.remorph.Result
 import com.databricks.labs.remorph.WorkflowStage.PARSE
+import com.databricks.labs.remorph.intermediate.UnexpectedOutput
 import com.databricks.labs.remorph.transpilers._
-import com.databricks.labs.remorph.utils.Strings
 
 trait QueryRunner extends Formatter {
   def runQuery(exampleQuery: ExampleQuery): ReportEntryReport
 
-  protected def compareQueries(expected: String, actual: String): String = {
-    s"""
-       |=== Unexpected output (expected vs actual) ===
-       |${Strings.sideBySide(format(expected), format(actual)).mkString("\n")}
-       |""".stripMargin
-  }
 }
 
 abstract class BaseQueryRunner(transpiler: Transpiler) extends QueryRunner {
 
   override def runQuery(exampleQuery: ExampleQuery): ReportEntryReport = {
     transpiler.transpile(SourceCode(exampleQuery.query)) match {
-      case Result.Failure(PARSE, error) => ReportEntryReport(statements = 1, parsing_error = Some(error.toString))
+      case Result.Failure(PARSE, error) => ReportEntryReport(statements = 1, parsing_error = Some(error))
       case Result.Failure(_, error) =>
         // If we got past the PARSE stage, then remember to record that we parsed it correctly
-        ReportEntryReport(parsed = 1, statements = 1, transpilation_error = Some(error.toString))
+        ReportEntryReport(parsed = 1, statements = 1, transpilation_error = Some(error))
       case Result.Success(output) =>
         if (exampleQuery.expectedTranslation.map(format).exists(_ != format(output))) {
           val expected = exampleQuery.expectedTranslation.getOrElse("")
-          ReportEntryReport(parsed = 1, statements = 1, transpilation_error = Some(compareQueries(expected, output)))
+          ReportEntryReport(
+            parsed = 1,
+            statements = 1,
+            transpilation_error = Some(UnexpectedOutput(format(expected), format(output))))
         } else {
           ReportEntryReport(parsed = 1, transpiled = 1, statements = 1, transpiled_statements = 1)
         }

--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
@@ -1,7 +1,8 @@
 package com.databricks.labs.remorph.coverage
 
 import com.databricks.labs.remorph.queries.ExampleQuery
-import com.databricks.labs.remorph.transpilers.WorkflowStage.PARSE
+import com.databricks.labs.remorph.Result
+import com.databricks.labs.remorph.WorkflowStage.PARSE
 import com.databricks.labs.remorph.transpilers._
 import com.databricks.labs.remorph.utils.Strings
 

--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/QueryRunner.scala
@@ -21,10 +21,10 @@ abstract class BaseQueryRunner(transpiler: Transpiler) extends QueryRunner {
 
   override def runQuery(exampleQuery: ExampleQuery): ReportEntryReport = {
     transpiler.transpile(SourceCode(exampleQuery.query)) match {
-      case Result.Failure(PARSE, errorJson) => ReportEntryReport(statements = 1, parsing_error = Some(errorJson))
-      case Result.Failure(_, errorJson) =>
+      case Result.Failure(PARSE, error) => ReportEntryReport(statements = 1, parsing_error = Some(error.toString))
+      case Result.Failure(_, error) =>
         // If we got past the PARSE stage, then remember to record that we parsed it correctly
-        ReportEntryReport(parsed = 1, statements = 1, transpilation_error = Some(errorJson))
+        ReportEntryReport(parsed = 1, statements = 1, transpilation_error = Some(error.toString))
       case Result.Success(output) =>
         if (exampleQuery.expectedTranslation.map(format).exists(_ != format(output))) {
           val expected = exampleQuery.expectedTranslation.getOrElse("")

--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/Estimator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/Estimator.scala
@@ -48,7 +48,7 @@ class Estimator(queryHistory: QueryHistoryProvider, planParser: PlanParser[_], a
         case Failure(PARSE, error) =>
           Some(
             EstimationReportRecord(
-              EstimationTranspilationReport(Some(query.source), statements = 1, parsing_error = Some(error.toString)),
+              EstimationTranspilationReport(Some(query.source), statements = 1, parsing_error = Some(error.msg)),
               EstimationAnalysisReport(
                 score = RuleScore(ParseFailureRule(), Seq.empty),
                 complexity = SqlComplexity.VERY_COMPLEX)))
@@ -59,7 +59,7 @@ class Estimator(queryHistory: QueryHistoryProvider, planParser: PlanParser[_], a
               EstimationTranspilationReport(
                 Some(query.source),
                 statements = 1,
-                transpilation_error = Some(error.toString)),
+                transpilation_error = Some(error.msg)),
               EstimationAnalysisReport(
                 score = RuleScore(PlanFailureRule(), Seq.empty),
                 complexity = SqlComplexity.VERY_COMPLEX)))
@@ -108,7 +108,7 @@ class Estimator(queryHistory: QueryHistoryProvider, planParser: PlanParser[_], a
             query = Some(query.source),
             statements = 1,
             parsed = 1,
-            transpilation_error = Some(error.toString)),
+            transpilation_error = Some(error.msg)),
           EstimationAnalysisReport(
             fingerprint = Some(anonymizer(query, plan)),
             score = tfr,

--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/Estimator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/Estimator.scala
@@ -4,8 +4,8 @@ import com.databricks.labs.remorph.coverage._
 import com.databricks.labs.remorph.discovery.{Anonymizer, ExecutedQuery, QueryHistoryProvider}
 import com.databricks.labs.remorph.parsers.PlanParser
 import com.databricks.labs.remorph.intermediate.LogicalPlan
-import com.databricks.labs.remorph.transpilers.Result.{Failure, Success}
-import com.databricks.labs.remorph.transpilers.WorkflowStage.{PARSE, PLAN}
+import com.databricks.labs.remorph.Result.{Failure, Success}
+import com.databricks.labs.remorph.WorkflowStage.{PARSE, PLAN}
 import com.databricks.labs.remorph.transpilers.{SourceCode, SqlGenerator}
 import com.typesafe.scalalogging.LazyLogging
 

--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/Estimator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/Estimator.scala
@@ -56,10 +56,7 @@ class Estimator(queryHistory: QueryHistoryProvider, planParser: PlanParser[_], a
         case Failure(PLAN, error) =>
           Some(
             EstimationReportRecord(
-              EstimationTranspilationReport(
-                Some(query.source),
-                statements = 1,
-                transpilation_error = Some(error.msg)),
+              EstimationTranspilationReport(Some(query.source), statements = 1, transpilation_error = Some(error.msg)),
               EstimationAnalysisReport(
                 score = RuleScore(PlanFailureRule(), Seq.empty),
                 complexity = SqlComplexity.VERY_COMPLEX)))

--- a/core/src/main/scala/com/databricks/labs/remorph/discovery/Anonymizer.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/discovery/Anonymizer.scala
@@ -2,8 +2,8 @@ package com.databricks.labs.remorph.discovery
 
 import com.databricks.labs.remorph.parsers.PlanParser
 import com.databricks.labs.remorph.intermediate._
-import com.databricks.labs.remorph.transpilers.WorkflowStage.PARSE
-import com.databricks.labs.remorph.transpilers.{Result, SourceCode}
+import com.databricks.labs.remorph.{Result, WorkflowStage}
+import com.databricks.labs.remorph.transpilers.SourceCode
 import com.typesafe.scalalogging.LazyLogging
 import upickle.default._
 
@@ -72,7 +72,7 @@ class Anonymizer(parser: PlanParser[_]) extends LazyLogging {
 
   private[discovery] def fingerprint(query: ExecutedQuery): Fingerprint = {
     parser.parse(SourceCode(query.source)).flatMap(parser.visit) match {
-      case Result.Failure(PARSE, errorJson) =>
+      case Result.Failure(WorkflowStage.PARSE, errorJson) =>
         logger.warn(s"Failed to parse query: ${query.source} $errorJson")
         Fingerprint(
           query.id,

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/Generator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/Generator.scala
@@ -1,9 +1,9 @@
 package com.databricks.labs.remorph.generators
 
-import com.databricks.labs.remorph.intermediate.{UnexpectedNode, TreeNode}
-import com.databricks.labs.remorph.transpilers.TranspileException
+import com.databricks.labs.remorph.{Result, WorkflowStage}
+import com.databricks.labs.remorph.intermediate.{TreeNode, UnexpectedNode}
 
 trait Generator[In <: TreeNode[In], Out] {
-  def generate(ctx: GeneratorContext, tree: In): Out
-  def unknown(tree: In): TranspileException = TranspileException(UnexpectedNode(tree))
+  def generate(ctx: GeneratorContext, tree: In): Result[Out]
+  def unknown(tree: In): Result[Out] = Result.Failure(WorkflowStage.GENERATE, UnexpectedNode(tree))
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/ExpressionGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/ExpressionGenerator.scala
@@ -1,9 +1,7 @@
 package com.databricks.labs.remorph.generators.sql
 
 import com.databricks.labs.remorph.generators.{Generator, GeneratorContext}
-import com.databricks.labs.remorph.intermediate.UnexpectedNode
-import com.databricks.labs.remorph.{intermediate => ir}
-import com.databricks.labs.remorph.transpilers.TranspileException
+import com.databricks.labs.remorph.{Result, WorkflowStage, intermediate => ir}
 
 import java.time._
 import java.time.format.DateTimeFormatter
@@ -13,9 +11,9 @@ class ExpressionGenerator extends Generator[ir.Expression, String] {
   private val dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd")
   private val timeFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.of("UTC"))
 
-  override def generate(ctx: GeneratorContext, tree: ir.Expression): String = expression(ctx, tree)
+  override def generate(ctx: GeneratorContext, tree: ir.Expression): SQL = expression(ctx, tree)
 
-  def expression(ctx: GeneratorContext, expr: ir.Expression): String = {
+  def expression(ctx: GeneratorContext, expr: ir.Expression): SQL = {
     expr match {
       case ir.Like(subject, pattern, escape) => likeSingle(ctx, subject, pattern, escape, caseSensitive = true)
       case ir.LikeAny(subject, patterns) => likeMultiple(ctx, subject, patterns, caseSensitive = true, all = false)
@@ -34,7 +32,7 @@ class ExpressionGenerator extends Generator[ir.Expression, String] {
       case s: ir.StructExpr => structExpr(ctx, s)
       case i: ir.IsNull => isNull(ctx, i)
       case i: ir.IsNotNull => isNotNull(ctx, i)
-      case ir.UnresolvedAttribute(name, _, _, _, _, _, _) => name
+      case ir.UnresolvedAttribute(name, _, _, _, _, _, _) => Result.Success(name)
       case d: ir.Dot => dot(ctx, d)
       case i: ir.Id => id(ctx, i)
       case o: ir.ObjectReference => objectReference(ctx, o)
@@ -44,7 +42,7 @@ class ExpressionGenerator extends Generator[ir.Expression, String] {
       case c: ir.Cast => cast(ctx, c)
       case t: ir.TryCast => tryCast(ctx, t)
       case col: ir.Column => column(ctx, col)
-      case _: ir.DeleteAction => "DELETE"
+      case _: ir.DeleteAction => sql"DELETE"
       case ia: ir.InsertAction => insertAction(ctx, ia)
       case ua: ir.UpdateAction => updateAction(ctx, ua)
       case a: ir.Assign => assign(ctx, a)
@@ -54,7 +52,7 @@ class ExpressionGenerator extends Generator[ir.Expression, String] {
       case c: ir.Case => caseWhen(ctx, c)
       case w: ir.Window => window(ctx, w)
       case o: ir.SortOrder => sortOrder(ctx, o)
-      case ir.Exists(subquery) => s"EXISTS (${ctx.logical.generate(ctx, subquery)})"
+      case ir.Exists(subquery) => sql"EXISTS (${ctx.logical.generate(ctx, subquery)})"
       case a: ir.ArrayAccess => arrayAccess(ctx, a)
       case j: ir.JsonAccess => jsonAccess(ctx, j)
       case l: ir.LambdaFunction => lambdaFunction(ctx, l)
@@ -68,43 +66,43 @@ class ExpressionGenerator extends Generator[ir.Expression, String] {
       case i: ir.In => in(ctx, i)
 
       // keep this case after every case involving an `Fn`, otherwise it will make said case unreachable
-      case fn: ir.Fn => s"${fn.prettyName}(${fn.children.map(expression(ctx, _)).mkString(", ")})"
+      case fn: ir.Fn => sql"${fn.prettyName}(${fn.children.map(expression(ctx, _)).mkSql(", ")})"
 
-      case null => "" // don't fail transpilation if the expression is null
-      case x => throw unknown(x)
+      case null => sql"" // don't fail transpilation if the expression is null
+      case x => unknown(x)
     }
   }
 
-  private def structExpr(ctx: GeneratorContext, s: ir.StructExpr): String = {
+  private def structExpr(ctx: GeneratorContext, s: ir.StructExpr): SQL = {
     s.fields
       .map {
         case a: ir.Alias => generate(ctx, a)
-        case s: ir.Star => "*"
+        case s: ir.Star => sql"*"
       }
-      .mkString("STRUCT(", ", ", ")")
+      .mkSql("STRUCT(", ", ", ")")
   }
 
-  private def jsonAccess(ctx: GeneratorContext, j: ir.JsonAccess): String = {
-    val path = jsonPath(j.path).mkString
-    val anchorPath = if (path.head == '.') ':' +: path.tail else path
-    s"${expression(ctx, j.json)}$anchorPath"
+  private def jsonAccess(ctx: GeneratorContext, j: ir.JsonAccess): SQL = {
+    val path = jsonPath(j.path).mkSql
+    val anchorPath = path.map(p => if (p.head == '.') ':' +: p.tail else p)
+    sql"${expression(ctx, j.json)}$anchorPath"
   }
 
-  private def jsonPath(j: ir.Expression): Seq[String] = {
+  private def jsonPath(j: ir.Expression): Seq[SQL] = {
     j match {
-      case ir.Id(name, _) if isValidIdentifier(name) => Seq(s".$name")
-      case ir.Id(name, _) => Seq(s"['$name']".replace("'", "\""))
-      case ir.IntLiteral(value) => Seq(s"[$value]")
-      case ir.StringLiteral(value) => Seq(s"['$value']")
+      case ir.Id(name, _) if isValidIdentifier(name) => Seq(sql".$name")
+      case ir.Id(name, _) => Seq(s"['$name']".replace("'", "\"")).map(Result.Success(_))
+      case ir.IntLiteral(value) => Seq(sql"[$value]")
+      case ir.StringLiteral(value) => Seq(sql"['$value']")
       case ir.Dot(left, right) => jsonPath(left) ++ jsonPath(right)
-      case i: ir.Expression => throw TranspileException(UnexpectedNode(i))
+      case i: ir.Expression => Seq(unknown(i))
     }
   }
 
-  private def isNull(ctx: GeneratorContext, i: ir.IsNull) = s"${expression(ctx, i.left)} IS NULL"
-  private def isNotNull(ctx: GeneratorContext, i: ir.IsNotNull) = s"${expression(ctx, i.left)} IS NOT NULL"
+  private def isNull(ctx: GeneratorContext, i: ir.IsNull) = sql"${expression(ctx, i.left)} IS NULL"
+  private def isNotNull(ctx: GeneratorContext, i: ir.IsNotNull) = sql"${expression(ctx, i.left)} IS NOT NULL"
 
-  private def interval(ctx: GeneratorContext, interval: ir.KnownInterval): String = {
+  private def interval(ctx: GeneratorContext, interval: ir.KnownInterval): SQL = {
     val iType = interval.iType match {
       case ir.YEAR_INTERVAL => "YEAR"
       case ir.MONTH_INTERVAL => "MONTH"
@@ -117,18 +115,21 @@ class ExpressionGenerator extends Generator[ir.Expression, String] {
       case ir.MICROSECOND_INTERVAL => "MICROSECOND"
       case ir.NANOSECOND_INTERVAL => "NANOSECOND"
     }
-    s"INTERVAL ${generate(ctx, interval.value)} ${iType}"
+    sql"INTERVAL ${generate(ctx, interval.value)} ${iType}"
   }
 
-  private def options(ctx: GeneratorContext, opts: ir.Options): String = {
+  private def options(ctx: GeneratorContext, opts: ir.Options): SQL = {
     // First gather the options that are set by expressions
-    val exprOptions = opts.expressionOpts.map { case (key, expression) =>
-      s"     ${key} = ${generate(ctx, expression)}\n"
-    }.mkString
+    val exprOptions = opts.expressionOpts
+      .map { case (key, expression) =>
+        sql"     ${key} = ${generate(ctx, expression)}\n"
+      }
+      .toSeq
+      .mkSql
     val exprStr = if (exprOptions.nonEmpty) {
-      s"    Expression options:\n\n${exprOptions}\n"
+      sql"    Expression options:\n\n${exprOptions}\n"
     } else {
-      ""
+      sql""
     }
 
     val stringOptions = opts.stringOpts.map { case (key, value) =>
@@ -158,49 +159,49 @@ class ExpressionGenerator extends Generator[ir.Expression, String] {
     } else {
       ""
     }
-    val optString = s"${exprStr}${stringStr}${boolStr}${autoStr}"
+    val optString = sql"${exprStr}${stringStr}${boolStr}${autoStr}"
     if (optString.nonEmpty) {
-      s"/*\n   The following statement was originally given the following OPTIONS:\n\n${optString}\n */\n"
+      sql"/*\n   The following statement was originally given the following OPTIONS:\n\n${optString}\n */\n"
     } else {
-      ""
+      sql""
     }
   }
 
-  private def assign(ctx: GeneratorContext, assign: ir.Assign): String = {
-    s"${expression(ctx, assign.left)} = ${expression(ctx, assign.right)}"
+  private def assign(ctx: GeneratorContext, assign: ir.Assign): SQL = {
+    sql"${expression(ctx, assign.left)} = ${expression(ctx, assign.right)}"
   }
 
-  private def column(ctx: GeneratorContext, column: ir.Column): String = {
-    val objectRef = column.tableNameOrAlias.map(or => generateObjectReference(ctx, or) + ".").getOrElse("")
-    s"$objectRef${id(ctx, column.columnName)}"
+  private def column(ctx: GeneratorContext, column: ir.Column): SQL = {
+    val objectRef = column.tableNameOrAlias.map(or => sql"${generateObjectReference(ctx, or)}.").getOrElse("")
+    sql"$objectRef${id(ctx, column.columnName)}"
   }
 
-  private def insertAction(ctx: GeneratorContext, insertAction: ir.InsertAction): String = {
+  private def insertAction(ctx: GeneratorContext, insertAction: ir.InsertAction): SQL = {
     val (cols, values) = insertAction.assignments.map { assign =>
       (generate(ctx, assign.left), generate(ctx, assign.right))
     }.unzip
-    s"INSERT (${cols.mkString(", ")}) VALUES (${values.mkString(", ")})"
+    sql"INSERT (${cols.mkSql(", ")}) VALUES (${values.mkSql(", ")})"
   }
 
-  private def updateAction(ctx: GeneratorContext, updateAction: ir.UpdateAction): String = {
-    s"UPDATE SET ${updateAction.assignments.map(assign => generate(ctx, assign)).mkString(", ")}"
+  private def updateAction(ctx: GeneratorContext, updateAction: ir.UpdateAction): SQL = {
+    sql"UPDATE SET ${updateAction.assignments.map(assign => generate(ctx, assign)).mkSql(", ")}"
   }
 
-  private def arithmetic(ctx: GeneratorContext, expr: ir.Expression): String = expr match {
-    case ir.UMinus(child) => s"-${expression(ctx, child)}"
-    case ir.UPlus(child) => s"+${expression(ctx, child)}"
-    case ir.Multiply(left, right) => s"${expression(ctx, left)} * ${expression(ctx, right)}"
-    case ir.Divide(left, right) => s"${expression(ctx, left)} / ${expression(ctx, right)}"
-    case ir.Mod(left, right) => s"${expression(ctx, left)} % ${expression(ctx, right)}"
-    case ir.Add(left, right) => s"${expression(ctx, left)} + ${expression(ctx, right)}"
-    case ir.Subtract(left, right) => s"${expression(ctx, left)} - ${expression(ctx, right)}"
+  private def arithmetic(ctx: GeneratorContext, expr: ir.Expression): SQL = expr match {
+    case ir.UMinus(child) => sql"-${expression(ctx, child)}"
+    case ir.UPlus(child) => sql"+${expression(ctx, child)}"
+    case ir.Multiply(left, right) => sql"${expression(ctx, left)} * ${expression(ctx, right)}"
+    case ir.Divide(left, right) => sql"${expression(ctx, left)} / ${expression(ctx, right)}"
+    case ir.Mod(left, right) => sql"${expression(ctx, left)} % ${expression(ctx, right)}"
+    case ir.Add(left, right) => sql"${expression(ctx, left)} + ${expression(ctx, right)}"
+    case ir.Subtract(left, right) => sql"${expression(ctx, left)} - ${expression(ctx, right)}"
   }
 
-  private def bitwise(ctx: GeneratorContext, expr: ir.Expression): String = expr match {
-    case ir.BitwiseOr(left, right) => s"${expression(ctx, left)} | ${expression(ctx, right)}"
-    case ir.BitwiseAnd(left, right) => s"${expression(ctx, left)} & ${expression(ctx, right)}"
-    case ir.BitwiseXor(left, right) => s"${expression(ctx, left)} ^ ${expression(ctx, right)}"
-    case ir.BitwiseNot(child) => s"~${expression(ctx, child)}"
+  private def bitwise(ctx: GeneratorContext, expr: ir.Expression): SQL = expr match {
+    case ir.BitwiseOr(left, right) => sql"${expression(ctx, left)} | ${expression(ctx, right)}"
+    case ir.BitwiseAnd(left, right) => sql"${expression(ctx, left)} & ${expression(ctx, right)}"
+    case ir.BitwiseXor(left, right) => sql"${expression(ctx, left)} ^ ${expression(ctx, right)}"
+    case ir.BitwiseNot(child) => sql"~${expression(ctx, child)}"
   }
 
   private def likeSingle(
@@ -208,11 +209,11 @@ class ExpressionGenerator extends Generator[ir.Expression, String] {
       subject: ir.Expression,
       pattern: ir.Expression,
       escapeChar: Option[ir.Expression],
-      caseSensitive: Boolean): String = {
+      caseSensitive: Boolean): SQL = {
     val op = if (caseSensitive) { "LIKE" }
     else { "ILIKE" }
-    val escape = escapeChar.map(char => s" ESCAPE ${expression(ctx, char)}").getOrElse("")
-    s"${expression(ctx, subject)} $op ${expression(ctx, pattern)}$escape"
+    val escape = escapeChar.map(char => sql" ESCAPE ${expression(ctx, char)}").getOrElse(sql"")
+    sql"${expression(ctx, subject)} $op ${expression(ctx, pattern)}$escape"
   }
 
   private def likeMultiple(
@@ -220,158 +221,154 @@ class ExpressionGenerator extends Generator[ir.Expression, String] {
       subject: ir.Expression,
       patterns: Seq[ir.Expression],
       caseSensitive: Boolean,
-      all: Boolean): String = {
+      all: Boolean): SQL = {
     val op = if (caseSensitive) { "LIKE" }
     else { "ILIKE" }
     val allOrAny = if (all) { "ALL" }
     else { "ANY" }
-    s"${expression(ctx, subject)} $op $allOrAny ${patterns.map(expression(ctx, _)).mkString("(", ", ", ")")}"
+    sql"${expression(ctx, subject)} $op $allOrAny ${patterns.map(expression(ctx, _)).mkSql("(", ", ", ")")}"
   }
 
-  private def rlike(ctx: GeneratorContext, r: ir.RLike): String = {
-    s"${expression(ctx, r.left)} RLIKE ${expression(ctx, r.right)}"
+  private def rlike(ctx: GeneratorContext, r: ir.RLike): SQL = {
+    sql"${expression(ctx, r.left)} RLIKE ${expression(ctx, r.right)}"
   }
 
-  private def predicate(ctx: GeneratorContext, expr: ir.Expression): String = expr match {
+  private def predicate(ctx: GeneratorContext, expr: ir.Expression): SQL = expr match {
     case a: ir.And => andPredicate(ctx, a)
     case o: ir.Or => orPredicate(ctx, o)
-    case ir.Not(child) => s"NOT (${expression(ctx, child)})"
-    case ir.Equals(left, right) => s"${expression(ctx, left)} = ${expression(ctx, right)}"
-    case ir.NotEquals(left, right) => s"${expression(ctx, left)} != ${expression(ctx, right)}"
-    case ir.LessThan(left, right) => s"${expression(ctx, left)} < ${expression(ctx, right)}"
-    case ir.LessThanOrEqual(left, right) => s"${expression(ctx, left)} <= ${expression(ctx, right)}"
-    case ir.GreaterThan(left, right) => s"${expression(ctx, left)} > ${expression(ctx, right)}"
-    case ir.GreaterThanOrEqual(left, right) => s"${expression(ctx, left)} >= ${expression(ctx, right)}"
-    case _ => throw new IllegalArgumentException(s"Unsupported expression: $expr")
+    case ir.Not(child) => sql"NOT (${expression(ctx, child)})"
+    case ir.Equals(left, right) => sql"${expression(ctx, left)} = ${expression(ctx, right)}"
+    case ir.NotEquals(left, right) => sql"${expression(ctx, left)} != ${expression(ctx, right)}"
+    case ir.LessThan(left, right) => sql"${expression(ctx, left)} < ${expression(ctx, right)}"
+    case ir.LessThanOrEqual(left, right) => sql"${expression(ctx, left)} <= ${expression(ctx, right)}"
+    case ir.GreaterThan(left, right) => sql"${expression(ctx, left)} > ${expression(ctx, right)}"
+    case ir.GreaterThanOrEqual(left, right) => sql"${expression(ctx, left)} >= ${expression(ctx, right)}"
+    case _ => unknown(expr)
   }
 
-  private def andPredicate(ctx: GeneratorContext, a: ir.And): String = a match {
+  private def andPredicate(ctx: GeneratorContext, a: ir.And): SQL = a match {
     case ir.And(ir.Or(ol, or), right) =>
-      s"(${expression(ctx, ol)} OR ${expression(ctx, or)}) AND ${expression(ctx, right)}"
+      sql"(${expression(ctx, ol)} OR ${expression(ctx, or)}) AND ${expression(ctx, right)}"
     case ir.And(left, ir.Or(ol, or)) =>
-      s"${expression(ctx, left)} AND (${expression(ctx, ol)} OR ${expression(ctx, or)})"
-    case ir.And(left, right) => s"${expression(ctx, left)} AND ${expression(ctx, right)}"
+      sql"${expression(ctx, left)} AND (${expression(ctx, ol)} OR ${expression(ctx, or)})"
+    case ir.And(left, right) => sql"${expression(ctx, left)} AND ${expression(ctx, right)}"
   }
 
-  private def orPredicate(ctx: GeneratorContext, a: ir.Or): String = a match {
+  private def orPredicate(ctx: GeneratorContext, a: ir.Or): SQL = a match {
     case ir.Or(ir.And(ol, or), right) =>
-      s"(${expression(ctx, ol)} AND ${expression(ctx, or)}) OR ${expression(ctx, right)}"
+      sql"(${expression(ctx, ol)} AND ${expression(ctx, or)}) OR ${expression(ctx, right)}"
     case ir.Or(left, ir.And(ol, or)) =>
-      s"${expression(ctx, left)} OR (${expression(ctx, ol)} AND ${expression(ctx, or)})"
-    case ir.Or(left, right) => s"${expression(ctx, left)} OR ${expression(ctx, right)}"
+      sql"${expression(ctx, left)} OR (${expression(ctx, ol)} AND ${expression(ctx, or)})"
+    case ir.Or(left, right) => sql"${expression(ctx, left)} OR ${expression(ctx, right)}"
   }
 
-  private def literal(ctx: GeneratorContext, l: ir.Literal): String = l match {
-    case ir.Literal(_, ir.NullType) => "NULL"
-    case ir.Literal(bytes: Array[Byte], ir.BinaryType) => bytes.map("%02X" format _).mkString
-    case ir.Literal(value, ir.BooleanType) => value.toString.toLowerCase(Locale.getDefault)
-    case ir.Literal(value, ir.ShortType) => value.toString
-    case ir.IntLiteral(value) => value.toString
-    case ir.Literal(value, ir.LongType) => value.toString
-    case ir.FloatLiteral(value) => value.toString
-    case ir.DoubleLiteral(value) => value.toString
-    case ir.DecimalLiteral(value) => value.toString
+  private def literal(ctx: GeneratorContext, l: ir.Literal): SQL = l match {
+    case ir.Literal(_, ir.NullType) => sql"NULL"
+    case ir.Literal(bytes: Array[Byte], ir.BinaryType) => Result.Success(bytes.map("%02X" format _).mkString)
+    case ir.Literal(value, ir.BooleanType) => Result.Success(value.toString.toLowerCase(Locale.getDefault))
+    case ir.Literal(value, ir.ShortType) => Result.Success(value.toString)
+    case ir.IntLiteral(value) => Result.Success(value.toString)
+    case ir.Literal(value, ir.LongType) => Result.Success(value.toString)
+    case ir.FloatLiteral(value) => Result.Success(value.toString)
+    case ir.DoubleLiteral(value) => Result.Success(value.toString)
+    case ir.DecimalLiteral(value) => Result.Success(value.toString)
     case ir.Literal(value: String, ir.StringType) => singleQuote(value)
     case ir.Literal(epochDay: Long, ir.DateType) =>
       val dateStr = singleQuote(LocalDate.ofEpochDay(epochDay).format(dateFormat))
-      s"CAST($dateStr AS DATE)"
+      sql"CAST($dateStr AS DATE)"
     case ir.Literal(epochSecond: Long, ir.TimestampType) =>
       val timestampStr = singleQuote(
         LocalDateTime
           .from(ZonedDateTime.ofInstant(Instant.ofEpochSecond(epochSecond), ZoneId.of("UTC")))
           .format(timeFormat))
-      s"CAST($timestampStr AS TIMESTAMP)"
-    case _ =>
-      throw new IllegalArgumentException(s"Unsupported expression: ${l.dataType}")
+      sql"CAST($timestampStr AS TIMESTAMP)"
+    case _ => Result.Failure(WorkflowStage.GENERATE, ir.UnsupportedDataType(l.dataType))
   }
 
-  private def arrayExpr(ctx: GeneratorContext, a: ir.ArrayExpr): String = {
-    val elementsStr = a.children.map(expression(ctx, _)).mkString(", ")
-    s"ARRAY($elementsStr)"
+  private def arrayExpr(ctx: GeneratorContext, a: ir.ArrayExpr): SQL = {
+    val elementsStr = a.children.map(expression(ctx, _)).mkSql(", ")
+    sql"ARRAY($elementsStr)"
   }
 
-  private def mapExpr(ctx: GeneratorContext, m: ir.MapExpr): String = {
+  private def mapExpr(ctx: GeneratorContext, m: ir.MapExpr): SQL = {
     val entriesStr = m.map
       .map { case (key, value) =>
-        s"${expression(ctx, key)}, ${expression(ctx, value)}"
+        sql"${expression(ctx, key)}, ${expression(ctx, value)}"
       }
-      .mkString(", ")
-    s"MAP($entriesStr)"
+      .toSeq
+      .mkSql(", ")
+    sql"MAP($entriesStr)"
   }
 
-  private def id(ctx: GeneratorContext, id: ir.Id): String = id match {
-    case ir.Id(name, true) => s"`$name`"
-    case ir.Id(name, false) => name
+  private def id(ctx: GeneratorContext, id: ir.Id): SQL = id match {
+    case ir.Id(name, true) => sql"`$name`"
+    case ir.Id(name, false) => Result.Success(name)
   }
 
-  private def alias(ctx: GeneratorContext, alias: ir.Alias): String = {
-    s"${expression(ctx, alias.expr)} AS ${expression(ctx, alias.name)}"
+  private def alias(ctx: GeneratorContext, alias: ir.Alias): SQL = {
+    sql"${expression(ctx, alias.expr)} AS ${expression(ctx, alias.name)}"
   }
 
-  private def distinct(ctx: GeneratorContext, distinct: ir.Distinct): String = {
-    s"DISTINCT ${expression(ctx, distinct.expression)}"
+  private def distinct(ctx: GeneratorContext, distinct: ir.Distinct): SQL = {
+    sql"DISTINCT ${expression(ctx, distinct.expression)}"
   }
 
-  private def star(ctx: GeneratorContext, star: ir.Star): String = {
-    val objectRef = star.objectName.map(or => generateObjectReference(ctx, or) + ".").getOrElse("")
-    s"$objectRef*"
+  private def star(ctx: GeneratorContext, star: ir.Star): SQL = {
+    val objectRef = star.objectName.map(or => sql"${generateObjectReference(ctx, or)}.").getOrElse(sql"")
+    sql"$objectRef*"
   }
 
-  private def generateObjectReference(ctx: GeneratorContext, reference: ir.ObjectReference): String = {
-    (reference.head +: reference.tail).map(id(ctx, _)).mkString(".")
+  private def generateObjectReference(ctx: GeneratorContext, reference: ir.ObjectReference): SQL = {
+    (reference.head +: reference.tail).map(id(ctx, _)).mkSql(".")
   }
 
-  private def cast(ctx: GeneratorContext, cast: ir.Cast): String = {
+  private def cast(ctx: GeneratorContext, cast: ir.Cast): SQL = {
     castLike(ctx, "CAST", cast.expr, cast.dataType)
   }
 
-  private def tryCast(ctx: GeneratorContext, tryCast: ir.TryCast): String = {
+  private def tryCast(ctx: GeneratorContext, tryCast: ir.TryCast): SQL = {
     castLike(ctx, "TRY_CAST", tryCast.expr, tryCast.dataType)
   }
 
-  private def castLike(
-      ctx: GeneratorContext,
-      prettyName: String,
-      expr: ir.Expression,
-      dataType: ir.DataType): String = {
+  private def castLike(ctx: GeneratorContext, prettyName: String, expr: ir.Expression, dataType: ir.DataType): SQL = {
     val e = expression(ctx, expr)
     val dt = DataTypeGenerator.generateDataType(ctx, dataType)
-    s"$prettyName($e AS $dt)"
+    sql"$prettyName($e AS $dt)"
   }
 
-  private def dot(ctx: GeneratorContext, dot: ir.Dot): String = {
-    s"${expression(ctx, dot.left)}.${expression(ctx, dot.right)}"
+  private def dot(ctx: GeneratorContext, dot: ir.Dot): SQL = {
+    sql"${expression(ctx, dot.left)}.${expression(ctx, dot.right)}"
   }
 
-  private def objectReference(ctx: GeneratorContext, objRef: ir.ObjectReference): String = {
-    (objRef.head +: objRef.tail).map(id(ctx, _)).mkString(".")
+  private def objectReference(ctx: GeneratorContext, objRef: ir.ObjectReference): SQL = {
+    (objRef.head +: objRef.tail).map(id(ctx, _)).mkSql(".")
   }
 
-  private def caseWhen(ctx: GeneratorContext, c: ir.Case): String = {
+  private def caseWhen(ctx: GeneratorContext, c: ir.Case): SQL = {
     val expr = c.expression.map(expression(ctx, _)).toSeq
     val branches = c.branches.map { branch =>
-      s"WHEN ${expression(ctx, branch.condition)} THEN ${expression(ctx, branch.expression)}"
+      sql"WHEN ${expression(ctx, branch.condition)} THEN ${expression(ctx, branch.expression)}"
     }
-    val otherwise = c.otherwise.map { o => s"ELSE ${expression(ctx, o)}" }.toSeq
+    val otherwise = c.otherwise.map { o => sql"ELSE ${expression(ctx, o)}" }.toSeq
     val chunks = expr ++ branches ++ otherwise
-    chunks.mkString("CASE ", " ", " END")
+    chunks.mkSql("CASE ", " ", " END")
   }
 
-  private def in(ctx: GeneratorContext, inExpr: ir.In): String = {
-    val values = inExpr.other.map(expression(ctx, _)).mkString(", ")
-    s"${expression(ctx, inExpr.left)} IN ($values)"
+  private def in(ctx: GeneratorContext, inExpr: ir.In): SQL = {
+    val values = inExpr.other.map(expression(ctx, _)).mkSql(", ")
+    sql"${expression(ctx, inExpr.left)} IN ($values)"
   }
 
-  private def scalarSubquery(ctx: GeneratorContext, subquery: ir.ScalarSubquery): String = {
+  private def scalarSubquery(ctx: GeneratorContext, subquery: ir.ScalarSubquery): SQL = {
     ctx.logical.generate(ctx, subquery.relation)
   }
 
-  private def window(ctx: GeneratorContext, window: ir.Window): String = {
+  private def window(ctx: GeneratorContext, window: ir.Window): SQL = {
     val expr = expression(ctx, window.window_function)
-    val partition = if (window.partition_spec.isEmpty) { "" }
-    else { window.partition_spec.map(expression(ctx, _)).mkString("PARTITION BY ", ", ", "") }
-    val orderBy = if (window.sort_order.isEmpty) { "" }
-    else { window.sort_order.map(sortOrder(ctx, _)).mkString(" ORDER BY ", ", ", "") }
+    val partition = if (window.partition_spec.isEmpty) { sql"" }
+    else { window.partition_spec.map(expression(ctx, _)).mkSql("PARTITION BY ", ", ", "") }
+    val orderBy = if (window.sort_order.isEmpty) { sql"" }
+    else { window.sort_order.map(sortOrder(ctx, _)).mkSql(" ORDER BY ", ", ", "") }
     val windowFrame = window.frame_spec
       .map { frame =>
         val mode = frame.frame_type match {
@@ -379,100 +376,101 @@ class ExpressionGenerator extends Generator[ir.Expression, String] {
           case ir.RangeFrame => "RANGE"
         }
         val boundaries = frameBoundary(ctx, frame.lower) ++ frameBoundary(ctx, frame.upper)
-        val frameBoundaries = if (boundaries.size < 2) { boundaries.mkString }
-        else { boundaries.mkString("BETWEEN ", " AND ", "") }
-        s" $mode $frameBoundaries"
+        val frameBoundaries = if (boundaries.size < 2) { boundaries.mkSql }
+        else { boundaries.mkSql("BETWEEN ", " AND ", "") }
+        sql" $mode $frameBoundaries"
       }
-      .getOrElse("")
+      .getOrElse(sql"")
     if (window.ignore_nulls) {
-      return s"$expr IGNORE NULLS OVER ($partition$orderBy$windowFrame)"
+      return sql"$expr IGNORE NULLS OVER ($partition$orderBy$windowFrame)"
     }
 
-    s"$expr OVER ($partition$orderBy$windowFrame)"
+    sql"$expr OVER ($partition$orderBy$windowFrame)"
   }
 
-  private def frameBoundary(ctx: GeneratorContext, boundary: ir.FrameBoundary): Seq[String] = boundary match {
+  private def frameBoundary(ctx: GeneratorContext, boundary: ir.FrameBoundary): Seq[Result[String]] = boundary match {
     case ir.NoBoundary => Seq.empty
-    case ir.CurrentRow => Seq("CURRENT ROW")
-    case ir.UnboundedPreceding => Seq("UNBOUNDED PRECEDING")
-    case ir.UnboundedFollowing => Seq("UNBOUNDED FOLLOWING")
-    case ir.PrecedingN(n) => Seq(s"${expression(ctx, n)} PRECEDING")
-    case ir.FollowingN(n) => Seq(s"${expression(ctx, n)} FOLLOWING")
+    case ir.CurrentRow => Seq(sql"CURRENT ROW")
+    case ir.UnboundedPreceding => Seq(sql"UNBOUNDED PRECEDING")
+    case ir.UnboundedFollowing => Seq(sql"UNBOUNDED FOLLOWING")
+    case ir.PrecedingN(n) => Seq(sql"${expression(ctx, n)} PRECEDING")
+    case ir.FollowingN(n) => Seq(sql"${expression(ctx, n)} FOLLOWING")
   }
 
-  private def sortOrder(ctx: GeneratorContext, order: ir.SortOrder): String = {
+  private def sortOrder(ctx: GeneratorContext, order: ir.SortOrder): SQL = {
     val orderBy = expression(ctx, order.child)
     val direction = order.direction match {
-      case ir.Ascending => Seq("ASC")
-      case ir.Descending => Seq("DESC")
+      case ir.Ascending => Seq(sql"ASC")
+      case ir.Descending => Seq(sql"DESC")
       case ir.UnspecifiedSortDirection => Seq()
     }
     val nulls = order.nullOrdering match {
-      case ir.NullsFirst => Seq("NULLS FIRST")
-      case ir.NullsLast => Seq("NULLS LAST")
+      case ir.NullsFirst => Seq(sql"NULLS FIRST")
+      case ir.NullsLast => Seq(sql"NULLS LAST")
       case ir.SortNullsUnspecified => Seq()
     }
-    (Seq(orderBy) ++ direction ++ nulls).mkString(" ")
+    (Seq(orderBy) ++ direction ++ nulls).mkSql(" ")
   }
 
-  private def regexpExtract(ctx: GeneratorContext, extract: ir.RegExpExtract): String = {
-    val c = if (extract.c == ir.Literal(1)) { "" }
-    else { s", ${expression(ctx, extract.c)}" }
-    s"${extract.prettyName}(${expression(ctx, extract.left)}, ${expression(ctx, extract.right)}$c)"
+  private def regexpExtract(ctx: GeneratorContext, extract: ir.RegExpExtract): SQL = {
+    val c = if (extract.c == ir.Literal(1)) { sql"" }
+    else { sql", ${expression(ctx, extract.c)}" }
+    sql"${extract.prettyName}(${expression(ctx, extract.left)}, ${expression(ctx, extract.right)}$c)"
   }
 
-  private def arrayAccess(ctx: GeneratorContext, access: ir.ArrayAccess): String = {
-    s"${expression(ctx, access.array)}[${expression(ctx, access.index)}]"
+  private def arrayAccess(ctx: GeneratorContext, access: ir.ArrayAccess): SQL = {
+    sql"${expression(ctx, access.array)}[${expression(ctx, access.index)}]"
   }
 
-  private def timestampDiff(ctx: GeneratorContext, diff: ir.TimestampDiff): String = {
-    s"${diff.prettyName}(${diff.unit}, ${expression(ctx, diff.start)}, ${expression(ctx, diff.end)})"
+  private def timestampDiff(ctx: GeneratorContext, diff: ir.TimestampDiff): SQL = {
+    sql"${diff.prettyName}(${diff.unit}, ${expression(ctx, diff.start)}, ${expression(ctx, diff.end)})"
   }
 
-  private def timestampAdd(ctx: GeneratorContext, tsAdd: ir.TimestampAdd): String = {
-    s"${tsAdd.prettyName}(${tsAdd.unit}, ${expression(ctx, tsAdd.quantity)}, ${expression(ctx, tsAdd.timestamp)})"
+  private def timestampAdd(ctx: GeneratorContext, tsAdd: ir.TimestampAdd): SQL = {
+    sql"${tsAdd.prettyName}(${tsAdd.unit}, ${expression(ctx, tsAdd.quantity)}, ${expression(ctx, tsAdd.timestamp)})"
   }
 
-  private def extract(ctx: GeneratorContext, e: ir.Extract): String = {
-    s"EXTRACT(${expression(ctx, e.left)} FROM ${expression(ctx, e.right)})"
+  private def extract(ctx: GeneratorContext, e: ir.Extract): SQL = {
+    sql"EXTRACT(${expression(ctx, e.left)} FROM ${expression(ctx, e.right)})"
   }
 
-  private def lambdaFunction(ctx: GeneratorContext, l: ir.LambdaFunction): String = {
+  private def lambdaFunction(ctx: GeneratorContext, l: ir.LambdaFunction): SQL = {
     val parameterList = l.arguments.map(lambdaArgument)
-    val parameters = if (parameterList.size > 1) { parameterList.mkString("(", ", ", ")") }
-    else { parameterList.mkString }
+    val parameters = if (parameterList.size > 1) { parameterList.mkSql("(", ", ", ")") }
+    else { parameterList.mkSql }
     val body = expression(ctx, l.function)
-    s"$parameters -> $body"
+    sql"$parameters -> $body"
   }
 
-  private def lambdaArgument(arg: ir.UnresolvedNamedLambdaVariable): String = {
-    arg.name_parts.mkString(".")
+  private def lambdaArgument(arg: ir.UnresolvedNamedLambdaVariable): SQL = {
+    Result.Success(arg.name_parts.mkString("."))
   }
 
-  private def variable(ctx: GeneratorContext, v: ir.Variable): String = s"$${${v.name}}"
+  private def variable(ctx: GeneratorContext, v: ir.Variable): SQL = sql"$${${v.name}}"
 
-  private def concat(ctx: GeneratorContext, c: ir.Concat): String = {
+  private def concat(ctx: GeneratorContext, c: ir.Concat): SQL = {
     val args = c.children.map(expression(ctx, _))
     if (c.children.size > 2) {
-      args.mkString(" || ")
+      args.mkSql(" || ")
     } else {
-      args.mkString("CONCAT(", ", ", ")")
+      args.mkSql("CONCAT(", ", ", ")")
     }
   }
 
-  private def schemaReference(ctx: GeneratorContext, s: ir.SchemaReference): String = {
+  private def schemaReference(ctx: GeneratorContext, s: ir.SchemaReference): SQL = {
     val ref = s.columnName match {
       case d: ir.Dot => expression(ctx, d)
       case i: ir.Id => expression(ctx, i)
-      case _ => "JSON_COLUMN"
+      case _ => sql"JSON_COLUMN"
     }
-    s"{${ref.toUpperCase(Locale.getDefault())}_SCHEMA}"
+    sql"{${ref.map(_.toUpperCase(Locale.getDefault()))}_SCHEMA}"
   }
-  private def singleQuote(s: String): String = s"'$s'"
+  private def singleQuote(s: String): SQL = sql"'$s'"
   private def isValidIdentifier(s: String): Boolean =
     (s.head.isLetter || s.head == '_') && s.forall(x => x.isLetterOrDigit || x == '_')
 
-  private def between(ctx: GeneratorContext, b: ir.Between): String = {
-    s"${expression(ctx, b.exp)} BETWEEN ${expression(ctx, b.lower)} AND ${expression(ctx, b.upper)}"
+  private def between(ctx: GeneratorContext, b: ir.Between): SQL = {
+    sql"${expression(ctx, b.exp)} BETWEEN ${expression(ctx, b.lower)} AND ${expression(ctx, b.upper)}"
   }
+
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
@@ -1,8 +1,7 @@
 package com.databricks.labs.remorph.generators.sql
 
 import com.databricks.labs.remorph.generators.{Generator, GeneratorContext}
-import com.databricks.labs.remorph.transpilers.TranspileException
-import com.databricks.labs.remorph.{intermediate => ir}
+import com.databricks.labs.remorph.{Result, WorkflowStage, intermediate => ir}
 
 class LogicalPlanGenerator(
     val expr: ExpressionGenerator,
@@ -10,19 +9,19 @@ class LogicalPlanGenerator(
     val explicitDistinct: Boolean = false)
     extends Generator[ir.LogicalPlan, String] {
 
-  override def generate(ctx: GeneratorContext, tree: ir.LogicalPlan): String = tree match {
+  override def generate(ctx: GeneratorContext, tree: ir.LogicalPlan): SQL = tree match {
     case b: ir.Batch => batch(ctx, b)
     case w: ir.WithCTE => cte(ctx, w)
     case p: ir.Project => project(ctx, p)
-    case ir.NamedTable(id, _, _) => id
+    case ir.NamedTable(id, _, _) => Result.Success(id)
     case ir.Filter(input, condition) =>
-      s"${generate(ctx, input)} WHERE ${expr.generate(ctx, condition)}"
+      sql"${generate(ctx, input)} WHERE ${expr.generate(ctx, condition)}"
     case ir.Limit(input, limit) =>
-      s"${generate(ctx, input)} LIMIT ${expr.generate(ctx, limit)}"
+      sql"${generate(ctx, input)} LIMIT ${expr.generate(ctx, limit)}"
     case ir.Offset(child, offset) =>
-      s"${generate(ctx, child)} OFFSET ${expr.generate(ctx, offset)}"
+      sql"${generate(ctx, child)} OFFSET ${expr.generate(ctx, offset)}"
     case ir.Values(data) =>
-      s"VALUES ${data.map(_.map(expr.generate(ctx, _)).mkString("(", ",", ")")).mkString(", ")}"
+      sql"VALUES ${data.map(_.map(expr.generate(ctx, _)).mkSql("(", ",", ")")).mkSql(", ")}"
     case agg: ir.Aggregate => aggregate(ctx, agg)
     case sort: ir.Sort => orderBy(ctx, sort)
     case join: ir.Join => generateJoin(ctx, join)
@@ -40,28 +39,28 @@ class LogicalPlanGenerator(
     case a: ir.AlterTableCommand => alterTable(ctx, a)
     case l: ir.Lateral => lateral(ctx, l)
     case c: ir.CreateTableParams => createTableParams(ctx, c)
-    case ir.NoopNode => ""
+    case ir.NoopNode => sql""
     //  TODO We should always generate an unresolved node, our plan should never be null
-    case null => "" // don't fail transpilation if the plan is null
-    case x => throw unknown(x)
+    case null => sql"" // don't fail transpilation if the plan is null
+    case x => unknown(x)
   }
 
-  private def batch(ctx: GeneratorContext, b: ir.Batch): String = {
+  private def batch(ctx: GeneratorContext, b: ir.Batch): SQL = {
     val seqSql = b.children
       .map {
         case u: ir.UnresolvedCommand =>
-          s"-- ${u.ruleText.stripSuffix(";")}"
-        case query => s"${generate(ctx, query)}"
+          sql"-- ${u.ruleText.stripSuffix(";")}"
+        case query => sql"${generate(ctx, query)}"
       }
-      .filter(_.nonEmpty)
+      .filter(_.isSuccess)
     if (seqSql.nonEmpty) {
-      seqSql.mkString("", ";\n", ";")
+      seqSql.mkSql("", ";\n", ";")
     } else {
-      ""
+      sql""
     }
   }
 
-  private def createTableParams(ctx: GeneratorContext, crp: ir.CreateTableParams): String = {
+  private def createTableParams(ctx: GeneratorContext, crp: ir.CreateTableParams): SQL = {
 
     // We build the overall table creation statement differently depending on whether the primitive is
     // a CREATE TABLE or a CREATE TABLE AS (SELECT ...)
@@ -77,31 +76,32 @@ class LogicalPlanGenerator(
                 val options = crp.colOptions.getOrElse(col.name, Seq.empty)
                 genColumnDecl(ctx, col, constraints, options)
               }
-              .mkString(", ")
+              .mkSql(", ")
         }
 
         // We now generate any table level constraints
-        val tableConstraintStr = crp.constraints.map(constraint(ctx, _)).mkString(", ")
-        val tableConstraintStrWithComma = if (tableConstraintStr.nonEmpty) s", $tableConstraintStr" else ""
+        val tableConstraintStr = crp.constraints.map(constraint(ctx, _)).mkSql(", ")
+        val tableConstraintStrWithComma = if (tableConstraintStr.nonEmpty) sql", $tableConstraintStr" else sql""
 
         // record any table level options
-        val tableOptions = crp.options.map(_.map(optGen.generateOption(ctx, _)).mkString("\n   ")).getOrElse("")
+        val tableOptions = crp.options.map(_.map(optGen.generateOption(ctx, _)).mkSql("\n   ")).getOrElse(sql"")
 
         val tableOptionsComment =
-          if (tableOptions.isEmpty) "" else s"   The following options are unsupported:\n\n   $tableOptions\n"
-        val indicesStr = crp.indices.map(constraint(ctx, _)).mkString("   \n")
+          if (tableOptions.isEmpty) sql"" else sql"   The following options are unsupported:\n\n   $tableOptions\n"
+        val indicesStr = crp.indices.map(constraint(ctx, _)).mkSql("   \n")
         val indicesComment =
-          if (indicesStr.isEmpty) "" else s"   The following index directives are unsupported:\n\n   $indicesStr*/\n"
+          if (indicesStr.isEmpty) sql""
+          else sql"   The following index directives are unsupported:\n\n   $indicesStr*/\n"
         val leadingComment = (tableOptionsComment, indicesComment) match {
-          case ("", "") => ""
-          case (a, "") => s"/*\n$a*/\n"
-          case ("", b) => s"/*\n$b*/\n"
-          case (a, b) => s"/*\n$a\n$b*/\n"
+          case (Result.Success(""), Result.Success("")) => Result.Success("")
+          case (a, Result.Success("")) => sql"/*\n$a*/\n"
+          case (Result.Success(""), b) => sql"/*\n$b*/\n"
+          case (a, b) => sql"/*\n$a\n$b*/\n"
         }
 
-        s"${leadingComment}CREATE TABLE ${ct.table_name} (${columns}${tableConstraintStrWithComma})"
+        sql"${leadingComment}CREATE TABLE ${ct.table_name} (${columns}${tableConstraintStrWithComma})"
 
-      case ctas: ir.CreateTableAsSelect => s"CREATE TABLE ${ctas.table_name} AS ${generate(ctx, ctas.query)}"
+      case ctas: ir.CreateTableAsSelect => sql"CREATE TABLE ${ctas.table_name} AS ${generate(ctx, ctas.query)}"
     }
   }
 
@@ -109,22 +109,22 @@ class LogicalPlanGenerator(
       ctx: GeneratorContext,
       col: ir.StructField,
       constraints: Seq[ir.Constraint],
-      options: Seq[ir.GenericOption]): String = {
+      options: Seq[ir.GenericOption]): SQL = {
     val dataType = DataTypeGenerator.generateDataType(ctx, col.dataType)
-    val dataTypeStr = if (!col.nullable) s"$dataType NOT NULL" else dataType
-    val constraintsStr = constraints.map(constraint(ctx, _)).mkString(" ")
-    val constraintsGen = if (constraintsStr.isEmpty) "" else s" $constraintsStr"
-    val optionsStr = options.map(optGen.generateOption(ctx, _)).mkString(" ")
-    val optionsComment = if (optionsStr.isEmpty) "" else s" /* $optionsStr */"
-    s"${col.name} ${dataTypeStr}${constraintsGen}${optionsComment}"
+    val dataTypeStr = if (!col.nullable) sql"$dataType NOT NULL" else dataType
+    val constraintsStr = constraints.map(constraint(ctx, _)).mkSql(" ")
+    val constraintsGen = if (constraintsStr.nonEmpty) sql" $constraintsStr" else sql""
+    val optionsStr = options.map(optGen.generateOption(ctx, _)).mkSql(" ")
+    val optionsComment = if (optionsStr.nonEmpty) sql" /* $optionsStr */" else sql""
+    sql"${col.name} ${dataTypeStr}${constraintsGen}${optionsComment}"
   }
 
-  private def alterTable(ctx: GeneratorContext, a: ir.AlterTableCommand): String = {
+  private def alterTable(ctx: GeneratorContext, a: ir.AlterTableCommand): SQL = {
     val operation = buildTableAlteration(ctx, a.alterations)
-    s"ALTER TABLE  ${a.tableName} $operation"
+    sql"ALTER TABLE  ${a.tableName} $operation"
   }
 
-  private def buildTableAlteration(ctx: GeneratorContext, alterations: Seq[ir.TableAlteration]): String = {
+  private def buildTableAlteration(ctx: GeneratorContext, alterations: Seq[ir.TableAlteration]): SQL = {
     // docs:https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-alter-table.html#parameters
     // docs:https://learn.microsoft.com/en-us/azure/databricks/sql/language-manual/sql-ref-syntax-ddl-alter-table#syntax
     // ADD COLUMN can be Seq[ir.TableAlteration]
@@ -133,68 +133,67 @@ class LogicalPlanGenerator(
     // RENAME COLUMN/ RENAME CONSTRAINTS Always be ir.TableAlteration
     // ALTER COLUMN IS A Seq[ir.TableAlternations] Data Type Change, Constraint Changes etc
     alterations map {
-      case ir.AddColumn(columns) => s"ADD COLUMN ${buildAddColumn(ctx, columns)}"
-      case ir.DropColumns(columns) => s"DROP COLUMN ${columns.mkString(", ")}"
-      case ir.DropConstraintByName(constraints) => s"DROP CONSTRAINT ${constraints}"
-      case ir.RenameColumn(oldName, newName) => s"RENAME COLUMN ${oldName} to ${newName}"
-      case x => throw TranspileException(ir.UnexpectedTableAlteration(x))
-    } mkString ", "
+      case ir.AddColumn(columns) => sql"ADD COLUMN ${buildAddColumn(ctx, columns)}"
+      case ir.DropColumns(columns) => sql"DROP COLUMN ${columns.mkString(", ")}"
+      case ir.DropConstraintByName(constraints) => sql"DROP CONSTRAINT ${constraints}"
+      case ir.RenameColumn(oldName, newName) => sql"RENAME COLUMN ${oldName} to ${newName}"
+      case x => Result.Failure(WorkflowStage.GENERATE, ir.UnexpectedTableAlteration(x))
+    } mkSql ", "
   }
 
-  private def buildAddColumn(ctx: GeneratorContext, columns: Seq[ir.ColumnDeclaration]): String = {
+  private def buildAddColumn(ctx: GeneratorContext, columns: Seq[ir.ColumnDeclaration]): SQL = {
     columns
       .map { c =>
         val dataType = DataTypeGenerator.generateDataType(ctx, c.dataType)
-        val constraints = c.constraints.map(constraint(ctx, _)).mkString(" ")
-        s"${c.name} $dataType $constraints"
+        val constraints = c.constraints.map(constraint(ctx, _)).mkSql(" ")
+        sql"${c.name} $dataType $constraints"
       }
-      .mkString(", ")
+      .mkSql(", ")
   }
 
   // @see https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-qry-select-lateral-view.html
-  private def lateral(ctx: GeneratorContext, lateral: ir.Lateral): String = lateral match {
+  private def lateral(ctx: GeneratorContext, lateral: ir.Lateral): SQL = lateral match {
     case ir.Lateral(ir.TableFunction(fn), isOuter, isView) =>
       val outer = if (isOuter) " OUTER" else ""
       val view = if (isView) " VIEW" else ""
-      s"LATERAL$view$outer ${expr.generate(ctx, fn)}"
-    case _ => throw unknown(lateral)
+      sql"LATERAL$view$outer ${expr.generate(ctx, fn)}"
+    case _ => Result.Failure(WorkflowStage.GENERATE, ir.UnexpectedNode(lateral))
   }
 
   // @see https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-qry-select-sampling.html
-  private def tableSample(ctx: GeneratorContext, t: ir.TableSample): String = {
+  private def tableSample(ctx: GeneratorContext, t: ir.TableSample): SQL = {
     val sampling = t.samplingMethod match {
       case ir.RowSamplingProbabilistic(probability) => s"$probability PERCENT"
       case ir.RowSamplingFixedAmount(amount) => s"$amount ROWS"
       case ir.BlockSampling(probability) => s"BUCKET $probability OUT OF 1"
     }
     val seed = t.seed.map(s => s" REPEATABLE ($s)").getOrElse("")
-    s"(${generate(ctx, t.child)}) TABLESAMPLE ($sampling)$seed"
+    sql"(${generate(ctx, t.child)}) TABLESAMPLE ($sampling)$seed"
   }
 
-  private def createTable(ctx: GeneratorContext, createTable: ir.CreateTableCommand): String = {
+  private def createTable(ctx: GeneratorContext, createTable: ir.CreateTableCommand): SQL = {
     val columns = createTable.columns
       .map { col =>
         val dataType = DataTypeGenerator.generateDataType(ctx, col.dataType)
-        val constraints = col.constraints.map(constraint(ctx, _)).mkString(" ")
-        s"${col.name} $dataType $constraints"
+        val constraints = col.constraints.map(constraint(ctx, _)).mkSql(" ")
+        sql"${col.name} $dataType $constraints"
       }
-      .mkString(", ")
-    s"CREATE TABLE ${createTable.name} ($columns)"
+    sql"CREATE TABLE ${createTable.name} (${columns.mkSql(", ")})"
   }
 
-  private def constraint(ctx: GeneratorContext, c: ir.Constraint): String = c match {
+  private def constraint(ctx: GeneratorContext, c: ir.Constraint): SQL = c match {
     case unique: ir.Unique => generateUniqueConstraint(ctx, unique)
-    case ir.Nullability(nullable) => if (nullable) "NULL" else "NOT NULL"
+    case ir.Nullability(nullable) => Result.Success(if (nullable) "NULL" else "NOT NULL")
     case pk: ir.PrimaryKey => generatePrimaryKey(ctx, pk)
     case fk: ir.ForeignKey => generateForeignKey(ctx, fk)
-    case ir.NamedConstraint(name, unnamed) => s"CONSTRAINT $name ${constraint(ctx, unnamed)}"
-    case ir.UnresolvedConstraint(inputText) => s"/** $inputText **/"
-    case ir.CheckConstraint(e) => s"CHECK (${expr.generate(ctx, e)})"
-    case ir.DefaultValueConstraint(value) => s"DEFAULT ${expr.generate(ctx, value)}"
-    case ir.IdentityConstraint(seed, step) => s"IDENTITY ($seed, $step)"
+    case ir.NamedConstraint(name, unnamed) => sql"CONSTRAINT $name ${constraint(ctx, unnamed)}"
+    case ir.UnresolvedConstraint(inputText) => sql"/** $inputText **/"
+    case ir.CheckConstraint(e) => sql"CHECK (${expr.generate(ctx, e)})"
+    case ir.DefaultValueConstraint(value) => sql"DEFAULT ${expr.generate(ctx, value)}"
+    case ir.IdentityConstraint(seed, step) => sql"IDENTITY ($seed, $step)"
   }
 
-  private def generateForeignKey(ctx: GeneratorContext, fk: ir.ForeignKey): String = {
+  private def generateForeignKey(ctx: GeneratorContext, fk: ir.ForeignKey): SQL = {
     val colNames = fk.tableCols match {
       case "" => ""
       case cols => s"(${cols}) "
@@ -203,49 +202,49 @@ class LogicalPlanGenerator(
       case "" => ""
       case options => s" /* Unsupported:  $options */"
     }
-    s"FOREIGN KEY ${colNames}REFERENCES ${fk.refObject}(${fk.refCols})$commentOptions"
+    sql"FOREIGN KEY ${colNames}REFERENCES ${fk.refObject}(${fk.refCols})$commentOptions"
   }
 
-  private def generatePrimaryKey(context: GeneratorContext, key: ir.PrimaryKey): String = {
+  private def generatePrimaryKey(context: GeneratorContext, key: ir.PrimaryKey): SQL = {
     val columns = key.columns.map(_.mkString("(", ", ", ")")).getOrElse("")
     val commentOptions = optGen.generateOptionList(context, key.options) match {
       case "" => ""
       case options => s" /* $options */"
     }
     val columnsStr = if (columns.isEmpty) "" else s" $columns"
-    s"PRIMARY KEY${columnsStr}${commentOptions}"
+    sql"PRIMARY KEY${columnsStr}${commentOptions}"
   }
 
-  private def generateUniqueConstraint(ctx: GeneratorContext, unique: ir.Unique): String = {
+  private def generateUniqueConstraint(ctx: GeneratorContext, unique: ir.Unique): SQL = {
     val columns = unique.columns.map(_.mkString("(", ", ", ")")).getOrElse("")
     val columnStr = if (columns.isEmpty) "" else s" $columns"
     val commentOptions = optGen.generateOptionList(ctx, unique.options) match {
       case "" => ""
       case options => s" /* $options */"
     }
-    s"UNIQUE${columnStr}${commentOptions}"
+    sql"UNIQUE${columnStr}${commentOptions}"
   }
 
-  private def project(ctx: GeneratorContext, proj: ir.Project): String = {
+  private def project(ctx: GeneratorContext, proj: ir.Project): SQL = {
     val fromClause = if (proj.input != ir.NoTable()) {
-      s" FROM ${generate(ctx, proj.input)}"
+      sql" FROM ${generate(ctx, proj.input)}"
     } else {
-      ""
+      sql""
     }
-    s"SELECT ${proj.expressions.map(expr.generate(ctx, _)).mkString(", ")}$fromClause"
+    sql"SELECT ${proj.expressions.map(expr.generate(ctx, _)).mkSql(", ")}$fromClause"
   }
 
-  private def orderBy(ctx: GeneratorContext, sort: ir.Sort): String = {
+  private def orderBy(ctx: GeneratorContext, sort: ir.Sort): SQL = {
     val orderStr = sort.order
       .map { case ir.SortOrder(child, direction, nulls) =>
         val dir = direction match {
           case ir.Ascending => ""
           case ir.Descending => " DESC"
         }
-        s"${expr.generate(ctx, child)}$dir ${nulls.sql}"
+        sql"${expr.generate(ctx, child)}$dir ${nulls.sql}"
       }
-      .mkString(", ")
-    s"${generate(ctx, sort.child)} ORDER BY $orderStr"
+
+    sql"${generate(ctx, sort.child)} ORDER BY ${orderStr.mkSql(", ")}"
   }
 
   private def isLateralView(lp: ir.LogicalPlan): Boolean = {
@@ -255,14 +254,14 @@ class LogicalPlanGenerator(
     }.isDefined
   }
 
-  private def generateJoin(ctx: GeneratorContext, join: ir.Join): String = {
+  private def generateJoin(ctx: GeneratorContext, join: ir.Join): SQL = {
     val left = generate(ctx, join.left)
     val right = generate(ctx, join.right)
     if (join.join_condition.isEmpty && join.using_columns.isEmpty && join.join_type == ir.InnerJoin) {
       if (isLateralView(join.right)) {
-        s"$left $right"
+        sql"$left $right"
       } else {
-        s"$left, $right"
+        sql"$left, $right"
       }
     } else {
       val joinType = generateJoinType(join.join_type)
@@ -270,13 +269,19 @@ class LogicalPlanGenerator(
       else { joinType + " JOIN" }
       val conditionOpt = join.join_condition.map(expr.generate(ctx, _))
       val condition = join.join_condition match {
-        case None => ""
-        case Some(_: ir.And) | Some(_: ir.Or) => s"ON (${conditionOpt.get})"
-        case Some(_) => s"ON ${conditionOpt.get}"
+        case None => sql""
+        case Some(_: ir.And) | Some(_: ir.Or) => sql"ON (${conditionOpt.get})"
+        case Some(_) => sql"ON ${conditionOpt.get}"
       }
       val usingColumns = join.using_columns.mkString(", ")
       val using = if (usingColumns.isEmpty) "" else s"USING ($usingColumns)"
-      Seq(left, joinClause, right, condition, using).filterNot(_.isEmpty).mkString(" ")
+      for {
+        l <- left
+        r <- right
+        cond <- condition
+      } yield {
+        Seq(l, joinClause, r, cond, using).filterNot(_.isEmpty).mkString(" ")
+      }
     }
   }
 
@@ -293,120 +298,123 @@ class LogicalPlanGenerator(
     case ir.UnspecifiedJoin => ""
   }
 
-  private def setOperation(ctx: GeneratorContext, setOp: ir.SetOperation): String = {
+  private def setOperation(ctx: GeneratorContext, setOp: ir.SetOperation): SQL = {
     if (setOp.allow_missing_columns) {
-      throw unknown(setOp)
+      return Result.Failure(WorkflowStage.GENERATE, ir.UnexpectedNode(setOp))
     }
     if (setOp.by_name) {
-      throw unknown(setOp)
+      return Result.Failure(WorkflowStage.GENERATE, ir.UnexpectedNode(setOp))
     }
     val op = setOp.set_op_type match {
       case ir.UnionSetOp => "UNION"
       case ir.IntersectSetOp => "INTERSECT"
       case ir.ExceptSetOp => "EXCEPT"
-      case _ => throw unknown(setOp)
+      case _ => return Result.Failure(WorkflowStage.GENERATE, ir.UnexpectedNode(setOp))
     }
     val duplicates = if (setOp.is_all) " ALL" else if (explicitDistinct) " DISTINCT" else ""
-    s"(${generate(ctx, setOp.left)}) $op$duplicates (${generate(ctx, setOp.right)})"
+    sql"(${generate(ctx, setOp.left)}) $op$duplicates (${generate(ctx, setOp.right)})"
   }
 
   // @see https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-dml-insert-into.html
-  private def insert(ctx: GeneratorContext, insert: ir.InsertIntoTable): String = {
+  private def insert(ctx: GeneratorContext, insert: ir.InsertIntoTable): SQL = {
     val target = generate(ctx, insert.target)
-    val columns = insert.columns.map(_.map(expr.generate(ctx, _)).mkString("(", ", ", ")")).getOrElse("")
+    val columns =
+      insert.columns.map(cols => cols.map(expr.generate(ctx, _)).mkSql("(", ", ", ")")).getOrElse(sql"")
     val values = generate(ctx, insert.values)
-    val output = insert.outputRelation.map(generate(ctx, _)).getOrElse("")
-    val options = insert.options.map(expr.generate(ctx, _)).getOrElse("")
+    val output = insert.outputRelation.map(generate(ctx, _)).getOrElse(sql"")
+    val options = insert.options.map(expr.generate(ctx, _)).getOrElse(sql"")
     val overwrite = if (insert.overwrite) "OVERWRITE TABLE" else "INTO"
-    s"INSERT $overwrite $target $columns $values$output$options"
+    sql"INSERT $overwrite $target $columns $values$output$options"
   }
 
   // @see https://docs.databricks.com/en/sql/language-manual/delta-update.html
-  private def update(ctx: GeneratorContext, update: ir.UpdateTable): String = {
+  private def update(ctx: GeneratorContext, update: ir.UpdateTable): SQL = {
     val target = generate(ctx, update.target)
-    val set = update.set.map(expr.generate(ctx, _)).mkString(", ")
-    val where = update.where.map(cond => s" WHERE ${expr.generate(ctx, cond)}").getOrElse("")
-    s"UPDATE $target SET $set$where"
+    val set = update.set.map(expr.generate(ctx, _)).mkSql(", ")
+    val where = update.where.map(cond => sql" WHERE ${expr.generate(ctx, cond)}").getOrElse("")
+    sql"UPDATE $target SET $set$where"
   }
 
   // @see https://docs.databricks.com/en/sql/language-manual/delta-delete-from.html
-  private def delete(ctx: GeneratorContext, target: ir.LogicalPlan, where: Option[ir.Expression]): String = {
-    val whereStr = where.map(cond => s" WHERE ${expr.generate(ctx, cond)}").getOrElse("")
-    s"DELETE FROM ${generate(ctx, target)}$whereStr"
+  private def delete(ctx: GeneratorContext, target: ir.LogicalPlan, where: Option[ir.Expression]): SQL = {
+    val whereStr = where.map(cond => sql" WHERE ${expr.generate(ctx, cond)}").getOrElse(sql"")
+    sql"DELETE FROM ${generate(ctx, target)}$whereStr"
   }
 
   // @see https://docs.databricks.com/en/sql/language-manual/delta-merge-into.html
-  private def merge(ctx: GeneratorContext, mergeIntoTable: ir.MergeIntoTable): String = {
+  private def merge(ctx: GeneratorContext, mergeIntoTable: ir.MergeIntoTable): SQL = {
     val target = generate(ctx, mergeIntoTable.targetTable)
     val source = generate(ctx, mergeIntoTable.sourceTable)
     val condition = expr.generate(ctx, mergeIntoTable.mergeCondition)
-    val matchedActions = mergeIntoTable.matchedActions.map { action =>
-      val conditionText = action.condition.map(cond => s" AND ${expr.generate(ctx, cond)}").getOrElse("")
-      s" WHEN MATCHED${conditionText} THEN ${expr.generate(ctx, action)}"
-    }.mkString
-    val notMatchedActions = mergeIntoTable.notMatchedActions.map { action =>
-      val conditionText = action.condition.map(cond => s" AND ${expr.generate(ctx, cond)}").getOrElse("")
-      s" WHEN NOT MATCHED${conditionText} THEN ${expr.generate(ctx, action)}"
-    }.mkString
-    val notMatchedBySourceActions = mergeIntoTable.notMatchedBySourceActions.map { action =>
-      val conditionText = action.condition.map(cond => s" AND ${expr.generate(ctx, cond)}").getOrElse("")
-      s" WHEN NOT MATCHED BY SOURCE${conditionText} THEN ${expr.generate(ctx, action)}"
-    }.mkString
-    s"""MERGE INTO $target
+    val matchedActions =
+      mergeIntoTable.matchedActions.map { action =>
+        val conditionText = action.condition.map(cond => sql" AND ${expr.generate(ctx, cond)}").getOrElse(sql"")
+        sql" WHEN MATCHED${conditionText} THEN ${expr.generate(ctx, action)}"
+      }.mkSql
+
+    val notMatchedActions =
+      mergeIntoTable.notMatchedActions.map { action =>
+        val conditionText = action.condition.map(cond => sql" AND ${expr.generate(ctx, cond)}").getOrElse(sql"")
+        sql" WHEN NOT MATCHED${conditionText} THEN ${expr.generate(ctx, action)}"
+      }.mkSql
+    val notMatchedBySourceActions =
+      mergeIntoTable.notMatchedBySourceActions.map { action =>
+        val conditionText = action.condition.map(cond => sql" AND ${expr.generate(ctx, cond)}").getOrElse(sql"")
+        sql" WHEN NOT MATCHED BY SOURCE${conditionText} THEN ${expr.generate(ctx, action)}"
+      }.mkSql
+    sql"""MERGE INTO $target
        |USING $source
        |ON $condition
        |$matchedActions
        |$notMatchedActions
        |$notMatchedBySourceActions
-       |""".stripMargin
+       |""".map(_.stripMargin)
   }
 
-  private def aggregate(ctx: GeneratorContext, aggregate: ir.Aggregate): String = {
+  private def aggregate(ctx: GeneratorContext, aggregate: ir.Aggregate): SQL = {
     val child = generate(ctx, aggregate.child)
-    val expressions = aggregate.grouping_expressions.map(expr.generate(ctx, _)).mkString(", ")
+    val expressions = aggregate.grouping_expressions.map(expr.generate(ctx, _)).mkSql(", ")
     aggregate.group_type match {
       case ir.GroupBy =>
-        s"$child GROUP BY $expressions"
+        sql"$child GROUP BY $expressions"
       case ir.Pivot if aggregate.pivot.isDefined =>
         val pivot = aggregate.pivot.get
         val col = expr.generate(ctx, pivot.col)
-        val values = pivot.values.map(expr.generate(ctx, _)).mkString(" IN(", ", ", ")")
-        s"$child PIVOT($expressions FOR $col$values)"
-      case a => throw TranspileException(ir.UnsupportedGroupType(a))
+        val values = pivot.values.map(expr.generate(ctx, _)).mkSql(" IN(", ", ", ")")
+        sql"$child PIVOT($expressions FOR $col$values)"
+      case a => Result.Failure(WorkflowStage.GENERATE, ir.UnsupportedGroupType(a))
     }
   }
-  private def generateWithOptions(ctx: GeneratorContext, withOptions: ir.WithOptions): String = {
+  private def generateWithOptions(ctx: GeneratorContext, withOptions: ir.WithOptions): SQL = {
     val optionComments = expr.generate(ctx, withOptions.options)
     val plan = generate(ctx, withOptions.input)
-    s"${optionComments}" +
-      s"${plan}"
+    sql"${optionComments}${plan}"
   }
 
-  private def cte(ctx: GeneratorContext, withCte: ir.WithCTE): String = {
+  private def cte(ctx: GeneratorContext, withCte: ir.WithCTE): SQL = {
     val ctes = withCte.ctes
       .map {
         case ir.SubqueryAlias(child, alias, cols) =>
-          val columns = cols.map(expr.generate(ctx, _)).mkString("(", ", ", ")")
-          val columnsStr = if (cols.isEmpty) "" else " " + columns
+          val columns = cols.map(expr.generate(ctx, _)).mkSql("(", ", ", ")")
+          val columnsStr = if (cols.isEmpty) sql"" else sql" $columns"
           val id = expr.generate(ctx, alias)
           val sub = generate(ctx, child)
-          s"$id$columnsStr AS ($sub)"
+          sql"$id$columnsStr AS ($sub)"
         case x => generate(ctx, x)
       }
-      .mkString(", ")
     val query = generate(ctx, withCte.query)
-    s"WITH $ctes $query"
+    sql"WITH ${ctes.mkSql(", ")} $query"
   }
 
-  private def subQueryAlias(ctx: GeneratorContext, subQAlias: ir.SubqueryAlias): String = {
+  private def subQueryAlias(ctx: GeneratorContext, subQAlias: ir.SubqueryAlias): SQL = {
     val subquery = subQAlias.child match {
       case l: ir.Lateral => lateral(ctx, l)
-      case _ => s"(${generate(ctx, subQAlias.child)})"
+      case _ => sql"(${generate(ctx, subQAlias.child)})"
     }
     val tableName = expr.generate(ctx, subQAlias.alias)
     val table =
       if (subQAlias.columnNames.isEmpty) {
-        s"AS $tableName"
+        sql"AS $tableName"
       } else {
         // Added this to handle the case for POS Explode
         // We have added two columns index and value as an alias for pos explode default columns (pos, col)
@@ -414,31 +422,31 @@ class LogicalPlanGenerator(
         subQAlias.columnNames match {
           case Seq(ir.Id("value", _), ir.Id("index", _)) =>
             val columnNamesStr =
-              subQAlias.columnNames.sortBy(_.nodeName).reverse.map(expr.generate(ctx, _)).mkString(",")
-            s"$tableName AS $columnNamesStr"
+              subQAlias.columnNames.sortBy(_.nodeName).reverse.map(expr.generate(ctx, _))
+            sql"$tableName AS ${columnNamesStr.mkSql(", ")}"
           case _ =>
-            val columnNamesStr = tableName + subQAlias.columnNames.map(expr.generate(ctx, _)).mkString("(", ", ", ")")
-            s"AS $columnNamesStr"
+            val columnNamesStr = subQAlias.columnNames.map(expr.generate(ctx, _))
+            sql"AS $tableName${columnNamesStr.mkSql("(", ", ", ")")}"
         }
       }
-    s"$subquery $table"
+    sql"$subquery $table"
   }
 
-  private def tableAlias(ctx: GeneratorContext, alias: ir.TableAlias): String = {
+  private def tableAlias(ctx: GeneratorContext, alias: ir.TableAlias): SQL = {
     val target = generate(ctx, alias.child)
-    val columns = if (alias.columns.isEmpty) { "" }
+    val columns = if (alias.columns.isEmpty) { sql"" }
     else {
-      alias.columns.map(expr.generate(ctx, _)).mkString("(", ", ", ")")
+      alias.columns.map(expr.generate(ctx, _)).mkSql("(", ", ", ")")
     }
-    s"$target AS ${alias.alias}$columns"
+    sql"$target AS ${alias.alias}$columns"
   }
 
-  private def deduplicate(ctx: GeneratorContext, dedup: ir.Deduplicate): String = {
+  private def deduplicate(ctx: GeneratorContext, dedup: ir.Deduplicate): SQL = {
     val table = generate(ctx, dedup.child)
-    val columns = if (dedup.all_columns_as_keys) { "*" }
+    val columns = if (dedup.all_columns_as_keys) { sql"*" }
     else {
-      dedup.column_names.map(expr.generate(ctx, _)).mkString(", ")
+      dedup.column_names.map(expr.generate(ctx, _)).mkSql(", ")
     }
-    s"SELECT DISTINCT $columns FROM $table"
+    sql"SELECT DISTINCT $columns FROM $table"
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/OptionGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/OptionGenerator.scala
@@ -1,26 +1,26 @@
 package com.databricks.labs.remorph.generators.sql
 
 import com.databricks.labs.remorph.generators.GeneratorContext
-import com.databricks.labs.remorph.{intermediate => ir}
+import com.databricks.labs.remorph.{Result, intermediate => ir}
 
 class OptionGenerator(expr: ExpressionGenerator) {
 
-  def generateOption(ctx: GeneratorContext, option: ir.GenericOption): String =
+  def generateOption(ctx: GeneratorContext, option: ir.GenericOption): Result[String] =
     option match {
       case ir.OptionExpression(id, value, supplement) =>
-        s"$id = ${expr.generate(ctx, value)}" + supplement.map(s => s" $s").getOrElse("")
+        sql"$id = ${expr.generate(ctx, value)} ${supplement.map(s => s" $s").getOrElse("")}"
       case ir.OptionString(id, value) =>
-        s"$id = '$value'"
+        sql"$id = '$value'"
       case ir.OptionOn(id) =>
-        s"$id = ON"
+        sql"$id = ON"
       case ir.OptionOff(id) =>
-        s"$id = OFF"
+        sql"$id = OFF"
       case ir.OptionAuto(id) =>
-        s"$id = AUTO"
+        sql"$id = AUTO"
       case ir.OptionDefault(id) =>
-        s"$id = DEFAULT"
+        sql"$id = DEFAULT"
       case ir.OptionUnresolved(text) =>
-        s"$text"
+        sql"$text"
     }
 
   def generateOptionList(ctx: GeneratorContext, options: Seq[ir.GenericOption]): String =

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/package.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/package.scala
@@ -1,0 +1,68 @@
+package com.databricks.labs.remorph.generators
+
+import com.databricks.labs.remorph.intermediate.UncaughtException
+import com.databricks.labs.remorph.{Result, WorkflowStage}
+
+import scala.util.control.NonFatal
+
+package object sql {
+
+  implicit class ResultInterpolator(sc: StringContext) {
+    def sql(args: Any*): Result[String] = {
+
+      val stringParts = sc.parts.iterator
+      val arguments = args.iterator
+      val sb = new StringBuilder(StringContext.treatEscapes(stringParts.next()))
+
+      while (arguments.hasNext) {
+        try {
+          arguments.next() match {
+            case Result.Success(s) => sb.append(StringContext.treatEscapes(s.toString))
+            case failure: Result.Failure => return failure
+            case other => sb.append(StringContext.treatEscapes(other.toString))
+          }
+          sb.append(StringContext.treatEscapes(stringParts.next()))
+        } catch {
+          case NonFatal(e) =>
+            return Result.Failure(WorkflowStage.GENERATE, UncaughtException(e))
+        }
+      }
+
+      Result.Success(sb.toString)
+    }
+  }
+
+  type SQL = Result[String]
+
+  implicit class SqlOps(sql: SQL) {
+    def nonEmpty: Boolean = sql match {
+      case Result.Success(str) => str.nonEmpty
+      case _ => false
+    }
+    def isEmpty: Boolean = sql match {
+      case Result.Success(str) => str.isEmpty
+      case _ => false
+    }
+  }
+
+  implicit class SQLSeqOps(sqls: Seq[SQL]) {
+
+    def mkSql: SQL = mkSql("", "", "")
+
+    def mkSql(sep: String): SQL = mkSql("", sep, "")
+
+    def mkSql(start: String, sep: String, end: String): SQL = {
+
+      if (sqls.isEmpty) {
+        sql"$start$end"
+      } else {
+        val separatedItems = sqls.tail.foldLeft[SQL](sqls.head) { case (agg, item) =>
+          sql"$agg$sep$item"
+        }
+        sql"$start$separatedItems$end"
+      }
+
+    }
+  }
+
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/package.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/package.scala
@@ -7,8 +7,10 @@ import scala.util.control.NonFatal
 
 package object sql {
 
-  implicit class ResultInterpolator(sc: StringContext) {
-    def sql(args: Any*): Result[String] = {
+  type SQL = Result[String]
+
+  implicit class SQLInterpolator(sc: StringContext) {
+    def sql(args: Any*): SQL = {
 
       val stringParts = sc.parts.iterator
       val arguments = args.iterator
@@ -31,8 +33,6 @@ package object sql {
       Result.Success(sb.toString)
     }
   }
-
-  type SQL = Result[String]
 
   implicit class SqlOps(sql: SQL) {
     def nonEmpty: Boolean = sql match {

--- a/core/src/main/scala/com/databricks/labs/remorph/graph/TableGraph.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/graph/TableGraph.scala
@@ -2,9 +2,9 @@ package com.databricks.labs.remorph.graph
 
 import com.databricks.labs.remorph.discovery.{ExecutedQuery, QueryHistory, TableDefinition}
 import com.databricks.labs.remorph.parsers.PlanParser
-import com.databricks.labs.remorph.transpilers.{Result, SourceCode}
+import com.databricks.labs.remorph.transpilers.SourceCode
 import com.typesafe.scalalogging.LazyLogging
-import com.databricks.labs.remorph.{intermediate => ir}
+import com.databricks.labs.remorph.{Result, intermediate => ir}
 
 protected case class Node(tableDefinition: TableDefinition, metadata: Map[String, Set[String]])
 // `from` is the table which is sourced to create `to` table

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/errors.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/errors.scala
@@ -20,6 +20,18 @@ object ParsingError {
   implicit val errorDetailRW: ReadWriter[ParsingError] = macroRW
 }
 
+case class ParsingErrors(errors: Seq[ParsingError]) extends RemorphError {
+  override def msg: String = s"Parsing errors: ${errors.map(_.msg).mkString(", ")}"
+}
+
+case class VisitingError(cause: Throwable) extends RemorphError {
+  override def msg: String = s"Visiting error: ${cause.getMessage}"
+}
+
+case class OptimizingError(cause: Throwable) extends RemorphError {
+  override def msg: String = s"Optimizing error: ${cause.getMessage}"
+}
+
 case class UnexpectedNode(offendingNode: TreeNode[_]) extends RemorphError {
   override def msg: String = s"Unexpected node of class ${offendingNode.getClass.getSimpleName}"
 }
@@ -47,4 +59,8 @@ case class UnsupportedArguments(functionName: String, arguments: Seq[Expression]
 
 case class UnsupportedDateTimePart(expression: Expression) extends RemorphError {
   override def msg: String = s"Unsupported date/time part specification: $expression"
+}
+
+case class UncaughtException(exception: Throwable) extends RemorphError {
+  override def msg: String = exception.getMessage
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/errors.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/errors.scala
@@ -1,5 +1,6 @@
 package com.databricks.labs.remorph.intermediate
 
+import com.databricks.labs.remorph.utils.Strings
 import upickle.default._
 
 trait RemorphError {
@@ -63,4 +64,12 @@ case class UnsupportedDateTimePart(expression: Expression) extends RemorphError 
 
 case class UncaughtException(exception: Throwable) extends RemorphError {
   override def msg: String = exception.getMessage
+}
+
+case class UnexpectedOutput(expected: String, actual: String) extends RemorphError {
+  override def msg: String =
+    s"""
+       |=== Unexpected output (expected vs actual) ===
+       |${Strings.sideBySide(expected, actual).mkString("\n")}
+       |""".stripMargin
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/PlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/PlanParser.scala
@@ -1,6 +1,7 @@
 package com.databricks.labs.remorph.parsers
 
-import com.databricks.labs.remorph.transpilers.{Result, SourceCode, WorkflowStage}
+import com.databricks.labs.remorph.{Result, WorkflowStage}
+import com.databricks.labs.remorph.transpilers.SourceCode
 import com.databricks.labs.remorph.{intermediate => ir}
 import org.antlr.v4.runtime._
 import org.json4s.jackson.Serialization

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/PlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/PlanParser.scala
@@ -1,14 +1,14 @@
 package com.databricks.labs.remorph.parsers
 
+import com.databricks.labs.remorph.intermediate.{OptimizingError, ParsingErrors, VisitingError}
+import com.databricks.labs.remorph.{intermediate => ir}
 import com.databricks.labs.remorph.{Result, WorkflowStage}
 import com.databricks.labs.remorph.transpilers.SourceCode
-import com.databricks.labs.remorph.{intermediate => ir}
 import org.antlr.v4.runtime._
 import org.json4s.jackson.Serialization
-import org.json4s.jackson.Serialization.write
 import org.json4s.{Formats, NoTypeHints}
 
-import java.io.{PrintWriter, StringWriter}
+import scala.util.control.NonFatal
 
 trait PlanParser[P <: Parser] {
 
@@ -41,7 +41,7 @@ trait PlanParser[P <: Parser] {
     val tree = createTree(parser)
     // TODO: Should we return the error listener, or perhaps the collection of errors and not JSON at this stage?
     if (errListener.errorCount > 0) {
-      Result.Failure(stage = WorkflowStage.PARSE, errListener.errorsAsJson)
+      Result.Failure(stage = WorkflowStage.PARSE, ParsingErrors(errListener.errors))
     } else {
       Result.Success(tree)
     }
@@ -57,13 +57,8 @@ trait PlanParser[P <: Parser] {
       val plan = createPlan(tree)
       Result.Success(plan)
     } catch {
-      case e: Exception =>
-        val sw = new StringWriter
-        e.printStackTrace(new PrintWriter(sw))
-        val stackTrace = sw.toString
-        val errorJson = write(
-          Map("exception" -> e.getClass.getSimpleName, "message" -> e.getMessage, "stackTrace" -> stackTrace))
-        Result.Failure(stage = WorkflowStage.PLAN, errorJson)
+      case NonFatal(e) =>
+        Result.Failure(stage = WorkflowStage.PLAN, VisitingError(e))
     }
   }
 
@@ -79,13 +74,8 @@ trait PlanParser[P <: Parser] {
       val plan = createOptimizer.apply(logicalPlan)
       Result.Success(plan)
     } catch {
-      case e: Exception =>
-        val sw = new StringWriter
-        e.printStackTrace(new PrintWriter(sw))
-        val stackTrace = sw.toString
-        val errorJson = write(
-          Map("exception" -> e.getClass.getSimpleName, "message" -> e.getMessage, "stackTrace" -> stackTrace))
-        Result.Failure(stage = WorkflowStage.OPTIMIZE, errorJson)
+      case NonFatal(e) =>
+        Result.Failure(stage = WorkflowStage.OPTIMIZE, OptimizingError(e))
     }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/queries/QueryExtractor.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/queries/QueryExtractor.scala
@@ -60,11 +60,11 @@ class ExampleDebugger(getParser: String => PlanParser[_], prettyPrinter: Any => 
     extractor.extractQuery(new File(name)) match {
       case Some(ExampleQuery(query, _)) =>
         parser.parse(new SourceCode(query)).flatMap(parser.visit) match {
-          case com.databricks.labs.remorph.transpilers.Result.Failure(stage, errorJson) =>
+          case com.databricks.labs.remorph.Result.Failure(stage, errorJson) =>
             // scalastyle:off println
             System.err.println(s"Failed to parse query: $query $errorJson")
           // scalastyle:on println
-          case com.databricks.labs.remorph.transpilers.Result.Success(plan) =>
+          case com.databricks.labs.remorph.Result.Success(plan) =>
             prettyPrinter(plan)
         }
       case None => throw new IllegalArgumentException(s"Example $name not found")

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/SqlGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/SqlGenerator.scala
@@ -1,11 +1,12 @@
 package com.databricks.labs.remorph.transpilers
 
-import com.databricks.labs.remorph.Result
+import com.databricks.labs.remorph.{Result, WorkflowStage, intermediate => ir}
 import com.databricks.labs.remorph.generators.GeneratorContext
-import com.databricks.labs.remorph.generators.sql.{ExpressionGenerator, LogicalPlanGenerator, OptionGenerator}
-import com.databricks.labs.remorph.{intermediate => ir}
+import com.databricks.labs.remorph.generators.sql.{ExpressionGenerator, LogicalPlanGenerator, OptionGenerator, SQL}
 import org.json4s.jackson.Serialization
 import org.json4s.{Formats, NoTypeHints}
+
+import scala.util.control.NonFatal
 
 // TODO: This should not be under transpilers but we have not refactored generation out of the transpiler yet
 //       and it may need changes before it is consider finished anyway, such as implementing a trait
@@ -17,7 +18,12 @@ class SqlGenerator {
 
   implicit val formats: Formats = Serialization.formats(NoTypeHints)
 
-  def generate(optimizedLogicalPlan: ir.LogicalPlan): Result[String] = {
-    generator.generate(GeneratorContext(generator), optimizedLogicalPlan)
+  def generate(optimizedLogicalPlan: ir.LogicalPlan): SQL = {
+    try {
+      generator.generate(GeneratorContext(generator), optimizedLogicalPlan)
+    } catch {
+      case NonFatal(e) =>
+        Result.Failure(WorkflowStage.GENERATE, ir.UncaughtException(e))
+    }
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/SqlGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/SqlGenerator.scala
@@ -1,14 +1,11 @@
 package com.databricks.labs.remorph.transpilers
 
-import com.databricks.labs.remorph.{Result, WorkflowStage}
+import com.databricks.labs.remorph.Result
 import com.databricks.labs.remorph.generators.GeneratorContext
 import com.databricks.labs.remorph.generators.sql.{ExpressionGenerator, LogicalPlanGenerator, OptionGenerator}
 import com.databricks.labs.remorph.{intermediate => ir}
 import org.json4s.jackson.Serialization
-import org.json4s.jackson.Serialization.write
 import org.json4s.{Formats, NoTypeHints}
-
-import java.io.{PrintWriter, StringWriter}
 
 // TODO: This should not be under transpilers but we have not refactored generation out of the transpiler yet
 //       and it may need changes before it is consider finished anyway, such as implementing a trait
@@ -21,17 +18,6 @@ class SqlGenerator {
   implicit val formats: Formats = Serialization.formats(NoTypeHints)
 
   def generate(optimizedLogicalPlan: ir.LogicalPlan): Result[String] = {
-    try {
-      val output = generator.generate(GeneratorContext(generator), optimizedLogicalPlan)
-      Result.Success(output)
-    } catch {
-      case e: Exception =>
-        val sw = new StringWriter
-        e.printStackTrace(new PrintWriter(sw))
-        val stackTrace = sw.toString
-        val errorJson = write(
-          Map("exception" -> e.getClass.getSimpleName, "message" -> e.getMessage, "stackTrace" -> stackTrace))
-        Result.Failure(stage = WorkflowStage.GENERATE, errorJson)
-    }
+    generator.generate(GeneratorContext(generator), optimizedLogicalPlan)
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/SqlGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/SqlGenerator.scala
@@ -1,5 +1,6 @@
 package com.databricks.labs.remorph.transpilers
 
+import com.databricks.labs.remorph.{Result, WorkflowStage}
 import com.databricks.labs.remorph.generators.GeneratorContext
 import com.databricks.labs.remorph.generators.sql.{ExpressionGenerator, LogicalPlanGenerator, OptionGenerator}
 import com.databricks.labs.remorph.{intermediate => ir}

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/Transpiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/Transpiler.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.transpilers
 
 import com.databricks.labs.remorph.parsers.PlanParser
-import com.databricks.labs.remorph.{intermediate => ir}
+import com.databricks.labs.remorph.{Result, intermediate => ir}
 import com.github.vertical_blank.sqlformatter.SqlFormatter
 import com.github.vertical_blank.sqlformatter.core.FormatConfig
 import com.github.vertical_blank.sqlformatter.languages.Dialect
@@ -11,13 +11,6 @@ import org.json4s.{Formats, NoTypeHints}
 
 import scala.util.matching.Regex
 
-sealed trait WorkflowStage
-object WorkflowStage {
-  case object PARSE extends WorkflowStage
-  case object PLAN extends WorkflowStage
-  case object OPTIMIZE extends WorkflowStage
-  case object GENERATE extends WorkflowStage
-}
 
 trait Transpiler {
   def transpile(input: SourceCode): Result[String]

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/Transpiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/Transpiler.scala
@@ -11,7 +11,6 @@ import org.json4s.{Formats, NoTypeHints}
 
 import scala.util.matching.Regex
 
-
 trait Transpiler {
   def transpile(input: SourceCode): Result[String]
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/DataTypeGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/DataTypeGeneratorTest.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.generators.sql
 
 import com.databricks.labs.remorph.generators.GeneratorContext
-import com.databricks.labs.remorph.{intermediate => ir}
+import com.databricks.labs.remorph.{Result, intermediate => ir}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor2}
 import org.scalatest.wordspec.AnyWordSpec
@@ -45,7 +45,7 @@ class DataTypeGeneratorTest extends AnyWordSpec with Matchers with TableDrivenPr
       val optionGenerator = new OptionGenerator(exprGenerator)
       val logical = new LogicalPlanGenerator(exprGenerator, optionGenerator)
       forAll(translations) { (dt, expected) =>
-        DataTypeGenerator.generateDataType(GeneratorContext(logical), dt) shouldBe expected
+        DataTypeGenerator.generateDataType(GeneratorContext(logical), dt) shouldBe Result.Success(expected)
       }
     }
   }

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/GeneratorTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/GeneratorTestCommon.scala
@@ -1,8 +1,7 @@
 package com.databricks.labs.remorph.generators.sql
 
 import com.databricks.labs.remorph.generators.{Generator, GeneratorContext}
-import com.databricks.labs.remorph.{intermediate => ir}
-import com.databricks.labs.remorph.transpilers.TranspileException
+import com.databricks.labs.remorph.{Result, intermediate => ir}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.Assertion
 
@@ -15,14 +14,14 @@ trait GeneratorTestCommon[T <: ir.TreeNode[T]] extends Matchers {
       val exprGenerator = new ExpressionGenerator()
       val optionGenerator = new OptionGenerator(exprGenerator)
       val logical = new LogicalPlanGenerator(exprGenerator, optionGenerator)
-      generator.generate(GeneratorContext(logical), t) shouldBe expectedOutput
+      generator.generate(GeneratorContext(logical), t) shouldBe Result.Success(expectedOutput)
     }
 
     def doesNotTranspile: Assertion = {
       val exprGenerator = new ExpressionGenerator()
       val optionGenerator = new OptionGenerator(exprGenerator)
       val logical = new LogicalPlanGenerator(exprGenerator, optionGenerator)
-      assertThrows[TranspileException](generator.generate(GeneratorContext(logical), t))
+      generator.generate(GeneratorContext(logical), t).isSuccess shouldBe false
     }
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/SQLInterpolatorSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/SQLInterpolatorSpec.scala
@@ -1,0 +1,59 @@
+package com.databricks.labs.remorph.generators.sql
+
+import com.databricks.labs.remorph.intermediate.{Noop, UnexpectedNode}
+import com.databricks.labs.remorph.{Result, WorkflowStage}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class SQLInterpolatorSpec extends AnyWordSpec with Matchers {
+
+  "SQLInterpolator" should {
+
+    "interpolate the empty string" in {
+      sql"" shouldBe Result.Success("")
+    }
+
+    "interpolate argument-less strings" in {
+      sql"foo" shouldBe Result.Success("foo")
+    }
+
+    "interpolate argument-less strings with escape sequences" in {
+      sql"\tbar\n" shouldBe Result.Success("\tbar\n")
+    }
+
+    "interpolate strings consisting only in a single String argument" in {
+      val arg = "FOO"
+      sql"$arg" shouldBe Result.Success("FOO")
+    }
+
+    "interpolate strings consisting only in a single Result.Success argument" in {
+      val arg = Result.Success("FOO")
+      sql"$arg" shouldBe Result.Success("FOO")
+    }
+
+    "interpolate strings consisting only in a single argument that is neither String nor Result.Success" in {
+      val arg = 42
+      sql"$arg" shouldBe Result.Success("42")
+    }
+
+    "interpolate strings with multiple arguments" in {
+      val arg1 = "foo"
+      val arg2 = Result.Success("bar")
+      val arg3 = 42
+      sql"arg1: $arg1, arg2: $arg2, arg3: $arg3" shouldBe Result.Success("arg1: foo, arg2: bar, arg3: 42")
+    }
+
+    "return a Failure if any one of the arguments is a Failure" in {
+      val arg1 = "foo"
+      val arg2 = Result.Failure(WorkflowStage.GENERATE, UnexpectedNode(Noop))
+      val arg3 = 42
+      sql"arg1: $arg1, arg2: $arg2, arg3: $arg3" shouldBe Result.Failure(WorkflowStage.GENERATE, UnexpectedNode(Noop))
+    }
+
+    "unfortunately, if evaluating one of the arguments throws an exception, " +
+      "it cannot be caught by the interpolator because arguments are evaluated eagerly" in {
+        def boom(): Unit = throw new RuntimeException("boom")
+        a[RuntimeException] should be thrownBy sql"3...2...1...${boom()}"
+      }
+  }
+}

--- a/core/src/test/scala/com/databricks/labs/remorph/queries/ExampleDebuggerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/queries/ExampleDebuggerTest.scala
@@ -2,7 +2,7 @@ package com.databricks.labs.remorph.queries
 
 import com.databricks.labs.remorph.parsers.PlanParser
 import com.databricks.labs.remorph.intermediate.NoopNode
-import com.databricks.labs.remorph.transpilers.Result
+import com.databricks.labs.remorph.Result
 import org.antlr.v4.runtime.ParserRuleContext
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/TranspilerTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/TranspilerTestCommon.scala
@@ -12,7 +12,7 @@ trait TranspilerTestCommon extends Matchers with Formatter {
     def transpilesTo(expectedOutput: String): Assertion = {
       transpiler.transpile(SourceCode(input)) match {
         case Result.Success(output) => format(output) shouldBe format(expectedOutput)
-        case Result.Failure(_, err) => fail(err)
+        case Result.Failure(_, err) => fail(err.msg)
       }
     }
     def failsTranspilation: Assertion = {

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/TranspilerTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/TranspilerTestCommon.scala
@@ -1,5 +1,6 @@
 package com.databricks.labs.remorph.transpilers
 
+import com.databricks.labs.remorph.Result
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
 


### PR DESCRIPTION
This is a rather important change although the most part (changes in the `Generator`s) is quite mechanical.

The signatures in the `Generator` trait have been changed so that the `generate` method returns a `Result[Out]` (instead of just `Out` before).

This introduces a difficulty, as the result of recursive calls can no longer be used directly, but must be accounted for potential failures by the caller. To make it easier to work with `Result[String]` (which have been aliased to `SQL`), an `SQLInterpolater` has been added (see `SQLInterpolatorSpec` for examples of how it can be used), as well as `mkSql` extension methods for `Seq[SQL]` (similar to the way `mkString` works on `Seq[String]`).

 Finally, we change `ReportEntry` produced by coverage tests to contain `RemorphError`s instead of JSON strings, to open the way for more structured and more informative such reports (which was the initial trigger for this whole change).