### PR TITLE
Adorn TSQL visitors/builders with error node checking

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilder.scala
@@ -36,7 +36,7 @@ class SnowflakeDMLBuilder(override val vc: SnowflakeVisitorCoordinator)
     case Some(errorResult) => errorResult
     case None =>
       val table = ctx.objectName().accept(vc.relationBuilder)
-      val columns = Option(ctx.ids).map(_.asScala).filter(_.nonEmpty).map(_.map(vc.expressionBuilder.visitId))
+      val columns = Option(ctx.ids).map(_.asScala).filter(_.nonEmpty).map(_.map(vc.expressionBuilder.buildId))
       val values = ctx match {
         case c if c.queryStatement() != null => c.queryStatement().accept(vc.relationBuilder)
         case c if c.valuesTableBody() != null => c.valuesTableBody().accept(vc.relationBuilder)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/OptionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/OptionBuilder.scala
@@ -35,7 +35,7 @@ class OptionBuilder(vc: TSqlVisitorCoordinator) {
       // FOR cannot be allowed as an id as it clashes with the FOR clause in SELECT et al. So
       // we special case it here and elide the FOR. It handles just a few things such as OPTIMIZE FOR UNKNOWN,
       // which becomes "OPTIMIZE", Id(UNKNOWN)
-      case c if c.FOR() != null => ir.OptionExpression(id, vc.expressionBuilder.visitId(c.id(1)), None)
+      case c if c.FOR() != null => ir.OptionExpression(id, vc.expressionBuilder.buildId(c.id(1)), None)
       case c if c.expression() != null =>
         val supplement = if (c.id(1) != null) Some(ctx.id(1).getText) else None
         ir.OptionExpression(id, c.expression().accept(vc.expressionBuilder), supplement)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilder.scala
@@ -20,65 +20,76 @@ class TSqlAstBuilder(override val vc: TSqlVisitorCoordinator)
 
   // Concrete visitors
 
-  override def visitTSqlFile(ctx: TSqlParser.TSqlFileContext): ir.LogicalPlan = {
-    Option(ctx.batch()).map(_.accept(this)).getOrElse(ir.Batch(List()))
+  override def visitTSqlFile(ctx: TSqlParser.TSqlFileContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      Option(ctx.batch()).map(_.accept(this)).getOrElse(ir.Batch(List()))
   }
 
-  override def visitBatch(ctx: TSqlParser.BatchContext): ir.LogicalPlan = {
-    val executeBodyBatchPlan = Option(ctx.executeBodyBatch()).map(_.accept(this))
-    val sqlClausesPlans = ctx.sqlClauses().asScala.map(_.accept(this)).collect { case p: ir.LogicalPlan => p }
+  override def visitBatch(ctx: TSqlParser.BatchContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val executeBodyBatchPlan = Option(ctx.executeBodyBatch()).map(_.accept(this))
+      val sqlClausesPlans = ctx.sqlClauses().asScala.map(_.accept(this)).collect { case p: ir.LogicalPlan => p }
 
-    executeBodyBatchPlan match {
-      case Some(plan) => ir.Batch(plan :: sqlClausesPlans.toList)
-      case None => ir.Batch(sqlClausesPlans.toList)
-    }
+      executeBodyBatchPlan match {
+        case Some(plan) => ir.Batch(plan :: sqlClausesPlans.toList)
+        case None => ir.Batch(sqlClausesPlans.toList)
+      }
   }
 
   // TODO: Stored procedure calls etc as batch start
-  override def visitExecuteBodyBatch(ctx: TSqlParser.ExecuteBodyBatchContext): ir.LogicalPlan =
-    ir.UnresolvedRelation(
-      ruleText = contextText(ctx),
-      message = "Execute body batch is not supported yet",
-      ruleName = vc.ruleName(ctx),
-      tokenName = Some(tokenName(ctx.getStart)))
-
-  override def visitSqlClauses(ctx: TSqlParser.SqlClausesContext): ir.LogicalPlan = {
-    ctx match {
-      case dml if dml.dmlClause() != null => dml.dmlClause().accept(this)
-      case cfl if cfl.cflStatement() != null => cfl.cflStatement().accept(this)
-      case another if another.anotherStatement() != null => another.anotherStatement().accept(this)
-      case ddl if ddl.ddlClause() != null => ddl.ddlClause().accept(vc.ddlBuilder)
-      case dbcc if dbcc.dbccClause() != null => dbcc.dbccClause().accept(this)
-      case backup if backup.backupStatement() != null => backup.backupStatement().accept(vc.ddlBuilder)
-      case coaFunction if coaFunction.createOrAlterFunction() != null =>
-        coaFunction.createOrAlterFunction().accept(this)
-      case coaProcedure if coaProcedure.createOrAlterProcedure() != null =>
-        coaProcedure.createOrAlterProcedure().accept(this)
-      case coaTrigger if coaTrigger.createOrAlterTrigger() != null => coaTrigger.createOrAlterTrigger().accept(this)
-      case cv if cv.createView() != null => cv.createView().accept(this)
-      case go if go.goStatement() != null => go.goStatement().accept(this)
-      case _ =>
-        ir.UnresolvedRelation(
-          ruleText = contextText(ctx),
-          message = s"Unknown SQL clause ${ctx.getStart.getText} in TSqlAstBuilder.visitSqlClauses",
-          ruleName = vc.ruleName(ctx),
-          tokenName = Some(tokenName(ctx.getStart)))
-    }
+  override def visitExecuteBodyBatch(ctx: TSqlParser.ExecuteBodyBatchContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ir.UnresolvedRelation(
+        ruleText = contextText(ctx),
+        message = "Execute body batch is not supported yet",
+        ruleName = vc.ruleName(ctx),
+        tokenName = Some(tokenName(ctx.getStart)))
   }
 
-  override def visitDmlClause(ctx: TSqlParser.DmlClauseContext): ir.LogicalPlan = {
-    val dml = ctx match {
-      case dml if dml.selectStatement() != null =>
-        dml.selectStatement().accept(vc.relationBuilder)
-      case _ =>
-        ctx.accept(vc.dmlBuilder)
-    }
-
-    Option(ctx.withExpression())
-      .map { withExpression =>
-        val ctes = withExpression.commonTableExpression().asScala.map(_.accept(vc.relationBuilder))
-        ir.WithCTE(ctes, dml)
+  override def visitSqlClauses(ctx: TSqlParser.SqlClausesContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx match {
+        case dml if dml.dmlClause() != null => dml.dmlClause().accept(this)
+        case cfl if cfl.cflStatement() != null => cfl.cflStatement().accept(this)
+        case another if another.anotherStatement() != null => another.anotherStatement().accept(this)
+        case ddl if ddl.ddlClause() != null => ddl.ddlClause().accept(vc.ddlBuilder)
+        case dbcc if dbcc.dbccClause() != null => dbcc.dbccClause().accept(this)
+        case backup if backup.backupStatement() != null => backup.backupStatement().accept(vc.ddlBuilder)
+        case coaFunction if coaFunction.createOrAlterFunction() != null =>
+          coaFunction.createOrAlterFunction().accept(this)
+        case coaProcedure if coaProcedure.createOrAlterProcedure() != null =>
+          coaProcedure.createOrAlterProcedure().accept(this)
+        case coaTrigger if coaTrigger.createOrAlterTrigger() != null => coaTrigger.createOrAlterTrigger().accept(this)
+        case cv if cv.createView() != null => cv.createView().accept(this)
+        case go if go.goStatement() != null => go.goStatement().accept(this)
+        case _ =>
+          ir.UnresolvedRelation(
+            ruleText = contextText(ctx),
+            message = s"Unknown SQL clause ${ctx.getStart.getText} in TSqlAstBuilder.visitSqlClauses",
+            ruleName = vc.ruleName(ctx),
+            tokenName = Some(tokenName(ctx.getStart)))
       }
-      .getOrElse(dml)
+  }
+
+  override def visitDmlClause(ctx: TSqlParser.DmlClauseContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val dml = ctx match {
+        case dml if dml.selectStatement() != null =>
+          dml.selectStatement().accept(vc.relationBuilder)
+        case _ =>
+          ctx.accept(vc.dmlBuilder)
+      }
+
+      Option(ctx.withExpression())
+        .map { withExpression =>
+          val ctes = withExpression.commonTableExpression().asScala.map(_.accept(vc.relationBuilder))
+          ir.WithCTE(ctes, dml)
+        }
+        .getOrElse(dml)
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDDLBuilder.scala
@@ -17,119 +17,131 @@ class TSqlDDLBuilder(override val vc: TSqlVisitorCoordinator)
 
   // Concrete visitors
 
-  override def visitCreateTable(ctx: TSqlParser.CreateTableContext): ir.Catalog =
-    ctx match {
-      case ci if ci.createInternal() != null => ci.createInternal().accept(this)
-      case ct if ct.createExternal() != null => ct.createExternal().accept(this)
-      case _ =>
-        ir.UnresolvedCatalog(
-          ruleText = contextText(ctx),
-          message = "Unknown CREATE TABLE variant",
-          ruleName = vc.ruleName(ctx),
-          tokenName = Some(tokenName(ctx.getStart)))
-    }
-
-  override def visitCreateInternal(ctx: TSqlParser.CreateInternalContext): ir.Catalog = {
-    val tableName = ctx.tableName().getText
-
-    val (columns, virtualColumns, constraints, indices) = Option(ctx.columnDefTableConstraints()).toSeq
-      .flatMap(_.columnDefTableConstraint().asScala)
-      .foldLeft((Seq.empty[TSqlColDef], Seq.empty[TSqlColDef], Seq.empty[ir.Constraint], Seq.empty[ir.Constraint])) {
-        case ((cols, virtualCols, cons, inds), constraint) =>
-          val newCols = constraint.columnDefinition() match {
-            case null => cols
-            case columnDef =>
-              cols :+ buildColumnDeclaration(columnDef)
-          }
-
-          val newVirtualCols = constraint.computedColumnDefinition() match {
-            case null => virtualCols
-            case computedCol =>
-              virtualCols :+ buildComputedColumn(computedCol)
-          }
-
-          val newCons = constraint.tableConstraint() match {
-            case null => cons
-            case tableCons => cons :+ buildTableConstraint(tableCons)
-          }
-
-          val newInds = constraint.tableIndices() match {
-            case null => inds
-            case tableInds => inds :+ buildIndex(tableInds)
-          }
-
-          (newCols, newVirtualCols, newCons, newInds)
+  override def visitCreateTable(ctx: TSqlParser.CreateTableContext): ir.Catalog = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx match {
+        case ci if ci.createInternal() != null => ci.createInternal().accept(this)
+        case ct if ct.createExternal() != null => ct.createExternal().accept(this)
+        case _ =>
+          ir.UnresolvedCatalog(
+            ruleText = contextText(ctx),
+            message = "Unknown CREATE TABLE variant",
+            ruleName = vc.ruleName(ctx),
+            tokenName = Some(tokenName(ctx.getStart)))
       }
-
-    // At this point we have all the columns, constraints and indices, so we can build the schema
-    val schema = ir.StructType((columns ++ virtualColumns).map(_.structField))
-
-    // Now we can build the create table statement or the create table as select statement
-
-    val createTable = ctx.createTableAs() match {
-      case null => ir.CreateTable(tableName, None, None, None, schema)
-      case ctas if ctas.selectStatementStandalone() != null =>
-        ir.CreateTableAsSelect(tableName, ctas.selectStatementStandalone().accept(vc.relationBuilder), None, None, None)
-      case _ =>
-        ir.UnresolvedCatalog(
-          ruleText = contextText(ctx),
-          message = "Unknown variant of CREATE TABLE is not yet supported",
-          ruleName = vc.ruleName(ctx),
-          tokenName = Some(tokenName(ctx.getStart)))
-    }
-
-    // But because TSQL is so much more complicated than Databricks SQL, we need to build the table alterations
-    // in a wrapper above the raw create statement.
-
-    // First we want to iterate all the columns and build a map of all the column constraints where the key is the
-    // element structField.name and the value is the TSqlColDef.constraints
-    val columnConstraints = (columns ++ virtualColumns).map { colDef =>
-      colDef.structField.name -> colDef.constraints
-    }.toMap
-
-    // Next we create another map all options for each column where the key is the element structField.name and the
-    // value is the TSqlColDef.options
-    val columnOptions = (columns ++ virtualColumns).map { colDef =>
-      colDef.structField.name -> colDef.options
-    }.toMap
-
-    // And we want to collect any table level constraints that were generated in the TSqlColDef.tableConstraints
-    // by iterating columns and virtualColumns and gathering any TSqlColDef tableConstraints and
-    // creating a single Seq that also includes the constraints
-    // that were already accumulated above
-    val tableConstraints = constraints ++ (columns ++ virtualColumns).flatMap(_.tableConstraints)
-
-    // We may have table level options as well as for each constraint and column
-    val options: Option[Seq[ir.GenericOption]] = Option(ctx.tableOptions).map { tableOptions =>
-      tableOptions.asScala.flatMap { el =>
-        el.tableOption().asScala.map(buildOption)
-      }
-    }
-
-    val partitionOn = Option(ctx.onPartitionOrFilegroup()).map(_.getText)
-
-    // Now we can build the table additions that wrap the primitive create table statement
-    createTable match {
-      case ct: ir.UnresolvedCatalog =>
-        ct
-      case _ =>
-        ir.CreateTableParams(
-          createTable,
-          columnConstraints,
-          columnOptions,
-          tableConstraints,
-          indices,
-          partitionOn,
-          options)
-    }
   }
 
-  override def visitCreateExternal(ctx: TSqlParser.CreateExternalContext): ir.Catalog = {
-    ir.UnresolvedCatalog(
-      ruleText = contextText(ctx),
-      message = "CREATE EXTERNAL TABLE is not yet supported",
-      ruleName = vc.ruleName(ctx),
-      tokenName = Some(tokenName(ctx.getStart)))
+  override def visitCreateInternal(ctx: TSqlParser.CreateInternalContext): ir.Catalog = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val tableName = ctx.tableName().getText
+
+      val (columns, virtualColumns, constraints, indices) = Option(ctx.columnDefTableConstraints()).toSeq
+        .flatMap(_.columnDefTableConstraint().asScala)
+        .foldLeft((Seq.empty[TSqlColDef], Seq.empty[TSqlColDef], Seq.empty[ir.Constraint], Seq.empty[ir.Constraint])) {
+          case ((cols, virtualCols, cons, inds), constraint) =>
+            val newCols = constraint.columnDefinition() match {
+              case null => cols
+              case columnDef =>
+                cols :+ buildColumnDeclaration(columnDef)
+            }
+
+            val newVirtualCols = constraint.computedColumnDefinition() match {
+              case null => virtualCols
+              case computedCol =>
+                virtualCols :+ buildComputedColumn(computedCol)
+            }
+
+            val newCons = constraint.tableConstraint() match {
+              case null => cons
+              case tableCons => cons :+ buildTableConstraint(tableCons)
+            }
+
+            val newInds = constraint.tableIndices() match {
+              case null => inds
+              case tableInds => inds :+ buildIndex(tableInds)
+            }
+
+            (newCols, newVirtualCols, newCons, newInds)
+        }
+
+      // At this point we have all the columns, constraints and indices, so we can build the schema
+      val schema = ir.StructType((columns ++ virtualColumns).map(_.structField))
+
+      // Now we can build the create table statement or the create table as select statement
+
+      val createTable = ctx.createTableAs() match {
+        case null => ir.CreateTable(tableName, None, None, None, schema)
+        case ctas if ctas.selectStatementStandalone() != null =>
+          ir.CreateTableAsSelect(
+            tableName,
+            ctas.selectStatementStandalone().accept(vc.relationBuilder),
+            None,
+            None,
+            None)
+        case _ =>
+          ir.UnresolvedCatalog(
+            ruleText = contextText(ctx),
+            message = "Unknown variant of CREATE TABLE is not yet supported",
+            ruleName = vc.ruleName(ctx),
+            tokenName = Some(tokenName(ctx.getStart)))
+      }
+
+      // But because TSQL is so much more complicated than Databricks SQL, we need to build the table alterations
+      // in a wrapper above the raw create statement.
+
+      // First we want to iterate all the columns and build a map of all the column constraints where the key is the
+      // element structField.name and the value is the TSqlColDef.constraints
+      val columnConstraints = (columns ++ virtualColumns).map { colDef =>
+        colDef.structField.name -> colDef.constraints
+      }.toMap
+
+      // Next we create another map all options for each column where the key is the element structField.name and the
+      // value is the TSqlColDef.options
+      val columnOptions = (columns ++ virtualColumns).map { colDef =>
+        colDef.structField.name -> colDef.options
+      }.toMap
+
+      // And we want to collect any table level constraints that were generated in the TSqlColDef.tableConstraints
+      // by iterating columns and virtualColumns and gathering any TSqlColDef tableConstraints and
+      // creating a single Seq that also includes the constraints
+      // that were already accumulated above
+      val tableConstraints = constraints ++ (columns ++ virtualColumns).flatMap(_.tableConstraints)
+
+      // We may have table level options as well as for each constraint and column
+      val options: Option[Seq[ir.GenericOption]] = Option(ctx.tableOptions).map { tableOptions =>
+        tableOptions.asScala.flatMap { el =>
+          el.tableOption().asScala.map(buildOption)
+        }
+      }
+
+      val partitionOn = Option(ctx.onPartitionOrFilegroup()).map(_.getText)
+
+      // Now we can build the table additions that wrap the primitive create table statement
+      createTable match {
+        case ct: ir.UnresolvedCatalog =>
+          ct
+        case _ =>
+          ir.CreateTableParams(
+            createTable,
+            columnConstraints,
+            columnOptions,
+            tableConstraints,
+            indices,
+            partitionOn,
+            options)
+      }
+  }
+
+  override def visitCreateExternal(ctx: TSqlParser.CreateExternalContext): ir.Catalog = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ir.UnresolvedCatalog(
+        ruleText = contextText(ctx),
+        message = "CREATE EXTERNAL TABLE is not yet supported",
+        ruleName = vc.ruleName(ctx),
+        tokenName = Some(tokenName(ctx.getStart)))
   }
 
   /**
@@ -425,202 +437,209 @@ class TSqlDDLBuilder(override val vc: TSqlVisitorCoordinator)
    * @param ctx
    *   the parse tree
    */
-  override def visitBackupStatement(ctx: TSqlParser.BackupStatementContext): ir.Catalog =
-    ctx.backupDatabase().accept(this)
-
-  override def visitBackupDatabase(ctx: TSqlParser.BackupDatabaseContext): ir.Catalog = {
-    val database = ctx.id().getText
-    val opts = ctx.optionList()
-    val options = opts.asScala.flatMap(_.genericOption().asScala).toList.map(vc.optionBuilder.buildOption)
-    val (disks, boolFlags, autoFlags, values) = options.foldLeft(
-      (List.empty[String], Map.empty[String, Boolean], List.empty[String], Map.empty[String, ir.Expression])) {
-      case ((disks, boolFlags, autoFlags, values), option) =>
-        option match {
-          case ir.OptionString("DISK", value) =>
-            (value.stripPrefix("'").stripSuffix("'") :: disks, boolFlags, autoFlags, values)
-          case ir.OptionOn(id) => (disks, boolFlags + (id -> true), autoFlags, values)
-          case ir.OptionOff(id) => (disks, boolFlags + (id -> false), autoFlags, values)
-          case ir.OptionAuto(id) => (disks, boolFlags, id :: autoFlags, values)
-          case ir.OptionExpression(id, expr, _) => (disks, boolFlags, autoFlags, values + (id -> expr))
-          case _ => (disks, boolFlags, autoFlags, values)
-        }
-    }
-    // Default flags generally don't need to be specified as they are by definition, the default
-    BackupDatabase(database, disks, boolFlags, autoFlags, values)
+  override def visitBackupStatement(ctx: TSqlParser.BackupStatementContext): ir.Catalog = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx.backupDatabase().accept(this)
   }
 
-  override def visitDdlClause(ctx: TSqlParser.DdlClauseContext): Catalog = {
-    ctx match {
-      case c if c.alterApplicationRole() != null => c.alterApplicationRole().accept(this)
-      case c if c.alterAssembly() != null => c.alterAssembly().accept(this)
-      case c if c.alterAsymmetricKey() != null => c.alterAsymmetricKey().accept(this)
-      case c if c.alterAuthorization() != null => c.alterAuthorization().accept(this)
-      case c if c.alterAvailabilityGroup() != null => c.alterAvailabilityGroup().accept(this)
-      case c if c.alterCertificate() != null => c.alterCertificate().accept(this)
-      case c if c.alterColumnEncryptionKey() != null => c.alterColumnEncryptionKey().accept(this)
-      case c if c.alterCredential() != null => c.alterCredential().accept(this)
-      case c if c.alterCryptographicProvider() != null => c.alterCryptographicProvider().accept(this)
-      case c if c.alterDatabase() != null => c.alterDatabase().accept(this)
-      case c if c.alterDatabaseAuditSpecification() != null => c.alterDatabaseAuditSpecification().accept(this)
-      case c if c.alterDbRole() != null => c.alterDbRole().accept(this)
-      case c if c.alterEndpoint() != null => c.alterEndpoint().accept(this)
-      case c if c.alterExternalDataSource() != null => c.alterExternalDataSource().accept(this)
-      case c if c.alterExternalLibrary() != null => c.alterExternalLibrary().accept(this)
-      case c if c.alterExternalResourcePool() != null => c.alterExternalResourcePool().accept(this)
-      case c if c.alterFulltextCatalog() != null => c.alterFulltextCatalog().accept(this)
-      case c if c.alterFulltextStoplist() != null => c.alterFulltextStoplist().accept(this)
-      case c if c.alterIndex() != null => c.alterIndex().accept(this)
-      case c if c.alterLoginAzureSql() != null => c.alterLoginAzureSql().accept(this)
-      case c if c.alterLoginAzureSqlDwAndPdw() != null => c.alterLoginAzureSqlDwAndPdw().accept(this)
-      case c if c.alterLoginSqlServer() != null => c.alterLoginSqlServer().accept(this)
-      case c if c.alterMasterKeyAzureSql() != null => c.alterMasterKeyAzureSql().accept(this)
-      case c if c.alterMasterKeySqlServer() != null => c.alterMasterKeySqlServer().accept(this)
-      case c if c.alterMessageType() != null => c.alterMessageType().accept(this)
-      case c if c.alterPartitionFunction() != null => c.alterPartitionFunction().accept(this)
-      case c if c.alterPartitionScheme() != null => c.alterPartitionScheme().accept(this)
-      case c if c.alterRemoteServiceBinding() != null => c.alterRemoteServiceBinding().accept(this)
-      case c if c.alterResourceGovernor() != null => c.alterResourceGovernor().accept(this)
-      case c if c.alterSchemaAzureSqlDwAndPdw() != null => c.alterSchemaAzureSqlDwAndPdw().accept(this)
-      case c if c.alterSchemaSql() != null => c.alterSchemaSql().accept(this)
-      case c if c.alterSequence() != null => c.alterSequence().accept(this)
-      case c if c.alterServerAudit() != null => c.alterServerAudit().accept(this)
-      case c if c.alterServerAuditSpecification() != null => c.alterServerAuditSpecification().accept(this)
-      case c if c.alterServerConfiguration() != null => c.alterServerConfiguration().accept(this)
-      case c if c.alterServerRole() != null => c.alterServerRole().accept(this)
-      case c if c.alterServerRolePdw() != null => c.alterServerRolePdw().accept(this)
-      case c if c.alterService() != null => c.alterService().accept(this)
-      case c if c.alterServiceMasterKey() != null => c.alterServiceMasterKey().accept(this)
-      case c if c.alterSymmetricKey() != null => c.alterSymmetricKey().accept(this)
-      case c if c.alterTable() != null => c.alterTable().accept(this)
-      case c if c.alterUser() != null => c.alterUser().accept(this)
-      case c if c.alterUserAzureSql() != null => c.alterUserAzureSql().accept(this)
-      case c if c.alterWorkloadGroup() != null => c.alterWorkloadGroup().accept(this)
-      case c if c.alterXmlSchemaCollection() != null => c.alterXmlSchemaCollection().accept(this)
-      case c if c.createApplicationRole() != null => c.createApplicationRole().accept(this)
-      case c if c.createAssembly() != null => c.createAssembly().accept(this)
-      case c if c.createAsymmetricKey() != null => c.createAsymmetricKey().accept(this)
-      case c if c.createColumnEncryptionKey() != null => c.createColumnEncryptionKey().accept(this)
-      case c if c.createColumnMasterKey() != null => c.createColumnMasterKey().accept(this)
-      case c if c.createColumnstoreIndex() != null => c.createColumnstoreIndex().accept(this)
-      case c if c.createCredential() != null => c.createCredential().accept(this)
-      case c if c.createCryptographicProvider() != null => c.createCryptographicProvider().accept(this)
-      case c if c.createDatabaseScopedCredential() != null => c.createDatabaseScopedCredential().accept(this)
-      case c if c.createDatabase() != null => c.createDatabase().accept(this)
-      case c if c.createDatabaseAuditSpecification() != null => c.createDatabaseAuditSpecification().accept(this)
-      case c if c.createDbRole() != null => c.createDbRole().accept(this)
-      case c if c.createEndpoint() != null => c.createEndpoint().accept(this)
-      case c if c.createEventNotification() != null => c.createEventNotification().accept(this)
-      case c if c.createExternalLibrary() != null => c.createExternalLibrary().accept(this)
-      case c if c.createExternalResourcePool() != null => c.createExternalResourcePool().accept(this)
-      case c if c.createExternalDataSource() != null => c.createExternalDataSource().accept(this)
-      case c if c.createFulltextCatalog() != null => c.createFulltextCatalog().accept(this)
-      case c if c.createFulltextStoplist() != null => c.createFulltextStoplist().accept(this)
-      case c if c.createIndex() != null => c.createIndex().accept(this)
-      case c if c.createLoginAzureSql() != null => c.createLoginAzureSql().accept(this)
-      case c if c.createLoginPdw() != null => c.createLoginPdw().accept(this)
-      case c if c.createLoginSqlServer() != null => c.createLoginSqlServer().accept(this)
-      case c if c.createMasterKeyAzureSql() != null => c.createMasterKeyAzureSql().accept(this)
-      case c if c.createMasterKeySqlServer() != null => c.createMasterKeySqlServer().accept(this)
-      case c if c.createNonclusteredColumnstoreIndex() != null => c.createNonclusteredColumnstoreIndex().accept(this)
-      case c if c.createOrAlterBrokerPriority() != null => c.createOrAlterBrokerPriority().accept(this)
-      case c if c.createOrAlterEventSession() != null => c.createOrAlterEventSession().accept(this)
-      case c if c.createPartitionFunction() != null => c.createPartitionFunction().accept(this)
-      case c if c.createPartitionScheme() != null => c.createPartitionScheme().accept(this)
-      case c if c.createRemoteServiceBinding() != null => c.createRemoteServiceBinding().accept(this)
-      case c if c.createResourcePool() != null => c.createResourcePool().accept(this)
-      case c if c.createRoute() != null => c.createRoute().accept(this)
-      case c if c.createRule() != null => c.createRule().accept(this)
-      case c if c.createSchema() != null => c.createSchema().accept(this)
-      case c if c.createSchemaAzureSqlDwAndPdw() != null => c.createSchemaAzureSqlDwAndPdw().accept(this)
-      case c if c.createSearchPropertyList() != null => c.createSearchPropertyList().accept(this)
-      case c if c.createSecurityPolicy() != null => c.createSecurityPolicy().accept(this)
-      case c if c.createSequence() != null => c.createSequence().accept(this)
-      case c if c.createServerAudit() != null => c.createServerAudit().accept(this)
-      case c if c.createServerAuditSpecification() != null => c.createServerAuditSpecification().accept(this)
-      case c if c.createServerRole() != null => c.createServerRole().accept(this)
-      case c if c.createService() != null => c.createService().accept(this)
-      case c if c.createStatistics() != null => c.createStatistics().accept(this)
-      case c if c.createSynonym() != null => c.createSynonym().accept(this)
-      case c if c.createTable() != null => c.createTable().accept(this)
-      case c if c.createType() != null => c.createType().accept(this)
-      case c if c.createUser() != null => c.createUser().accept(this)
-      case c if c.createUserAzureSqlDw() != null => c.createUserAzureSqlDw().accept(this)
-      case c if c.createWorkloadGroup() != null => c.createWorkloadGroup().accept(this)
-      case c if c.createXmlIndex() != null => c.createXmlIndex().accept(this)
-      case c if c.createXmlSchemaCollection() != null => c.createXmlSchemaCollection().accept(this)
-      case c if c.triggerDisEn() != null => c.triggerDisEn().accept(this)
-      case c if c.dropAggregate() != null => c.dropAggregate().accept(this)
-      case c if c.dropApplicationRole() != null => c.dropApplicationRole().accept(this)
-      case c if c.dropAssembly() != null => c.dropAssembly().accept(this)
-      case c if c.dropAsymmetricKey() != null => c.dropAsymmetricKey().accept(this)
-      case c if c.dropAvailabilityGroup() != null => c.dropAvailabilityGroup().accept(this)
-      case c if c.dropBrokerPriority() != null => c.dropBrokerPriority().accept(this)
-      case c if c.dropCertificate() != null => c.dropCertificate().accept(this)
-      case c if c.dropColumnEncryptionKey() != null => c.dropColumnEncryptionKey().accept(this)
-      case c if c.dropColumnMasterKey() != null => c.dropColumnMasterKey().accept(this)
-      case c if c.dropContract() != null => c.dropContract().accept(this)
-      case c if c.dropCredential() != null => c.dropCredential().accept(this)
-      case c if c.dropCryptograhicProvider() != null => c.dropCryptograhicProvider().accept(this)
-      case c if c.dropDatabase() != null => c.dropDatabase().accept(this)
-      case c if c.dropDatabaseAuditSpecification() != null => c.dropDatabaseAuditSpecification().accept(this)
-      case c if c.dropDatabaseEncryptionKey() != null => c.dropDatabaseEncryptionKey().accept(this)
-      case c if c.dropDatabaseScopedCredential() != null => c.dropDatabaseScopedCredential().accept(this)
-      case c if c.dropDbRole() != null => c.dropDbRole().accept(this)
-      case c if c.dropDefault() != null => c.dropDefault().accept(this)
-      case c if c.dropEndpoint() != null => c.dropEndpoint().accept(this)
-      case c if c.dropEventNotifications() != null => c.dropEventNotifications().accept(this)
-      case c if c.dropEventSession() != null => c.dropEventSession().accept(this)
-      case c if c.dropExternalDataSource() != null => c.dropExternalDataSource().accept(this)
-      case c if c.dropExternalFileFormat() != null => c.dropExternalFileFormat().accept(this)
-      case c if c.dropExternalLibrary() != null => c.dropExternalLibrary().accept(this)
-      case c if c.dropExternalResourcePool() != null => c.dropExternalResourcePool().accept(this)
-      case c if c.dropExternalTable() != null => c.dropExternalTable().accept(this)
-      case c if c.dropFulltextCatalog() != null => c.dropFulltextCatalog().accept(this)
-      case c if c.dropFulltextIndex() != null => c.dropFulltextIndex().accept(this)
-      case c if c.dropFulltextStoplist() != null => c.dropFulltextStoplist().accept(this)
-      case c if c.dropFunction() != null => c.dropFunction().accept(this)
-      case c if c.dropIndex() != null => c.dropIndex().accept(this)
-      case c if c.dropLogin() != null => c.dropLogin().accept(this)
-      case c if c.dropMasterKey() != null => c.dropMasterKey().accept(this)
-      case c if c.dropMessageType() != null => c.dropMessageType().accept(this)
-      case c if c.dropPartitionFunction() != null => c.dropPartitionFunction().accept(this)
-      case c if c.dropPartitionScheme() != null => c.dropPartitionScheme().accept(this)
-      case c if c.dropProcedure() != null => c.dropProcedure().accept(this)
-      case c if c.dropQueue() != null => c.dropQueue().accept(this)
-      case c if c.dropRemoteServiceBinding() != null => c.dropRemoteServiceBinding().accept(this)
-      case c if c.dropResourcePool() != null => c.dropResourcePool().accept(this)
-      case c if c.dropRoute() != null => c.dropRoute().accept(this)
-      case c if c.dropRule() != null => c.dropRule().accept(this)
-      case c if c.dropSchema() != null => c.dropSchema().accept(this)
-      case c if c.dropSearchPropertyList() != null => c.dropSearchPropertyList().accept(this)
-      case c if c.dropSecurityPolicy() != null => c.dropSecurityPolicy().accept(this)
-      case c if c.dropSequence() != null => c.dropSequence().accept(this)
-      case c if c.dropServerAudit() != null => c.dropServerAudit().accept(this)
-      case c if c.dropServerAuditSpecification() != null => c.dropServerAuditSpecification().accept(this)
-      case c if c.dropServerRole() != null => c.dropServerRole().accept(this)
-      case c if c.dropService() != null => c.dropService().accept(this)
-      case c if c.dropSignature() != null => c.dropSignature().accept(this)
-      case c if c.dropStatistics() != null => c.dropStatistics().accept(this)
-      case c if c.dropStatisticsNameAzureDwAndPdw() != null => c.dropStatisticsNameAzureDwAndPdw().accept(this)
-      case c if c.dropSymmetricKey() != null => c.dropSymmetricKey().accept(this)
-      case c if c.dropSynonym() != null => c.dropSynonym().accept(this)
-      case c if c.dropTable() != null => c.dropTable().accept(this)
-      case c if c.dropTrigger() != null => c.dropTrigger().accept(this)
-      case c if c.dropType() != null => c.dropType().accept(this)
-      case c if c.dropUser() != null => c.dropUser().accept(this)
-      case c if c.dropView() != null => c.dropView().accept(this)
-      case c if c.dropWorkloadGroup() != null => c.dropWorkloadGroup().accept(this)
-      case c if c.dropXmlSchemaCollection() != null => c.dropXmlSchemaCollection().accept(this)
-      case c if c.triggerDisEn() != null => c.triggerDisEn().accept(this)
-      case c if c.lockTable() != null => c.lockTable().accept(this)
-      case c if c.truncateTable() != null => c.truncateTable().accept(this)
-      case c if c.updateStatistics() != null => c.updateStatistics().accept(this)
-      case _ =>
-        ir.UnresolvedCatalog(
-          ruleText = contextText(ctx),
-          message = "Unknown DDL clause",
-          ruleName = vc.ruleName(ctx),
-          tokenName = Some(tokenName(ctx.getStart)))
-    }
+  override def visitBackupDatabase(ctx: TSqlParser.BackupDatabaseContext): ir.Catalog = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val database = ctx.id().getText
+      val opts = ctx.optionList()
+      val options = opts.asScala.flatMap(_.genericOption().asScala).toList.map(vc.optionBuilder.buildOption)
+      val (disks, boolFlags, autoFlags, values) = options.foldLeft(
+        (List.empty[String], Map.empty[String, Boolean], List.empty[String], Map.empty[String, ir.Expression])) {
+        case ((disks, boolFlags, autoFlags, values), option) =>
+          option match {
+            case ir.OptionString("DISK", value) =>
+              (value.stripPrefix("'").stripSuffix("'") :: disks, boolFlags, autoFlags, values)
+            case ir.OptionOn(id) => (disks, boolFlags + (id -> true), autoFlags, values)
+            case ir.OptionOff(id) => (disks, boolFlags + (id -> false), autoFlags, values)
+            case ir.OptionAuto(id) => (disks, boolFlags, id :: autoFlags, values)
+            case ir.OptionExpression(id, expr, _) => (disks, boolFlags, autoFlags, values + (id -> expr))
+            case _ => (disks, boolFlags, autoFlags, values)
+          }
+      }
+      // Default flags generally don't need to be specified as they are by definition, the default
+      BackupDatabase(database, disks, boolFlags, autoFlags, values)
+  }
+
+  override def visitDdlClause(ctx: TSqlParser.DdlClauseContext): Catalog = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx match {
+        case c if c.alterApplicationRole() != null => c.alterApplicationRole().accept(this)
+        case c if c.alterAssembly() != null => c.alterAssembly().accept(this)
+        case c if c.alterAsymmetricKey() != null => c.alterAsymmetricKey().accept(this)
+        case c if c.alterAuthorization() != null => c.alterAuthorization().accept(this)
+        case c if c.alterAvailabilityGroup() != null => c.alterAvailabilityGroup().accept(this)
+        case c if c.alterCertificate() != null => c.alterCertificate().accept(this)
+        case c if c.alterColumnEncryptionKey() != null => c.alterColumnEncryptionKey().accept(this)
+        case c if c.alterCredential() != null => c.alterCredential().accept(this)
+        case c if c.alterCryptographicProvider() != null => c.alterCryptographicProvider().accept(this)
+        case c if c.alterDatabase() != null => c.alterDatabase().accept(this)
+        case c if c.alterDatabaseAuditSpecification() != null => c.alterDatabaseAuditSpecification().accept(this)
+        case c if c.alterDbRole() != null => c.alterDbRole().accept(this)
+        case c if c.alterEndpoint() != null => c.alterEndpoint().accept(this)
+        case c if c.alterExternalDataSource() != null => c.alterExternalDataSource().accept(this)
+        case c if c.alterExternalLibrary() != null => c.alterExternalLibrary().accept(this)
+        case c if c.alterExternalResourcePool() != null => c.alterExternalResourcePool().accept(this)
+        case c if c.alterFulltextCatalog() != null => c.alterFulltextCatalog().accept(this)
+        case c if c.alterFulltextStoplist() != null => c.alterFulltextStoplist().accept(this)
+        case c if c.alterIndex() != null => c.alterIndex().accept(this)
+        case c if c.alterLoginAzureSql() != null => c.alterLoginAzureSql().accept(this)
+        case c if c.alterLoginAzureSqlDwAndPdw() != null => c.alterLoginAzureSqlDwAndPdw().accept(this)
+        case c if c.alterLoginSqlServer() != null => c.alterLoginSqlServer().accept(this)
+        case c if c.alterMasterKeyAzureSql() != null => c.alterMasterKeyAzureSql().accept(this)
+        case c if c.alterMasterKeySqlServer() != null => c.alterMasterKeySqlServer().accept(this)
+        case c if c.alterMessageType() != null => c.alterMessageType().accept(this)
+        case c if c.alterPartitionFunction() != null => c.alterPartitionFunction().accept(this)
+        case c if c.alterPartitionScheme() != null => c.alterPartitionScheme().accept(this)
+        case c if c.alterRemoteServiceBinding() != null => c.alterRemoteServiceBinding().accept(this)
+        case c if c.alterResourceGovernor() != null => c.alterResourceGovernor().accept(this)
+        case c if c.alterSchemaAzureSqlDwAndPdw() != null => c.alterSchemaAzureSqlDwAndPdw().accept(this)
+        case c if c.alterSchemaSql() != null => c.alterSchemaSql().accept(this)
+        case c if c.alterSequence() != null => c.alterSequence().accept(this)
+        case c if c.alterServerAudit() != null => c.alterServerAudit().accept(this)
+        case c if c.alterServerAuditSpecification() != null => c.alterServerAuditSpecification().accept(this)
+        case c if c.alterServerConfiguration() != null => c.alterServerConfiguration().accept(this)
+        case c if c.alterServerRole() != null => c.alterServerRole().accept(this)
+        case c if c.alterServerRolePdw() != null => c.alterServerRolePdw().accept(this)
+        case c if c.alterService() != null => c.alterService().accept(this)
+        case c if c.alterServiceMasterKey() != null => c.alterServiceMasterKey().accept(this)
+        case c if c.alterSymmetricKey() != null => c.alterSymmetricKey().accept(this)
+        case c if c.alterTable() != null => c.alterTable().accept(this)
+        case c if c.alterUser() != null => c.alterUser().accept(this)
+        case c if c.alterUserAzureSql() != null => c.alterUserAzureSql().accept(this)
+        case c if c.alterWorkloadGroup() != null => c.alterWorkloadGroup().accept(this)
+        case c if c.alterXmlSchemaCollection() != null => c.alterXmlSchemaCollection().accept(this)
+        case c if c.createApplicationRole() != null => c.createApplicationRole().accept(this)
+        case c if c.createAssembly() != null => c.createAssembly().accept(this)
+        case c if c.createAsymmetricKey() != null => c.createAsymmetricKey().accept(this)
+        case c if c.createColumnEncryptionKey() != null => c.createColumnEncryptionKey().accept(this)
+        case c if c.createColumnMasterKey() != null => c.createColumnMasterKey().accept(this)
+        case c if c.createColumnstoreIndex() != null => c.createColumnstoreIndex().accept(this)
+        case c if c.createCredential() != null => c.createCredential().accept(this)
+        case c if c.createCryptographicProvider() != null => c.createCryptographicProvider().accept(this)
+        case c if c.createDatabaseScopedCredential() != null => c.createDatabaseScopedCredential().accept(this)
+        case c if c.createDatabase() != null => c.createDatabase().accept(this)
+        case c if c.createDatabaseAuditSpecification() != null => c.createDatabaseAuditSpecification().accept(this)
+        case c if c.createDbRole() != null => c.createDbRole().accept(this)
+        case c if c.createEndpoint() != null => c.createEndpoint().accept(this)
+        case c if c.createEventNotification() != null => c.createEventNotification().accept(this)
+        case c if c.createExternalLibrary() != null => c.createExternalLibrary().accept(this)
+        case c if c.createExternalResourcePool() != null => c.createExternalResourcePool().accept(this)
+        case c if c.createExternalDataSource() != null => c.createExternalDataSource().accept(this)
+        case c if c.createFulltextCatalog() != null => c.createFulltextCatalog().accept(this)
+        case c if c.createFulltextStoplist() != null => c.createFulltextStoplist().accept(this)
+        case c if c.createIndex() != null => c.createIndex().accept(this)
+        case c if c.createLoginAzureSql() != null => c.createLoginAzureSql().accept(this)
+        case c if c.createLoginPdw() != null => c.createLoginPdw().accept(this)
+        case c if c.createLoginSqlServer() != null => c.createLoginSqlServer().accept(this)
+        case c if c.createMasterKeyAzureSql() != null => c.createMasterKeyAzureSql().accept(this)
+        case c if c.createMasterKeySqlServer() != null => c.createMasterKeySqlServer().accept(this)
+        case c if c.createNonclusteredColumnstoreIndex() != null => c.createNonclusteredColumnstoreIndex().accept(this)
+        case c if c.createOrAlterBrokerPriority() != null => c.createOrAlterBrokerPriority().accept(this)
+        case c if c.createOrAlterEventSession() != null => c.createOrAlterEventSession().accept(this)
+        case c if c.createPartitionFunction() != null => c.createPartitionFunction().accept(this)
+        case c if c.createPartitionScheme() != null => c.createPartitionScheme().accept(this)
+        case c if c.createRemoteServiceBinding() != null => c.createRemoteServiceBinding().accept(this)
+        case c if c.createResourcePool() != null => c.createResourcePool().accept(this)
+        case c if c.createRoute() != null => c.createRoute().accept(this)
+        case c if c.createRule() != null => c.createRule().accept(this)
+        case c if c.createSchema() != null => c.createSchema().accept(this)
+        case c if c.createSchemaAzureSqlDwAndPdw() != null => c.createSchemaAzureSqlDwAndPdw().accept(this)
+        case c if c.createSearchPropertyList() != null => c.createSearchPropertyList().accept(this)
+        case c if c.createSecurityPolicy() != null => c.createSecurityPolicy().accept(this)
+        case c if c.createSequence() != null => c.createSequence().accept(this)
+        case c if c.createServerAudit() != null => c.createServerAudit().accept(this)
+        case c if c.createServerAuditSpecification() != null => c.createServerAuditSpecification().accept(this)
+        case c if c.createServerRole() != null => c.createServerRole().accept(this)
+        case c if c.createService() != null => c.createService().accept(this)
+        case c if c.createStatistics() != null => c.createStatistics().accept(this)
+        case c if c.createSynonym() != null => c.createSynonym().accept(this)
+        case c if c.createTable() != null => c.createTable().accept(this)
+        case c if c.createType() != null => c.createType().accept(this)
+        case c if c.createUser() != null => c.createUser().accept(this)
+        case c if c.createUserAzureSqlDw() != null => c.createUserAzureSqlDw().accept(this)
+        case c if c.createWorkloadGroup() != null => c.createWorkloadGroup().accept(this)
+        case c if c.createXmlIndex() != null => c.createXmlIndex().accept(this)
+        case c if c.createXmlSchemaCollection() != null => c.createXmlSchemaCollection().accept(this)
+        case c if c.triggerDisEn() != null => c.triggerDisEn().accept(this)
+        case c if c.dropAggregate() != null => c.dropAggregate().accept(this)
+        case c if c.dropApplicationRole() != null => c.dropApplicationRole().accept(this)
+        case c if c.dropAssembly() != null => c.dropAssembly().accept(this)
+        case c if c.dropAsymmetricKey() != null => c.dropAsymmetricKey().accept(this)
+        case c if c.dropAvailabilityGroup() != null => c.dropAvailabilityGroup().accept(this)
+        case c if c.dropBrokerPriority() != null => c.dropBrokerPriority().accept(this)
+        case c if c.dropCertificate() != null => c.dropCertificate().accept(this)
+        case c if c.dropColumnEncryptionKey() != null => c.dropColumnEncryptionKey().accept(this)
+        case c if c.dropColumnMasterKey() != null => c.dropColumnMasterKey().accept(this)
+        case c if c.dropContract() != null => c.dropContract().accept(this)
+        case c if c.dropCredential() != null => c.dropCredential().accept(this)
+        case c if c.dropCryptograhicProvider() != null => c.dropCryptograhicProvider().accept(this)
+        case c if c.dropDatabase() != null => c.dropDatabase().accept(this)
+        case c if c.dropDatabaseAuditSpecification() != null => c.dropDatabaseAuditSpecification().accept(this)
+        case c if c.dropDatabaseEncryptionKey() != null => c.dropDatabaseEncryptionKey().accept(this)
+        case c if c.dropDatabaseScopedCredential() != null => c.dropDatabaseScopedCredential().accept(this)
+        case c if c.dropDbRole() != null => c.dropDbRole().accept(this)
+        case c if c.dropDefault() != null => c.dropDefault().accept(this)
+        case c if c.dropEndpoint() != null => c.dropEndpoint().accept(this)
+        case c if c.dropEventNotifications() != null => c.dropEventNotifications().accept(this)
+        case c if c.dropEventSession() != null => c.dropEventSession().accept(this)
+        case c if c.dropExternalDataSource() != null => c.dropExternalDataSource().accept(this)
+        case c if c.dropExternalFileFormat() != null => c.dropExternalFileFormat().accept(this)
+        case c if c.dropExternalLibrary() != null => c.dropExternalLibrary().accept(this)
+        case c if c.dropExternalResourcePool() != null => c.dropExternalResourcePool().accept(this)
+        case c if c.dropExternalTable() != null => c.dropExternalTable().accept(this)
+        case c if c.dropFulltextCatalog() != null => c.dropFulltextCatalog().accept(this)
+        case c if c.dropFulltextIndex() != null => c.dropFulltextIndex().accept(this)
+        case c if c.dropFulltextStoplist() != null => c.dropFulltextStoplist().accept(this)
+        case c if c.dropFunction() != null => c.dropFunction().accept(this)
+        case c if c.dropIndex() != null => c.dropIndex().accept(this)
+        case c if c.dropLogin() != null => c.dropLogin().accept(this)
+        case c if c.dropMasterKey() != null => c.dropMasterKey().accept(this)
+        case c if c.dropMessageType() != null => c.dropMessageType().accept(this)
+        case c if c.dropPartitionFunction() != null => c.dropPartitionFunction().accept(this)
+        case c if c.dropPartitionScheme() != null => c.dropPartitionScheme().accept(this)
+        case c if c.dropProcedure() != null => c.dropProcedure().accept(this)
+        case c if c.dropQueue() != null => c.dropQueue().accept(this)
+        case c if c.dropRemoteServiceBinding() != null => c.dropRemoteServiceBinding().accept(this)
+        case c if c.dropResourcePool() != null => c.dropResourcePool().accept(this)
+        case c if c.dropRoute() != null => c.dropRoute().accept(this)
+        case c if c.dropRule() != null => c.dropRule().accept(this)
+        case c if c.dropSchema() != null => c.dropSchema().accept(this)
+        case c if c.dropSearchPropertyList() != null => c.dropSearchPropertyList().accept(this)
+        case c if c.dropSecurityPolicy() != null => c.dropSecurityPolicy().accept(this)
+        case c if c.dropSequence() != null => c.dropSequence().accept(this)
+        case c if c.dropServerAudit() != null => c.dropServerAudit().accept(this)
+        case c if c.dropServerAuditSpecification() != null => c.dropServerAuditSpecification().accept(this)
+        case c if c.dropServerRole() != null => c.dropServerRole().accept(this)
+        case c if c.dropService() != null => c.dropService().accept(this)
+        case c if c.dropSignature() != null => c.dropSignature().accept(this)
+        case c if c.dropStatistics() != null => c.dropStatistics().accept(this)
+        case c if c.dropStatisticsNameAzureDwAndPdw() != null => c.dropStatisticsNameAzureDwAndPdw().accept(this)
+        case c if c.dropSymmetricKey() != null => c.dropSymmetricKey().accept(this)
+        case c if c.dropSynonym() != null => c.dropSynonym().accept(this)
+        case c if c.dropTable() != null => c.dropTable().accept(this)
+        case c if c.dropTrigger() != null => c.dropTrigger().accept(this)
+        case c if c.dropType() != null => c.dropType().accept(this)
+        case c if c.dropUser() != null => c.dropUser().accept(this)
+        case c if c.dropView() != null => c.dropView().accept(this)
+        case c if c.dropWorkloadGroup() != null => c.dropWorkloadGroup().accept(this)
+        case c if c.dropXmlSchemaCollection() != null => c.dropXmlSchemaCollection().accept(this)
+        case c if c.triggerDisEn() != null => c.triggerDisEn().accept(this)
+        case c if c.lockTable() != null => c.lockTable().accept(this)
+        case c if c.truncateTable() != null => c.truncateTable().accept(this)
+        case c if c.updateStatistics() != null => c.updateStatistics().accept(this)
+        case _ =>
+          ir.UnresolvedCatalog(
+            ruleText = contextText(ctx),
+            message = "Unknown DDL clause",
+            ruleName = vc.ruleName(ctx),
+            tokenName = Some(tokenName(ctx.getStart)))
+      }
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
@@ -17,71 +17,76 @@ class TSqlDMLBuilder(override val vc: TSqlVisitorCoordinator)
 
   // Concrete visitors
 
-  override def visitDmlClause(ctx: DmlClauseContext): ir.Modification =
-    ctx match {
-      // NB: select is handled by the relationBuilder
-      case dml if dml.insert() != null => dml.insert.accept(this)
-      case dml if dml.delete() != null => dml.delete().accept(this)
-      case dml if dml.merge() != null => dml.merge().accept(this)
-      case dml if dml.update() != null => dml.update().accept(this)
-      case bulk if bulk.bulkStatement() != null => bulk.bulkStatement().accept(this)
-      case _ =>
-        ir.UnresolvedModification(
-          ruleText = contextText(ctx),
-          message = s"Unknown DML clause ${ctx.getStart.getText} in TSqlDMLBuilder.visitDmlClause",
-          ruleName = vc.ruleName(ctx),
-          tokenName = Some(tokenName(ctx.getStart)))
-    }
+  override def visitDmlClause(ctx: DmlClauseContext): ir.Modification = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx match {
+        // NB: select is handled by the relationBuilder
+        case dml if dml.insert() != null => dml.insert.accept(this)
+        case dml if dml.delete() != null => dml.delete().accept(this)
+        case dml if dml.merge() != null => dml.merge().accept(this)
+        case dml if dml.update() != null => dml.update().accept(this)
+        case bulk if bulk.bulkStatement() != null => bulk.bulkStatement().accept(this)
+        case _ =>
+          ir.UnresolvedModification(
+            ruleText = contextText(ctx),
+            message = s"Unknown DML clause ${ctx.getStart.getText} in TSqlDMLBuilder.visitDmlClause",
+            ruleName = vc.ruleName(ctx),
+            tokenName = Some(tokenName(ctx.getStart)))
+      }
+  }
 
-  override def visitMerge(ctx: MergeContext): ir.Modification = {
-    val targetPlan = ctx.ddlObject().accept(vc.relationBuilder)
-    val hints = vc.relationBuilder.buildTableHints(Option(ctx.withTableHints()))
-    val finalTarget = if (hints.nonEmpty) {
-      ir.TableWithHints(targetPlan, hints)
-    } else {
-      targetPlan
-    }
+  override def visitMerge(ctx: MergeContext): ir.Modification = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val targetPlan = ctx.ddlObject().accept(vc.relationBuilder)
+      val hints = vc.relationBuilder.buildTableHints(Option(ctx.withTableHints()))
+      val finalTarget = if (hints.nonEmpty) {
+        ir.TableWithHints(targetPlan, hints)
+      } else {
+        targetPlan
+      }
 
-    val mergeCondition = ctx.searchCondition().accept(vc.expressionBuilder)
-    val tableSourcesPlan = ctx.tableSources().tableSource().asScala.map(_.accept(vc.relationBuilder))
-    val sourcePlan = tableSourcesPlan.tail.foldLeft(tableSourcesPlan.head)(
-      ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
+      val mergeCondition = ctx.searchCondition().accept(vc.expressionBuilder)
+      val tableSourcesPlan = ctx.tableSources().tableSource().asScala.map(_.accept(vc.relationBuilder))
+      val sourcePlan = tableSourcesPlan.tail.foldLeft(tableSourcesPlan.head)(
+        ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
 
-    // We may have a number of when clauses, each with a condition and an action. We keep the ANTLR syntax compact
-    // and lean and determine which of the three types of action we have in the whenMatch method based on
-    // the presence or absence of syntactical elements NOT and SOURCE as SOURCE can only be used with NOT
-    val (matchedActions, notMatchedActions, notMatchedBySourceActions) = Option(ctx.whenMatch())
-      .map(_.asScala.foldLeft((List.empty[ir.MergeAction], List.empty[ir.MergeAction], List.empty[ir.MergeAction])) {
-        case ((matched, notMatched, notMatchedBySource), m) =>
-          val action = buildWhenMatch(m)
-          (m.NOT(), m.SOURCE()) match {
-            case (null, _) => (action :: matched, notMatched, notMatchedBySource)
-            case (_, null) => (matched, action :: notMatched, notMatchedBySource)
-            case _ => (matched, notMatched, action :: notMatchedBySource)
-          }
-      })
-      .getOrElse((List.empty, List.empty, List.empty))
+      // We may have a number of when clauses, each with a condition and an action. We keep the ANTLR syntax compact
+      // and lean and determine which of the three types of action we have in the whenMatch method based on
+      // the presence or absence of syntactical elements NOT and SOURCE as SOURCE can only be used with NOT
+      val (matchedActions, notMatchedActions, notMatchedBySourceActions) = Option(ctx.whenMatch())
+        .map(_.asScala.foldLeft((List.empty[ir.MergeAction], List.empty[ir.MergeAction], List.empty[ir.MergeAction])) {
+          case ((matched, notMatched, notMatchedBySource), m) =>
+            val action = buildWhenMatch(m)
+            (m.NOT(), m.SOURCE()) match {
+              case (null, _) => (action :: matched, notMatched, notMatchedBySource)
+              case (_, null) => (matched, action :: notMatched, notMatchedBySource)
+              case _ => (matched, notMatched, action :: notMatchedBySource)
+            }
+        })
+        .getOrElse((List.empty, List.empty, List.empty))
 
-    val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
-    val outputClause = Option(ctx.outputClause()).map(buildOutputClause)
+      val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
+      val outputClause = Option(ctx.outputClause()).map(buildOutputClause)
 
-    val mergeIntoTable = ir.MergeIntoTable(
-      finalTarget,
-      sourcePlan,
-      mergeCondition,
-      matchedActions,
-      notMatchedActions,
-      notMatchedBySourceActions)
+      val mergeIntoTable = ir.MergeIntoTable(
+        finalTarget,
+        sourcePlan,
+        mergeCondition,
+        matchedActions,
+        notMatchedActions,
+        notMatchedBySourceActions)
 
-    val withOptions = optionClause match {
-      case Some(option) => ir.WithModificationOptions(mergeIntoTable, option)
-      case None => mergeIntoTable
-    }
+      val withOptions = optionClause match {
+        case Some(option) => ir.WithModificationOptions(mergeIntoTable, option)
+        case None => mergeIntoTable
+      }
 
-    outputClause match {
-      case Some(output) => WithOutputClause(withOptions, output)
-      case None => withOptions
-    }
+      outputClause match {
+        case Some(output) => WithOutputClause(withOptions, output)
+        case None => withOptions
+      }
   }
 
   private def buildWhenMatch(ctx: WhenMatchContext): ir.MergeAction = {
@@ -119,67 +124,75 @@ class TSqlDMLBuilder(override val vc: TSqlVisitorCoordinator)
     ir.UpdateAction(condition, setElements)
   }
 
-  override def visitUpdate(ctx: UpdateContext): ir.Modification = {
-    val target = ctx.ddlObject().accept(vc.relationBuilder)
-    val hints = vc.relationBuilder.buildTableHints(Option(ctx.withTableHints()))
-    val hintTarget = if (hints.nonEmpty) {
-      ir.TableWithHints(target, hints)
-    } else {
-      target
-    }
+  override def visitUpdate(ctx: UpdateContext): ir.Modification = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val target = ctx.ddlObject().accept(vc.relationBuilder)
+      val hints = vc.relationBuilder.buildTableHints(Option(ctx.withTableHints()))
+      val hintTarget = if (hints.nonEmpty) {
+        ir.TableWithHints(target, hints)
+      } else {
+        target
+      }
 
-    val finalTarget = vc.relationBuilder.buildTop(Option(ctx.topClause()), hintTarget)
-    val output = Option(ctx.outputClause()).map(buildOutputClause)
-    val setElements = ctx.updateElem().asScala.map(_.accept(vc.expressionBuilder))
+      val finalTarget = vc.relationBuilder.buildTop(Option(ctx.topClause()), hintTarget)
+      val output = Option(ctx.outputClause()).map(buildOutputClause)
+      val setElements = ctx.updateElem().asScala.map(_.accept(vc.expressionBuilder))
 
-    val tableSourcesOption = Option(ctx.tableSources()).map(_.tableSource().asScala.map(_.accept(vc.relationBuilder)))
-    val sourceRelation = tableSourcesOption.map { tableSources =>
-      tableSources.tail.foldLeft(tableSources.head)(
-        ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
-    }
+      val tableSourcesOption = Option(ctx.tableSources()).map(_.tableSource().asScala.map(_.accept(vc.relationBuilder)))
+      val sourceRelation = tableSourcesOption.map { tableSources =>
+        tableSources.tail.foldLeft(tableSources.head)(
+          ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
+      }
 
-    val where = Option(ctx.updateWhereClause()) map (_.accept(vc.expressionBuilder))
-    val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
-    ir.UpdateTable(finalTarget, sourceRelation, setElements, where, output, optionClause)
+      val where = Option(ctx.updateWhereClause()) map (_.accept(vc.expressionBuilder))
+      val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
+      ir.UpdateTable(finalTarget, sourceRelation, setElements, where, output, optionClause)
   }
 
-  override def visitDelete(ctx: DeleteContext): ir.Modification = {
-    val target = ctx.ddlObject().accept(vc.relationBuilder)
-    val hints = vc.relationBuilder.buildTableHints(Option(ctx.withTableHints()))
-    val finalTarget = if (hints.nonEmpty) {
-      ir.TableWithHints(target, hints)
-    } else {
-      target
-    }
+  override def visitDelete(ctx: DeleteContext): ir.Modification = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val target = ctx.ddlObject().accept(vc.relationBuilder)
+      val hints = vc.relationBuilder.buildTableHints(Option(ctx.withTableHints()))
+      val finalTarget = if (hints.nonEmpty) {
+        ir.TableWithHints(target, hints)
+      } else {
+        target
+      }
 
-    val output = Option(ctx.outputClause()).map(buildOutputClause)
-    val tableSourcesOption = Option(ctx.tableSources()).map(_.tableSource().asScala.map(_.accept(vc.relationBuilder)))
-    val sourceRelation = tableSourcesOption.map { tableSources =>
-      tableSources.tail.foldLeft(tableSources.head)(
-        ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
-    }
+      val output = Option(ctx.outputClause()).map(buildOutputClause)
+      val tableSourcesOption = Option(ctx.tableSources()).map(_.tableSource().asScala.map(_.accept(vc.relationBuilder)))
+      val sourceRelation = tableSourcesOption.map { tableSources =>
+        tableSources.tail.foldLeft(tableSources.head)(
+          ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
+      }
 
-    val where = Option(ctx.updateWhereClause()) map (_.accept(vc.expressionBuilder))
-    val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
-    ir.DeleteFromTable(finalTarget, sourceRelation, where, output, optionClause)
+      val where = Option(ctx.updateWhereClause()) map (_.accept(vc.expressionBuilder))
+      val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
+      ir.DeleteFromTable(finalTarget, sourceRelation, where, output, optionClause)
   }
 
-  override def visitInsert(ctx: InsertContext): ir.Modification = {
-    val target = ctx.ddlObject().accept(vc.relationBuilder)
-    val hints = vc.relationBuilder.buildTableHints(Option(ctx.withTableHints()))
-    val finalTarget = if (hints.nonEmpty) {
-      ir.TableWithHints(target, hints)
-    } else {
-      target
-    }
+  override def visitInsert(ctx: InsertContext): ir.Modification = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val target = ctx.ddlObject().accept(vc.relationBuilder)
+      val hints = vc.relationBuilder.buildTableHints(Option(ctx.withTableHints()))
+      val finalTarget = if (hints.nonEmpty) {
+        ir.TableWithHints(target, hints)
+      } else {
+        target
+      }
 
-    val columns = Option(ctx.expressionList())
-      .map(_.expression().asScala.map(_.accept(vc.expressionBuilder)).collect { case col: ir.Column => col.columnName })
+      val columns = Option(ctx.expressionList())
+        .map(_.expression().asScala.map(_.accept(vc.expressionBuilder)).collect { case col: ir.Column =>
+          col.columnName
+        })
 
-    val output = Option(ctx.outputClause()).map(buildOutputClause)
-    val values = buildInsertStatementValue(ctx.insertStatementValue())
-    val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
-    ir.InsertIntoTable(finalTarget, columns, values, output, optionClause)
+      val output = Option(ctx.outputClause()).map(buildOutputClause)
+      val values = buildInsertStatementValue(ctx.insertStatementValue())
+      val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
+      ir.InsertIntoTable(finalTarget, columns, values, output, optionClause)
   }
 
   private def buildInsertStatementValue(ctx: InsertStatementValueContext): ir.LogicalPlan = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
@@ -208,7 +208,7 @@ class TSqlDMLBuilder(override val vc: TSqlVisitorCoordinator)
     val target = Option(ctx.ddlObject()).map(_.accept(vc.relationBuilder))
     val columns =
       Option(ctx.columnNameList())
-        .map(_.id().asScala.map(id => ir.Column(None, vc.expressionBuilder.visitId(id))))
+        .map(_.id().asScala.map(id => ir.Column(None, vc.expressionBuilder.buildId(id))))
 
     // Databricks SQL does not support the OUTPUT clause, but we may be able to translate
     // the clause to SELECT statements executed before or after the INSERT/DELETE/UPDATE/MERGE

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -20,58 +20,69 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
 
   // Concrete visitors..
 
-  override def visitSelectListElem(ctx: TSqlParser.SelectListElemContext): ir.Expression = {
-    ctx match {
-      case c if c.asterisk() != null => c.asterisk().accept(this)
-      case c if c.LOCAL_ID() != null => buildLocalAssign(ctx)
-      case c if c.expressionElem() != null => ctx.expressionElem().accept(this)
-      case _ =>
-        ir.UnresolvedExpression(
-          ruleText = contextText(ctx),
-          message = s"Unsupported select list element",
-          ruleName = "expression",
-          tokenName = Some(tokenName(ctx.getStart)))
-    }
+  override def visitSelectListElem(ctx: TSqlParser.SelectListElemContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx match {
+        case c if c.asterisk() != null => c.asterisk().accept(this)
+        case c if c.LOCAL_ID() != null => buildLocalAssign(ctx)
+        case c if c.expressionElem() != null => ctx.expressionElem().accept(this)
+        case _ =>
+          ir.UnresolvedExpression(
+            ruleText = contextText(ctx),
+            message = s"Unsupported select list element",
+            ruleName = "expression",
+            tokenName = Some(tokenName(ctx.getStart)))
+      }
   }
 
-  override def visitOptionClause(ctx: TSqlParser.OptionClauseContext): ir.Expression = {
-    // we gather the options given to use by the original query, though at the moment, we do nothing
-    // with them.
-    val opts = vc.optionBuilder.buildOptionList(ctx.lparenOptionList().optionList().genericOption().asScala)
-    ir.Options(opts.expressionOpts, opts.stringOpts, opts.boolFlags, opts.autoFlags)
+  override def visitOptionClause(ctx: TSqlParser.OptionClauseContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      // we gather the options given to use by the original query, though at the moment, we do nothing
+      // with them.
+      val opts = vc.optionBuilder.buildOptionList(ctx.lparenOptionList().optionList().genericOption().asScala)
+      ir.Options(opts.expressionOpts, opts.stringOpts, opts.boolFlags, opts.autoFlags)
   }
 
-  override def visitUpdateElemCol(ctx: TSqlParser.UpdateElemColContext): ir.Expression = {
-    val value = ctx.expression().accept(this)
-    val target1 = Option(ctx.l2)
-      .map(l2 => ir.Identifier(l2.getText, isQuoted = false))
-      .getOrElse(ctx.fullColumnName().accept(this))
-    val a1 = buildAssign(target1, value, ctx.op)
-    Option(ctx.l1).map(l1 => ir.Assign(ir.Identifier(l1.getText, isQuoted = false), a1)).getOrElse(a1)
+  override def visitUpdateElemCol(ctx: TSqlParser.UpdateElemColContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val value = ctx.expression().accept(this)
+      val target1 = Option(ctx.l2)
+        .map(l2 => ir.Identifier(l2.getText, isQuoted = false))
+        .getOrElse(ctx.fullColumnName().accept(this))
+      val a1 = buildAssign(target1, value, ctx.op)
+      Option(ctx.l1).map(l1 => ir.Assign(ir.Identifier(l1.getText, isQuoted = false), a1)).getOrElse(a1)
   }
 
-  override def visitUpdateElemUdt(ctx: TSqlParser.UpdateElemUdtContext): ir.Expression = {
-    val args = ctx.expressionList().expression().asScala.map(_.accept(this))
-    val fName = ctx.id(0).getText + "." + ctx.id(1).getText
-    val functionResult = vc.functionBuilder.buildFunction(fName, args)
+  override def visitUpdateElemUdt(ctx: TSqlParser.UpdateElemUdtContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val args = ctx.expressionList().expression().asScala.map(_.accept(this))
+      val fName = ctx.id(0).getText + "." + ctx.id(1).getText
+      val functionResult = vc.functionBuilder.buildFunction(fName, args)
 
-    functionResult match {
-      case unresolvedFunction: ir.UnresolvedFunction =>
-        unresolvedFunction.copy(is_user_defined_function = true)
-      case _ => functionResult
-    }
+      functionResult match {
+        case unresolvedFunction: ir.UnresolvedFunction =>
+          unresolvedFunction.copy(is_user_defined_function = true)
+        case _ => functionResult
+      }
   }
 
-  override def visitUpdateWhereClause(ctx: UpdateWhereClauseContext): ir.Expression = {
-    ctx.searchCondition().accept(this)
-    // TODO: TSQL also supports updates via cursor traversal, which is not supported in Databricks SQL - lint error?
+  override def visitUpdateWhereClause(ctx: UpdateWhereClauseContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx.searchCondition().accept(this)
+    // TODO: TSQL also supports updates via cursor traversal, which is not supported in Databricks SQL
+    //       generate UnresolvedExpression
   }
 
   /**
    * Build a local variable assignment from a column source
    *
    * @param ctx
-   *   the parse tree containing the assignment
+   * the parse tree containing the assignment
    */
   private def buildLocalAssign(ctx: TSqlParser.SelectListElemContext): ir.Expression = {
     val localId = ir.Identifier(ctx.LOCAL_ID().getText, isQuoted = false)
@@ -102,20 +113,24 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
   }
 
   private def buildTableName(ctx: TableNameContext): ir.ObjectReference = {
-    val linkedServer = Option(ctx.linkedServer).map(visitId)
-    val ids = ctx.ids.asScala.map(visitId)
+    val linkedServer = Option(ctx.linkedServer).map(buildId)
+    val ids = ctx.ids.asScala.map(buildId)
     val allIds = linkedServer.fold(ids)(ser => ser +: ids)
     ir.ObjectReference(allIds.head, allIds.tail: _*)
   }
 
-  override def visitExprId(ctx: ExprIdContext): ir.Expression = {
-    ir.Column(None, visitId(ctx.id()))
+  override def visitExprId(ctx: ExprIdContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ir.Column(None, buildId(ctx.id()))
   }
 
-  override def visitFullColumnName(ctx: FullColumnNameContext): ir.Column = {
-    val columnName = visitId(ctx.id)
-    val tableName = Option(ctx.tableName()).map(buildTableName)
-    ir.Column(tableName, columnName)
+  override def visitFullColumnName(ctx: FullColumnNameContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val columnName = buildId(ctx.id)
+      val tableName = Option(ctx.tableName()).map(buildTableName)
+      ir.Column(tableName, columnName)
   }
 
   /**
@@ -124,36 +139,44 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
    * This can be used in things like SELECT * FROM table
    *
    * @param ctx
-   *   the parse tree
+   * the parse tree
    */
-  override def visitAsterisk(ctx: AsteriskContext): ir.Expression = ctx match {
-    case _ if ctx.tableName() != null =>
-      val objectName = Option(ctx.tableName()).map(buildTableName)
-      ir.Star(objectName)
-    case _ if ctx.INSERTED() != null => Inserted(ir.Star(None))
-    case _ if ctx.DELETED() != null => Deleted(ir.Star(None))
-    case _ => ir.Star(None)
+  override def visitAsterisk(ctx: AsteriskContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx match {
+        case _ if ctx.tableName() != null =>
+          val objectName = Option(ctx.tableName()).map(buildTableName)
+          ir.Star(objectName)
+        case _ if ctx.INSERTED() != null => Inserted(ir.Star(None))
+        case _ if ctx.DELETED() != null => Deleted(ir.Star(None))
+        case _ => ir.Star(None)
+      }
   }
 
   /**
    * Expression precedence as defined by parenthesis
    *
    * @param ctx
-   *   the ExprPrecedenceContext to visit, which contains the expression to which precedence is applied
+   * the ExprPrecedenceContext to visit, which contains the expression to which precedence is applied
    * @return
-   *   the visited expression in IR
+   * the visited expression in IR
    *
    * Note that precedence COULD be explicitly placed in the AST here. If we wish to construct an exact replication of
    * expression source code from the AST, we need to know that the () were there. Redundant parens are otherwise elided
    * and the generated code may seem to be incorrect in the eyes of the customer, even though it will be logically
    * equivalent.
    */
-  override def visitExprPrecedence(ctx: ExprPrecedenceContext): ir.Expression = {
-    ctx.expression().accept(this)
+  override def visitExprPrecedence(ctx: ExprPrecedenceContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx.expression().accept(this)
   }
 
-  override def visitExprBitNot(ctx: ExprBitNotContext): ir.Expression = {
-    ir.BitwiseNot(ctx.expression().accept(this))
+  override def visitExprBitNot(ctx: ExprBitNotContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ir.BitwiseNot(ctx.expression().accept(this))
   }
 
   // Note that while we could evaluate the unary expression if it is a numeric
@@ -167,20 +190,28 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
     }
   }
 
-  override def visitExprOpPrec1(ctx: ExprOpPrec1Context): ir.Expression = {
-    buildBinaryExpression(ctx.expression(0).accept(this), ctx.expression(1).accept(this), ctx.op)
+  override def visitExprOpPrec1(ctx: ExprOpPrec1Context): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      buildBinaryExpression(ctx.expression(0).accept(this), ctx.expression(1).accept(this), ctx.op)
   }
 
-  override def visitExprOpPrec2(ctx: ExprOpPrec2Context): ir.Expression = {
-    buildBinaryExpression(ctx.expression(0).accept(this), ctx.expression(1).accept(this), ctx.op)
+  override def visitExprOpPrec2(ctx: ExprOpPrec2Context): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      buildBinaryExpression(ctx.expression(0).accept(this), ctx.expression(1).accept(this), ctx.op)
   }
 
-  override def visitExprOpPrec3(ctx: ExprOpPrec3Context): ir.Expression = {
-    buildBinaryExpression(ctx.expression(0).accept(this), ctx.expression(1).accept(this), ctx.op)
+  override def visitExprOpPrec3(ctx: ExprOpPrec3Context): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      buildBinaryExpression(ctx.expression(0).accept(this), ctx.expression(1).accept(this), ctx.op)
   }
 
-  override def visitExprOpPrec4(ctx: ExprOpPrec4Context): ir.Expression = {
-    buildBinaryExpression(ctx.expression(0).accept(this), ctx.expression(1).accept(this), ctx.op)
+  override def visitExprOpPrec4(ctx: ExprOpPrec4Context): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      buildBinaryExpression(ctx.expression(0).accept(this), ctx.expression(1).accept(this), ctx.op)
   }
 
   /**
@@ -191,186 +222,265 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
    * TODO: Expand this to handle more complex cases
    *
    * @param ctx
-   *   the parse tree
+   * the parse tree
    */
-  override def visitExprDot(ctx: ExprDotContext): ir.Expression = {
-    val left = ctx.expression(0).accept(this)
-    val right = ctx.expression(1).accept(this)
-    (left, right) match {
-      case (c1: ir.Column, c2: ir.Column) =>
-        val path = c1.columnName +: c2.tableNameOrAlias.map(ref => ref.head +: ref.tail).getOrElse(Nil)
-        ir.Column(Some(ir.ObjectReference(path.head, path.tail: _*)), c2.columnName)
-      case (_: ir.Column, c2: ir.CallFunction) =>
-        vc.functionBuilder.functionType(c2.function_name) match {
-          case XmlFunction => tsql.TsqlXmlFunction(c2, left)
-          case _ => ir.Dot(left, right)
-        }
-      // Other cases
-      case _ => ir.Dot(left, right)
-    }
+  override def visitExprDot(ctx: ExprDotContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val left = ctx.expression(0).accept(this)
+      val right = ctx.expression(1).accept(this)
+      (left, right) match {
+        case (c1: ir.Column, c2: ir.Column) =>
+          val path = c1.columnName +: c2.tableNameOrAlias.map(ref => ref.head +: ref.tail).getOrElse(Nil)
+          ir.Column(Some(ir.ObjectReference(path.head, path.tail: _*)), c2.columnName)
+        case (_: ir.Column, c2: ir.CallFunction) =>
+          vc.functionBuilder.functionType(c2.function_name) match {
+            case XmlFunction => tsql.TsqlXmlFunction(c2, left)
+            case _ => ir.Dot(left, right)
+          }
+        // Other cases
+        case _ => ir.Dot(left, right)
+      }
   }
 
-  override def visitExprCase(ctx: ExprCaseContext): ir.Expression = {
-    ctx.caseExpression().accept(this)
+  override def visitExprCase(ctx: ExprCaseContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx.caseExpression().accept(this)
   }
 
-  override def visitCaseExpression(ctx: CaseExpressionContext): ir.Expression = {
-    val caseExpr = if (ctx.caseExpr != null) Option(ctx.caseExpr.accept(this)) else None
-    val elseExpr = if (ctx.elseExpr != null) Option(ctx.elseExpr.accept(this)) else None
-    val whenThenPairs: Seq[ir.WhenBranch] = ctx
-      .switchSection()
-      .asScala
-      .map(buildWhen)
+  override def visitCaseExpression(ctx: CaseExpressionContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val caseExpr = if (ctx.caseExpr != null) Option(ctx.caseExpr.accept(this)) else None
+      val elseExpr = if (ctx.elseExpr != null) Option(ctx.elseExpr.accept(this)) else None
+      val whenThenPairs: Seq[ir.WhenBranch] = ctx
+        .switchSection()
+        .asScala
+        .map(buildWhen)
 
-    ir.Case(caseExpr, whenThenPairs, elseExpr)
+      ir.Case(caseExpr, whenThenPairs, elseExpr)
   }
 
   private def buildWhen(ctx: SwitchSectionContext): ir.WhenBranch =
     ir.WhenBranch(ctx.searchCondition.accept(this), ctx.expression().accept(this))
 
-  override def visitExprFunc(ctx: ExprFuncContext): ir.Expression = ctx.functionCall.accept(this)
-
-  override def visitExprDollar(ctx: ExprDollarContext): ir.Expression = ir.DollarAction()
-
-  override def visitExprStar(ctx: ExprStarContext): ir.Expression = ir.Star(None)
-
-  override def visitExprFuncVal(ctx: ExprFuncValContext): ir.Expression = {
-    vc.functionBuilder.buildFunction(ctx.getText, Seq.empty)
+  override def visitExprFunc(ctx: ExprFuncContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx.functionCall.accept(this)
   }
 
-  override def visitExprPrimitive(ctx: ExprPrimitiveContext): ir.Expression = {
-    ctx.primitiveExpression().accept(this)
+  override def visitExprDollar(ctx: ExprDollarContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ir.DollarAction()
   }
 
-  override def visitExprCollate(ctx: ExprCollateContext): ir.Expression =
-    ir.Collate(ctx.expression.accept(this), removeQuotes(ctx.id.getText))
-
-  override def visitPrimitiveExpression(ctx: PrimitiveExpressionContext): ir.Expression = {
-    Option(ctx.op).map(buildPrimitive).getOrElse(ctx.constant().accept(this))
+  override def visitExprStar(ctx: ExprStarContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ir.Star(None)
   }
 
-  override def visitConstant(ctx: TSqlParser.ConstantContext): ir.Expression = {
-    buildPrimitive(ctx.con)
+  override def visitExprFuncVal(ctx: ExprFuncValContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      vc.functionBuilder.buildFunction(ctx.getText, Seq.empty)
   }
 
-  override def visitExprSubquery(ctx: ExprSubqueryContext): ir.Expression = {
-    ir.ScalarSubquery(ctx.selectStatement().accept(vc.relationBuilder))
+  override def visitExprPrimitive(ctx: ExprPrimitiveContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx.primitiveExpression().accept(this)
   }
 
-  override def visitExprTz(ctx: ExprTzContext): ir.Expression = {
-    val expression = ctx.expression().accept(this)
-    val timezone = ctx.timeZone.expression().accept(this)
-    ir.Timezone(expression, timezone)
+  override def visitExprCollate(ctx: ExprCollateContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ir.Collate(ctx.expression.accept(this), removeQuotes(ctx.id.getText))
   }
 
-  override def visitScNot(ctx: TSqlParser.ScNotContext): ir.Expression =
-    ir.Not(ctx.searchCondition().accept(this))
-
-  override def visitScAnd(ctx: TSqlParser.ScAndContext): ir.Expression =
-    ir.And(ctx.searchCondition(0).accept(this), ctx.searchCondition(1).accept(this))
-
-  override def visitScOr(ctx: TSqlParser.ScOrContext): ir.Expression =
-    ir.Or(ctx.searchCondition(0).accept(this), ctx.searchCondition(1).accept(this))
-
-  override def visitScPred(ctx: TSqlParser.ScPredContext): ir.Expression = ctx.predicate().accept(this)
-
-  override def visitScPrec(ctx: TSqlParser.ScPrecContext): ir.Expression = ctx.searchCondition.accept(this)
-
-  override def visitPredExists(ctx: PredExistsContext): ir.Expression = {
-    ir.Exists(ctx.selectStatement().accept(vc.relationBuilder))
+  override def visitPrimitiveExpression(ctx: PrimitiveExpressionContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      Option(ctx.op).map(buildPrimitive).getOrElse(ctx.constant().accept(this))
   }
 
-  override def visitPredFreetext(ctx: PredFreetextContext): ir.Expression = {
-    // TODO: build FREETEXT ?
-    ir.UnresolvedExpression(
-      ruleText = contextText(ctx),
-      message = s"Freetext predicates are unsupported",
-      ruleName = "expression",
-      tokenName = Some(tokenName(ctx.getStart)))
+  override def visitConstant(ctx: TSqlParser.ConstantContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      buildPrimitive(ctx.con)
   }
 
-  override def visitPredBinop(ctx: PredBinopContext): ir.Expression = {
-    val left = ctx.expression(0).accept(this)
-    val right = ctx.expression(1).accept(this)
-    ctx.comparisonOperator match {
-      case op if op.LT != null && op.EQ != null => ir.LessThanOrEqual(left, right)
-      case op if op.GT != null && op.EQ != null => ir.GreaterThanOrEqual(left, right)
-      case op if op.LT != null && op.GT != null => ir.NotEquals(left, right)
-      case op if op.BANG != null && op.GT != null => ir.LessThanOrEqual(left, right)
-      case op if op.BANG != null && op.LT != null => ir.GreaterThanOrEqual(left, right)
-      case op if op.BANG != null && op.EQ != null => ir.NotEquals(left, right)
-      case op if op.EQ != null => ir.Equals(left, right)
-      case op if op.GT != null => ir.GreaterThan(left, right)
-      case op if op.LT != null => ir.LessThan(left, right)
+  override def visitExprSubquery(ctx: ExprSubqueryContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ir.ScalarSubquery(ctx.selectStatement().accept(vc.relationBuilder))
+  }
+
+  override def visitExprTz(ctx: ExprTzContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val expression = ctx.expression().accept(this)
+      val timezone = ctx.timeZone.expression().accept(this)
+      ir.Timezone(expression, timezone)
+  }
+
+  override def visitScNot(ctx: TSqlParser.ScNotContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ir.Not(ctx.searchCondition().accept(this))
+  }
+
+  override def visitScAnd(ctx: TSqlParser.ScAndContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ir.And(ctx.searchCondition(0).accept(this), ctx.searchCondition(1).accept(this))
+  }
+
+  override def visitScOr(ctx: TSqlParser.ScOrContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ir.Or(ctx.searchCondition(0).accept(this), ctx.searchCondition(1).accept(this))
+  }
+
+  override def visitScPred(ctx: TSqlParser.ScPredContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx.predicate().accept(this)
+  }
+
+  override def visitScPrec(ctx: TSqlParser.ScPrecContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx.searchCondition.accept(this)
+  }
+
+  override def visitPredExists(ctx: PredExistsContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ir.Exists(ctx.selectStatement().accept(vc.relationBuilder))
+  }
+
+  override def visitPredFreetext(ctx: PredFreetextContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      // TODO: build FREETEXT ?
+      ir.UnresolvedExpression(
+        ruleText = contextText(ctx),
+        message = s"Freetext predicates are unsupported",
+        ruleName = "expression",
+        tokenName = Some(tokenName(ctx.getStart)))
+  }
+
+  override def visitPredBinop(ctx: PredBinopContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val left = ctx.expression(0).accept(this)
+      val right = ctx.expression(1).accept(this)
+      ctx.comparisonOperator match {
+        case op if op.LT != null && op.EQ != null => ir.LessThanOrEqual(left, right)
+        case op if op.GT != null && op.EQ != null => ir.GreaterThanOrEqual(left, right)
+        case op if op.LT != null && op.GT != null => ir.NotEquals(left, right)
+        case op if op.BANG != null && op.GT != null => ir.LessThanOrEqual(left, right)
+        case op if op.BANG != null && op.LT != null => ir.GreaterThanOrEqual(left, right)
+        case op if op.BANG != null && op.EQ != null => ir.NotEquals(left, right)
+        case op if op.EQ != null => ir.Equals(left, right)
+        case op if op.GT != null => ir.GreaterThan(left, right)
+        case op if op.LT != null => ir.LessThan(left, right)
+      }
+  }
+
+  override def visitPredASA(ctx: PredASAContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      // TODO: build ASA
+      ir.UnresolvedExpression(
+        ruleText = contextText(ctx),
+        message = s"ALL | SOME | ANY predicate not yet supported",
+        ruleName = vc.ruleName(ctx),
+        tokenName = Some(tokenName(ctx.getStart)))
+  }
+
+  override def visitPredBetween(ctx: PredBetweenContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val lowerBound = ctx.expression(1).accept(this)
+      val upperBound = ctx.expression(2).accept(this)
+      val expression = ctx.expression(0).accept(this)
+      val between = ir.Between(expression, lowerBound, upperBound)
+      Option(ctx.NOT()).fold[ir.Expression](between)(_ => ir.Not(between))
+  }
+
+  override def visitPredIn(ctx: PredInContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val in = if (ctx.selectStatement() != null) {
+        // In the result of a sub query
+        ir.In(ctx.expression().accept(this), Seq(ir.ScalarSubquery(ctx.selectStatement().accept(vc.relationBuilder))))
+      } else {
+        // In a list of expressions
+        ir.In(ctx.expression().accept(this), ctx.expressionList().expression().asScala.map(_.accept(this)))
+      }
+      Option(ctx.NOT()).fold[ir.Expression](in)(_ => ir.Not(in))
+  }
+
+  override def visitPredLike(ctx: PredLikeContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val left = ctx.expression(0).accept(this)
+      val right = ctx.expression(1).accept(this)
+      // NB: The escape character is a complete expression that evaluates to a single char at runtime
+      // and not a single char at parse time.
+      val escape = Option(ctx.expression(2))
+        .map(_.accept(this))
+      val like = ir.Like(left, right, escape)
+      Option(ctx.NOT()).fold[ir.Expression](like)(_ => ir.Not(like))
+  }
+
+  override def visitPredIsNull(ctx: PredIsNullContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val expression = ctx.expression().accept(this)
+      if (ctx.NOT() != null) ir.IsNotNull(expression) else ir.IsNull(expression)
+  }
+
+  override def visitPredExpression(ctx: PredExpressionContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx.expression().accept(this)
+  }
+
+  override def visitFunctionCall(ctx: FunctionCallContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx match {
+        case b if b.builtInFunctions() != null => b.builtInFunctions().accept(this)
+        case s if s.standardFunction() != null => s.standardFunction().accept(this)
+        case f if f.freetextFunction() != null => f.freetextFunction().accept(this)
+        case p if p.partitionFunction() != null => p.partitionFunction().accept(this)
+        case h if h.hierarchyidStaticMethod() != null => h.hierarchyidStaticMethod().accept(this)
+      }
+  }
+
+  override def visitId(ctx: IdContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      buildId(ctx)
+  }
+
+  private[tsql] def buildId(ctx: IdContext): ir.Id =
+    ctx match {
+      case c if c.ID() != null => ir.Id(ctx.getText)
+      case c if c.TEMP_ID() != null => ir.Id(ctx.getText)
+      case c if c.DOUBLE_QUOTE_ID() != null =>
+        ir.Id(ctx.getText.trim.stripPrefix("\"").stripSuffix("\""), caseSensitive = true)
+      case c if c.SQUARE_BRACKET_ID() != null =>
+        ir.Id(ctx.getText.trim.stripPrefix("[").stripSuffix("]"), caseSensitive = true)
+      case c if c.RAW() != null => ir.Id(ctx.getText)
+      case _ => ir.Id(removeQuotes(ctx.getText))
     }
-  }
-
-  override def visitPredASA(ctx: PredASAContext): ir.Expression = {
-    // TODO: build ASA
-    ir.UnresolvedExpression(
-      ruleText = contextText(ctx),
-      message = s"ALL | SOME | ANY predicate not yet supported",
-      ruleName = vc.ruleName(ctx),
-      tokenName = Some(tokenName(ctx.getStart)))
-  }
-
-  override def visitPredBetween(ctx: PredBetweenContext): ir.Expression = {
-    val lowerBound = ctx.expression(1).accept(this)
-    val upperBound = ctx.expression(2).accept(this)
-    val expression = ctx.expression(0).accept(this)
-    val between = ir.Between(expression, lowerBound, upperBound)
-    Option(ctx.NOT()).fold[ir.Expression](between)(_ => ir.Not(between))
-  }
-
-  override def visitPredIn(ctx: PredInContext): ir.Expression = {
-    val in = if (ctx.selectStatement() != null) {
-      // In the result of a sub query
-      ir.In(ctx.expression().accept(this), Seq(ir.ScalarSubquery(ctx.selectStatement().accept(vc.relationBuilder))))
-    } else {
-      // In a list of expressions
-      ir.In(ctx.expression().accept(this), ctx.expressionList().expression().asScala.map(_.accept(this)))
-    }
-    Option(ctx.NOT()).fold[ir.Expression](in)(_ => ir.Not(in))
-  }
-
-  override def visitPredLike(ctx: PredLikeContext): ir.Expression = {
-    val left = ctx.expression(0).accept(this)
-    val right = ctx.expression(1).accept(this)
-    // NB: The escape character is a complete expression that evaluates to a single char at runtime
-    // and not a single char at parse time.
-    val escape = Option(ctx.expression(2))
-      .map(_.accept(this))
-    val like = ir.Like(left, right, escape)
-    Option(ctx.NOT()).fold[ir.Expression](like)(_ => ir.Not(like))
-  }
-
-  override def visitPredIsNull(ctx: PredIsNullContext): ir.Expression = {
-    val expression = ctx.expression().accept(this)
-    if (ctx.NOT() != null) ir.IsNotNull(expression) else ir.IsNull(expression)
-  }
-
-  override def visitPredExpression(ctx: PredExpressionContext): ir.Expression = {
-    ctx.expression().accept(this)
-  }
-
-  override def visitFunctionCall(ctx: FunctionCallContext): ir.Expression = ctx match {
-    case b if b.builtInFunctions() != null => b.builtInFunctions().accept(this)
-    case s if s.standardFunction() != null => s.standardFunction().accept(this)
-    case f if f.freetextFunction() != null => f.freetextFunction().accept(this)
-    case p if p.partitionFunction() != null => p.partitionFunction().accept(this)
-    case h if h.hierarchyidStaticMethod() != null => h.hierarchyidStaticMethod().accept(this)
-  }
-
-  override def visitId(ctx: IdContext): ir.Id = ctx match {
-    case c if c.ID() != null => ir.Id(ctx.getText)
-    case c if c.TEMP_ID() != null => ir.Id(ctx.getText)
-    case c if c.DOUBLE_QUOTE_ID() != null =>
-      ir.Id(ctx.getText.trim.stripPrefix("\"").stripSuffix("\""), caseSensitive = true)
-    case c if c.SQUARE_BRACKET_ID() != null =>
-      ir.Id(ctx.getText.trim.stripPrefix("[").stripSuffix("]"), caseSensitive = true)
-    case c if c.RAW() != null => ir.Id(ctx.getText)
-    case _ => ir.Id(removeQuotes(ctx.getText))
-  }
 
   private[tsql] def removeQuotes(str: String): String = {
     str.stripPrefix("'").stripSuffix("'")
@@ -399,37 +509,40 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
     case INT | REAL | FLOAT => ir.NumericLiteral(con.getText)
   }
 
-  override def visitStandardFunction(ctx: StandardFunctionContext): ir.Expression = {
-    val name = ctx.funcId.getText
-    val args = Option(ctx.expression()).map(_.asScala.map(_.accept(this))).getOrElse(Seq.empty)
-    vc.functionBuilder.buildFunction(name, args)
+  override def visitStandardFunction(ctx: StandardFunctionContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val name = ctx.funcId.getText
+      val args = Option(ctx.expression()).map(_.asScala.map(_.accept(this))).getOrElse(Seq.empty)
+      vc.functionBuilder.buildFunction(name, args)
   }
 
   // Note that this visitor is made complicated and difficult because the built-in ir does not use options.
   // So we build placeholder values for the optional values. They also do not extend expression
   // so we can't build them logically with visit and accept. Maybe replace them with
   // extensions that do this?
-  override def visitExprOver(ctx: ExprOverContext): ir.Window = {
+  override def visitExprOver(ctx: ExprOverContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      // The OVER clause is used to accept the IGNORE nulls clause that can be specified after certain
+      // windowing functions such as LAG or LEAD, so that the clause is manifest here. The syntax allows
+      // 'IGNORE NULLS' and 'RESPECT NULLS', but 'RESPECT NULLS' is the default behavior.
+      val windowFunction =
+        buildWindowingFunction(ctx.expression().accept(this))
+      val partitionByExpressions =
+        Option(ctx.overClause().expression()).map(_.asScala.toList.map(_.accept(this))).getOrElse(List.empty)
+      val orderByExpressions = Option(ctx.overClause().orderByClause())
+        .map(buildOrderBy)
+        .getOrElse(List.empty)
+      val windowFrame = Option(ctx.overClause().rowOrRangeClause())
+        .map(buildWindowFrame)
 
-    // The OVER clause is used to accept the IGNORE nulls clause that can be specified after certain
-    // windowing functions such as LAG or LEAD, so that the clause is manifest here. The syntax allows
-    // 'IGNORE NULLS' and 'RESPECT NULLS', but 'RESPECT NULLS' is the default behavior.
-    val windowFunction =
-      buildWindowingFunction(ctx.expression().accept(this))
-    val partitionByExpressions =
-      Option(ctx.overClause().expression()).map(_.asScala.toList.map(_.accept(this))).getOrElse(List.empty)
-    val orderByExpressions = Option(ctx.overClause().orderByClause())
-      .map(buildOrderBy)
-      .getOrElse(List.empty)
-    val windowFrame = Option(ctx.overClause().rowOrRangeClause())
-      .map(buildWindowFrame)
-
-    ir.Window(
-      windowFunction,
-      partitionByExpressions,
-      orderByExpressions,
-      windowFrame,
-      ctx.overClause().IGNORE() != null)
+      ir.Window(
+        windowFunction,
+        partitionByExpressions,
+        orderByExpressions,
+        windowFrame,
+        ctx.overClause().IGNORE() != null)
   }
 
   // Some functions need to be converted to Databricks equivalent Windowing functions for the OVER clause
@@ -481,103 +594,127 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
         ir.FollowingN(ir.Literal(c.INT().getText.toInt, ir.IntegerType))
     }
 
-  override def visitExpressionElem(ctx: ExpressionElemContext): ir.Expression = {
-    val columnDef = ctx.expression().accept(this)
-    val aliasOption = Option(ctx.columnAlias()).orElse(Option(ctx.asColumnAlias()).map(_.columnAlias())).map { alias =>
-      val name = Option(alias.id()).map(visitId).getOrElse(ir.Id(alias.STRING().getText))
-      ir.Alias(columnDef, name)
-    }
-    aliasOption.getOrElse(columnDef)
+  override def visitExpressionElem(ctx: ExpressionElemContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val columnDef = ctx.expression().accept(this)
+      val aliasOption =
+        Option(ctx.columnAlias()).orElse(Option(ctx.asColumnAlias()).map(_.columnAlias())).map { alias =>
+          val name = Option(alias.id()).map(buildId).getOrElse(ir.Id(alias.STRING().getText))
+          ir.Alias(columnDef, name)
+        }
+      aliasOption.getOrElse(columnDef)
   }
 
-  override def visitExprWithinGroup(ctx: ExprWithinGroupContext): ir.Expression = {
-    val expression = ctx.expression().accept(this)
-    val orderByExpressions = buildOrderBy(ctx.withinGroup().orderByClause())
-    ir.WithinGroup(expression, orderByExpressions)
+  override def visitExprWithinGroup(ctx: ExprWithinGroupContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val expression = ctx.expression().accept(this)
+      val orderByExpressions = buildOrderBy(ctx.withinGroup().orderByClause())
+      ir.WithinGroup(expression, orderByExpressions)
   }
 
-  override def visitExprDistinct(ctx: ExprDistinctContext): ir.Expression = {
-    // Support for functions such as COUNT(DISTINCT column), which is an expression not a child
-    ir.Distinct(ctx.expression().accept(this))
+  override def visitExprDistinct(ctx: ExprDistinctContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      // Support for functions such as COUNT(DISTINCT column), which is an expression not a child
+      ir.Distinct(ctx.expression().accept(this))
   }
 
-  override def visitExprAll(ctx: ExprAllContext): ir.Expression = {
-    // Support for functions such as COUNT(ALL column), which is an expression not a child.
-    // ALL has no actual effect on the result so we just pass the expression as is. If we wish to
-    // reproduce existing annotations like this, then we would need to add IR.
-    ctx.expression().accept(this)
+  override def visitExprAll(ctx: ExprAllContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      // Support for functions such as COUNT(ALL column), which is an expression not a child.
+      // ALL has no actual effect on the result so we just pass the expression as is. If we wish to
+      // reproduce existing annotations like this, then we would need to add IR.
+      ctx.expression().accept(this)
   }
 
-  override def visitPartitionFunction(ctx: PartitionFunctionContext): ir.Expression = {
-    // $$PARTITION is not supported in Databricks SQL, so we will report it is not supported
-    vc.functionBuilder.buildFunction(s"$$PARTITION", List.empty)
+  override def visitPartitionFunction(ctx: PartitionFunctionContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      // $$PARTITION is not supported in Databricks SQL, so we will report it is not supported
+      vc.functionBuilder.buildFunction(s"$$PARTITION", List.empty)
   }
 
   /**
    * Handles the NEXT VALUE FOR function in SQL Server, which has a special syntax.
    *
    * @param ctx
-   *   the parse tree
+   * the parse tree
    */
-  override def visitNextValueFor(ctx: NextValueForContext): ir.Expression = {
-    val sequenceName = buildTableName(ctx.tableName())
-    vc.functionBuilder.buildFunction("NEXTVALUEFOR", Seq(sequenceName))
+  override def visitNextValueFor(ctx: NextValueForContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val sequenceName = buildTableName(ctx.tableName())
+      vc.functionBuilder.buildFunction("NEXTVALUEFOR", Seq(sequenceName))
   }
 
-  override def visitCast(ctx: CastContext): ir.Expression = {
-    val expression = ctx.expression().accept(this)
-    val dataType = vc.dataTypeBuilder.build(ctx.dataType())
-    ir.Cast(expression, dataType, returnNullOnError = ctx.TRY_CAST() != null)
+  override def visitCast(ctx: CastContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val expression = ctx.expression().accept(this)
+      val dataType = vc.dataTypeBuilder.build(ctx.dataType())
+      ir.Cast(expression, dataType, returnNullOnError = ctx.TRY_CAST() != null)
   }
 
-  override def visitJsonArray(ctx: JsonArrayContext): ir.Expression = {
-    val elements = buildExpressionList(Option(ctx.expressionList()))
-    val absentOnNull = checkAbsentNull(ctx.jsonNullClause())
-    buildJsonArray(elements, absentOnNull)
+  override def visitJsonArray(ctx: JsonArrayContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val elements = buildExpressionList(Option(ctx.expressionList()))
+      val absentOnNull = checkAbsentNull(ctx.jsonNullClause())
+      buildJsonArray(elements, absentOnNull)
   }
 
-  override def visitJsonObject(ctx: JsonObjectContext): ir.Expression = {
-    val jsonKeyValues = Option(ctx.jsonKeyValue()).map(_.asScala).getOrElse(Nil)
-    val namedStruct = buildNamedStruct(jsonKeyValues)
-    val absentOnNull = checkAbsentNull(ctx.jsonNullClause())
-    buildJsonObject(namedStruct, absentOnNull)
+  override def visitJsonObject(ctx: JsonObjectContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val jsonKeyValues = Option(ctx.jsonKeyValue()).map(_.asScala).getOrElse(Nil)
+      val namedStruct = buildNamedStruct(jsonKeyValues)
+      val absentOnNull = checkAbsentNull(ctx.jsonNullClause())
+      buildJsonObject(namedStruct, absentOnNull)
   }
 
-  override def visitFreetextFunction(ctx: FreetextFunctionContext): ir.Expression = {
-    // Databricks SQL does not support FREETEXT functions, so there is no point in trying to convert these
-    // functions. We do need to generate IR that indicates that this is a function that is not supported.
-    vc.functionBuilder.buildFunction(ctx.f.getText, List.empty)
+  override def visitFreetextFunction(ctx: FreetextFunctionContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      // Databricks SQL does not support FREETEXT functions, so there is no point in trying to convert these
+      // functions. We do need to generate IR that indicates that this is a function that is not supported.
+      vc.functionBuilder.buildFunction(ctx.f.getText, List.empty)
   }
 
-  override def visitHierarchyidStaticMethod(ctx: HierarchyidStaticMethodContext): ir.Expression = {
-    // Databricks SQL does not support HIERARCHYID functions, so there is no point in trying to convert these
-    // functions. We do need to generate IR that indicates that this is a function that is not supported.
-    vc.functionBuilder.buildFunction("HIERARCHYID", List.empty)
+  override def visitHierarchyidStaticMethod(ctx: HierarchyidStaticMethodContext): ir.Expression = errorCheck(
+    ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      // Databricks SQL does not support HIERARCHYID functions, so there is no point in trying to convert these
+      // functions. We do need to generate IR that indicates that this is a function that is not supported.
+      vc.functionBuilder.buildFunction("HIERARCHYID", List.empty)
   }
 
-  override def visitOutputDmlListElem(ctx: OutputDmlListElemContext): ir.Expression = {
-    val expression = Option(ctx.expression()).map(_.accept(this)).getOrElse(ctx.asterisk().accept(this))
-    val aliasOption = Option(ctx.asColumnAlias()).map(_.columnAlias()).map { alias =>
-      val name = Option(alias.id()).map(visitId).getOrElse(ir.Id(alias.STRING().getText))
-      ir.Alias(expression, name)
-    }
-    aliasOption.getOrElse(expression)
+  override def visitOutputDmlListElem(ctx: OutputDmlListElemContext): ir.Expression = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val expression = Option(ctx.expression()).map(_.accept(this)).getOrElse(ctx.asterisk().accept(this))
+      val aliasOption = Option(ctx.asColumnAlias()).map(_.columnAlias()).map { alias =>
+        val name = Option(alias.id()).map(buildId).getOrElse(ir.Id(alias.STRING().getText))
+        ir.Alias(expression, name)
+      }
+      aliasOption.getOrElse(expression)
   }
 
-  // format: off
   /**
    * Check if the ABSENT ON NULL clause is present in the JSON clause. The behavior is as follows:
    * <ul>
-   *   <li>If the clause does not exist, the ABSENT ON NULL is assumed - so true</li>
+   * <li>If the clause does not exist, the ABSENT ON NULL is assumed - so true</li>
    * <li>If the clause exists and ABSENT ON NULL - true</li>
    * <li>If the clause exists and NULL ON NULL - false</li>
    * </ul>
    *
    * @param ctx
-   *   null clause parser context
+   * null clause parser context
    * @return
    */
-  // format on
   private def checkAbsentNull(ctx: JsonNullClauseContext): Boolean = {
     Option(ctx).forall(_.loseNulls != null)
   }
@@ -601,11 +738,11 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
    * set, then any NULL expressions are left out of the JSON array.
    *
    * @param args
-   *   the list of expressions yield JSON values
+   * the list of expressions yield JSON values
    * @param absentOnNull
-   *   whether we should remove NULL values from the JSON array
+   * whether we should remove NULL values from the JSON array
    * @return
-   *   IR for the JSON_ARRAY function
+   * IR for the JSON_ARRAY function
    */
   private[tsql] def buildJsonArray(args: Seq[ir.Expression], absentOnNull: Boolean): ir.Expression = {
     if (absentOnNull) {
@@ -625,11 +762,11 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
    * set, then any NULL expressions are left out of the JSON object.
    *
    * @param namedStruct
-   *   the named struct of key-value pairs
+   * the named struct of key-value pairs
    * @param absentOnNull
-   *   whether we should remove NULL values from the JSON object
+   * whether we should remove NULL values from the JSON object
    * @return
-   *   IR for the JSON_OBJECT function
+   * IR for the JSON_OBJECT function
    */
   // TODO: This is not likely the correct way to handle this, but it is a start
   //       maybe needs external function at runtime
@@ -645,6 +782,4 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
       ir.CallFunction("TO_JSON", Seq(namedStruct))
     }
   }
-
-
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -19,67 +19,78 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
 
   // Concrete visitors
 
-  override def visitCommonTableExpression(ctx: CommonTableExpressionContext): ir.LogicalPlan = {
-    val tableName = vc.expressionBuilder.buildId(ctx.id())
-    // Column list can be empty if the select specifies distinct column names
-    val columns =
-      Option(ctx.columnNameList())
-        .map(_.id().asScala.map(vc.expressionBuilder.buildId))
-        .getOrElse(Seq.empty)
-    val query = ctx.selectStatement().accept(this)
-    ir.SubqueryAlias(query, tableName, columns)
+  override def visitCommonTableExpression(ctx: CommonTableExpressionContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val tableName = vc.expressionBuilder.buildId(ctx.id())
+      // Column list can be empty if the select specifies distinct column names
+      val columns =
+        Option(ctx.columnNameList())
+          .map(_.id().asScala.map(vc.expressionBuilder.buildId))
+          .getOrElse(Seq.empty)
+      val query = ctx.selectStatement().accept(this)
+      ir.SubqueryAlias(query, tableName, columns)
   }
 
-  override def visitSelectStatementStandalone(ctx: TSqlParser.SelectStatementStandaloneContext): ir.LogicalPlan = {
-    val query = ctx.selectStatement().accept(this)
-    Option(ctx.withExpression())
-      .map { withExpression =>
-        val ctes = withExpression.commonTableExpression().asScala.map(_.accept(this))
-        ir.WithCTE(ctes, query)
+  override def visitSelectStatementStandalone(ctx: TSqlParser.SelectStatementStandaloneContext): ir.LogicalPlan =
+    errorCheck(ctx) match {
+      case Some(errorResult) => errorResult
+      case None =>
+        val query = ctx.selectStatement().accept(this)
+        Option(ctx.withExpression())
+          .map { withExpression =>
+            val ctes = withExpression.commonTableExpression().asScala.map(_.accept(this))
+            ir.WithCTE(ctes, query)
+          }
+          .getOrElse(query)
+    }
+
+  override def visitSelectStatement(ctx: TSqlParser.SelectStatementContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      // TODO: The FOR clause of TSQL is not supported in Databricks SQL as XML and JSON are not supported
+      //       we need to create an UnresolvedRelation for it
+
+      // We visit the OptionClause because in the future, we may be able to glean information from it
+      // as an aid to migration, however the clause is not used in the AST or translation.
+      val query = ctx.queryExpression.accept(this)
+      Option(ctx.optionClause) match {
+        case Some(optionClause) => ir.WithOptions(query, optionClause.accept(vc.expressionBuilder))
+        case None => query
       }
-      .getOrElse(query)
   }
 
-  override def visitSelectStatement(ctx: TSqlParser.SelectStatementContext): ir.LogicalPlan = {
-    // TODO: The FOR clause of TSQL is not supported in Databricks SQL as XML and JSON are not supported
-    //       we need to create an UnresolvedRelation for it
-
-    // We visit the OptionClause because in the future, we may be able to glean information from it
-    // as an aid to migration, however the clause is not used in the AST or translation.
-    val query = ctx.queryExpression.accept(this)
-    Option(ctx.optionClause) match {
-      case Some(optionClause) => ir.WithOptions(query, optionClause.accept(vc.expressionBuilder))
-      case None => query
-    }
+  override def visitQueryExpression(ctx: TSqlParser.QueryExpressionContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx match {
+        case qs if qs.querySpecification() != null => qs.querySpecification().accept(this) // TODO: Implement set ops
+        case _ =>
+          // TODO: Implement this style of UNION
+          ir.UnresolvedRelation(
+            ruleText = contextText(ctx),
+            message = s"This style of UNION specification is as yet supported",
+            ruleName = vc.ruleName(ctx),
+            tokenName = Some(tokenName(ctx.getStart)))
+      }
   }
 
-  override def visitQueryExpression(ctx: TSqlParser.QueryExpressionContext): ir.LogicalPlan = {
-    ctx match {
-      case qs if qs.querySpecification() != null => qs.querySpecification().accept(this) // TODO: Implement set ops
-      case _ =>
-        // TODO: Implement this style of UNION
-        ir.UnresolvedRelation(
-          ruleText = contextText(ctx),
-          message = s"This style of UNION specification is as yet supported",
-          ruleName = vc.ruleName(ctx),
-          tokenName = Some(tokenName(ctx.getStart)))
-    }
-  }
+  override def visitQuerySpecification(ctx: TSqlParser.QuerySpecificationContext): ir.LogicalPlan = errorCheck(
+    ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      // TODO: Check the logic here for all the elements of a query specification
+      val select = ctx.selectOptionalClauses().accept(this)
 
-  override def visitQuerySpecification(ctx: TSqlParser.QuerySpecificationContext): ir.LogicalPlan = {
-
-    // TODO: Check the logic here for all the elements of a query specification
-    val select = ctx.selectOptionalClauses().accept(this)
-
-    val columns =
-      ctx.selectListElem().asScala.map(_.accept(vc.expressionBuilder))
-    // Note that ALL is the default so we don't need to check for it
-    ctx match {
-      case c if c.DISTINCT() != null =>
-        ir.Project(buildTop(Option(ctx.topClause()), buildDistinct(select, columns)), columns)
-      case _ =>
-        ir.Project(buildTop(Option(ctx.topClause()), select), columns)
-    }
+      val columns =
+        ctx.selectListElem().asScala.map(_.accept(vc.expressionBuilder))
+      // Note that ALL is the default so we don't need to check for it
+      ctx match {
+        case c if c.DISTINCT() != null =>
+          ir.Project(buildTop(Option(ctx.topClause()), buildDistinct(select, columns)), columns)
+        case _ =>
+          ir.Project(buildTop(Option(ctx.topClause()), select), columns)
+      }
   }
 
   private[tsql] def buildTop(ctxOpt: Option[TSqlParser.TopClauseContext], input: ir.LogicalPlan): ir.LogicalPlan =
@@ -92,11 +103,13 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
       }
     }
 
-  override def visitSelectOptionalClauses(ctx: SelectOptionalClausesContext): ir.LogicalPlan = {
-    val from = Option(ctx.fromClause()).map(_.accept(this)).getOrElse(ir.NoTable())
-    buildOrderBy(
-      ctx.selectOrderByClause(),
-      buildHaving(ctx.havingClause(), buildGroupBy(ctx.groupByClause(), buildWhere(ctx.whereClause(), from))))
+  override def visitSelectOptionalClauses(ctx: SelectOptionalClausesContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val from = Option(ctx.fromClause()).map(_.accept(this)).getOrElse(ir.NoTable())
+      buildOrderBy(
+        ctx.selectOrderByClause(),
+        buildHaving(ctx.havingClause(), buildGroupBy(ctx.groupByClause(), buildWhere(ctx.whereClause(), from))))
   }
 
   private def buildFilter[A](ctx: A, conditionRule: A => ParserRuleContext, input: ir.LogicalPlan): ir.LogicalPlan =
@@ -149,15 +162,17 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
     }
   }
 
-  override def visitFromClause(ctx: FromClauseContext): ir.LogicalPlan = {
-    val tableSources = ctx.tableSources().tableSource().asScala.map(_.accept(this))
-    // The tableSources seq cannot be empty (as empty FROM clauses are not allowed
-    tableSources match {
-      case Seq(tableSource) => tableSource
-      case sources =>
-        sources.reduce(
-          ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
-    }
+  override def visitFromClause(ctx: FromClauseContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val tableSources = ctx.tableSources().tableSource().asScala.map(_.accept(this))
+      // The tableSources seq cannot be empty (as empty FROM clauses are not allowed
+      tableSources match {
+        case Seq(tableSource) => tableSource
+        case sources =>
+          sources.reduce(
+            ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
+      }
   }
 
   private def buildDistinct(from: ir.LogicalPlan, columns: Seq[ir.Expression]): ir.LogicalPlan = {
@@ -169,44 +184,50 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
     ir.Deduplicate(from, columnNames, all_columns_as_keys = columnNames.isEmpty, within_watermark = false)
   }
 
-  override def visitTableName(ctx: TableNameContext): ir.NamedTable = {
-    val linkedServer = Option(ctx.linkedServer).map(_.getText)
-    val ids = ctx.ids.asScala.map(_.getText).mkString(".")
-    val fullName = linkedServer.fold(ids)(ls => s"$ls..$ids")
-    ir.NamedTable(fullName, Map.empty, is_streaming = false)
+  override def visitTableName(ctx: TableNameContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val linkedServer = Option(ctx.linkedServer).map(_.getText)
+      val ids = ctx.ids.asScala.map(_.getText).mkString(".")
+      val fullName = linkedServer.fold(ids)(ls => s"$ls..$ids")
+      ir.NamedTable(fullName, Map.empty, is_streaming = false)
   }
 
-  override def visitTableSource(ctx: TableSourceContext): ir.LogicalPlan = {
-    val left = ctx.tableSourceItem().accept(this)
-    ctx match {
-      case c if c.joinPart() != null => c.joinPart().asScala.foldLeft(left)(buildJoinPart)
-    }
-  }
-
-  override def visitTableSourceItem(ctx: TableSourceItemContext): ir.LogicalPlan = {
-    val tsiElement = ctx.tsiElement().accept(this)
-
-    // Assemble any table hints, though we do nothing with them for now
-    val hints = buildTableHints(Option(ctx.withTableHints()))
-
-    // If we have column aliases, they are applied here first
-    val tsiElementWithAliases = Option(ctx.columnAliasList())
-      .map { aliasList =>
-        val aliases = aliasList.columnAlias().asScala.map(id => buildColumnAlias(id))
-        ColumnAliases(tsiElement, aliases)
+  override def visitTableSource(ctx: TableSourceContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val left = ctx.tableSourceItem().accept(this)
+      ctx match {
+        case c if c.joinPart() != null => c.joinPart().asScala.foldLeft(left)(buildJoinPart)
       }
-      .getOrElse(tsiElement)
+  }
 
-    val relation = if (hints.nonEmpty) {
-      ir.TableWithHints(tsiElementWithAliases, hints)
-    } else {
-      tsiElementWithAliases
-    }
+  override def visitTableSourceItem(ctx: TableSourceItemContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val tsiElement = ctx.tsiElement().accept(this)
 
-    // Then any table alias is applied to the source
-    Option(ctx.asTableAlias())
-      .map(alias => ir.TableAlias(relation, alias.id.getText))
-      .getOrElse(relation)
+      // Assemble any table hints, though we do nothing with them for now
+      val hints = buildTableHints(Option(ctx.withTableHints()))
+
+      // If we have column aliases, they are applied here first
+      val tsiElementWithAliases = Option(ctx.columnAliasList())
+        .map { aliasList =>
+          val aliases = aliasList.columnAlias().asScala.map(id => buildColumnAlias(id))
+          ColumnAliases(tsiElement, aliases)
+        }
+        .getOrElse(tsiElement)
+
+      val relation = if (hints.nonEmpty) {
+        ir.TableWithHints(tsiElementWithAliases, hints)
+      } else {
+        tsiElementWithAliases
+      }
+
+      // Then any table alias is applied to the source
+      Option(ctx.asTableAlias())
+        .map(alias => ir.TableAlias(relation, alias.id.getText))
+        .getOrElse(relation)
   }
 
   // Table hints arrive syntactically as a () delimited list of options and, in the
@@ -244,81 +265,91 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
     }
   }
 
-  override def visitTsiNamedTable(ctx: TsiNamedTableContext): ir.LogicalPlan =
-    ctx.tableName().accept(this)
-
-  override def visitTsiDerivedTable(ctx: TsiDerivedTableContext): ir.LogicalPlan = {
-    ctx.derivedTable().accept(this)
+  override def visitTsiNamedTable(ctx: TsiNamedTableContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx.tableName().accept(this)
   }
 
-  override def visitDerivedTable(ctx: DerivedTableContext): ir.LogicalPlan = {
-    val result = if (ctx.tableValueConstructor() != null) {
-      ctx.tableValueConstructor().accept(this)
-    } else {
-      ctx.selectStatement().accept(this)
-    }
-    result
+  override def visitTsiDerivedTable(ctx: TsiDerivedTableContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx.derivedTable().accept(this)
   }
 
-  override def visitTableValueConstructor(ctx: TableValueConstructorContext): ir.LogicalPlan = {
-    val rows = ctx.tableValueRow().asScala.map(buildValueRow)
-    DerivedRows(rows)
+  override def visitDerivedTable(ctx: DerivedTableContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val result = if (ctx.tableValueConstructor() != null) {
+        ctx.tableValueConstructor().accept(this)
+      } else {
+        ctx.selectStatement().accept(this)
+      }
+      result
+  }
+
+  override def visitTableValueConstructor(ctx: TableValueConstructorContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val rows = ctx.tableValueRow().asScala.map(buildValueRow)
+      DerivedRows(rows)
   }
 
   private def buildValueRow(ctx: TableValueRowContext): Seq[ir.Expression] = {
     ctx.expressionList().expression().asScala.map(_.accept(vc.expressionBuilder))
   }
 
-  override def visitMerge(ctx: MergeContext): ir.LogicalPlan = {
+  override def visitMerge(ctx: MergeContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val targetPlan = ctx.ddlObject().accept(this)
+      val hints = buildTableHints(Option(ctx.withTableHints()))
+      val finalTarget = if (hints.nonEmpty) {
+        ir.TableWithHints(targetPlan, hints)
+      } else {
+        targetPlan
+      }
 
-    val targetPlan = ctx.ddlObject().accept(this)
-    val hints = buildTableHints(Option(ctx.withTableHints()))
-    val finalTarget = if (hints.nonEmpty) {
-      ir.TableWithHints(targetPlan, hints)
-    } else {
-      targetPlan
-    }
+      val mergeCondition = ctx.searchCondition().accept(vc.expressionBuilder)
+      val tableSourcesPlan = ctx.tableSources().tableSource().asScala.map(_.accept(this))
+      val sourcePlan = tableSourcesPlan.tail.foldLeft(tableSourcesPlan.head)(
+        ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
 
-    val mergeCondition = ctx.searchCondition().accept(vc.expressionBuilder)
-    val tableSourcesPlan = ctx.tableSources().tableSource().asScala.map(_.accept(this))
-    val sourcePlan = tableSourcesPlan.tail.foldLeft(tableSourcesPlan.head)(
-      ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
+      // We may have a number of when clauses, each with a condition and an action. We keep the ANTLR syntax compact
+      // and lean and determine which of the three types of action we have in the whenMatch method based on
+      // the presence or absence of syntactical elements NOT and SOURCE as SOURCE can only be used with NOT
+      val (matchedActions, notMatchedActions, notMatchedBySourceActions) = Option(ctx.whenMatch())
+        .map(_.asScala.foldLeft((List.empty[ir.MergeAction], List.empty[ir.MergeAction], List.empty[ir.MergeAction])) {
+          case ((matched, notMatched, notMatchedBySource), m) =>
+            val action = buildWhenMatch(m)
+            (m.NOT(), m.SOURCE()) match {
+              case (null, _) => (action :: matched, notMatched, notMatchedBySource)
+              case (_, null) => (matched, action :: notMatched, notMatchedBySource)
+              case _ => (matched, notMatched, action :: notMatchedBySource)
+            }
+        })
+        .getOrElse((List.empty, List.empty, List.empty))
 
-    // We may have a number of when clauses, each with a condition and an action. We keep the ANTLR syntax compact
-    // and lean and determine which of the three types of action we have in the whenMatch method based on
-    // the presence or absence of syntactical elements NOT and SOURCE as SOURCE can only be used with NOT
-    val (matchedActions, notMatchedActions, notMatchedBySourceActions) = Option(ctx.whenMatch())
-      .map(_.asScala.foldLeft((List.empty[ir.MergeAction], List.empty[ir.MergeAction], List.empty[ir.MergeAction])) {
-        case ((matched, notMatched, notMatchedBySource), m) =>
-          val action = buildWhenMatch(m)
-          (m.NOT(), m.SOURCE()) match {
-            case (null, _) => (action :: matched, notMatched, notMatchedBySource)
-            case (_, null) => (matched, action :: notMatched, notMatchedBySource)
-            case _ => (matched, notMatched, action :: notMatchedBySource)
-          }
-      })
-      .getOrElse((List.empty, List.empty, List.empty))
+      val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
+      val outputClause = Option(ctx.outputClause()).map(_.accept(this))
 
-    val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
-    val outputClause = Option(ctx.outputClause()).map(_.accept(this))
+      val mergeIntoTable = ir.MergeIntoTable(
+        finalTarget,
+        sourcePlan,
+        mergeCondition,
+        matchedActions,
+        notMatchedActions,
+        notMatchedBySourceActions)
 
-    val mergeIntoTable = ir.MergeIntoTable(
-      finalTarget,
-      sourcePlan,
-      mergeCondition,
-      matchedActions,
-      notMatchedActions,
-      notMatchedBySourceActions)
+      val withOptions = optionClause match {
+        case Some(option) => ir.WithOptions(mergeIntoTable, option)
+        case None => mergeIntoTable
+      }
 
-    val withOptions = optionClause match {
-      case Some(option) => ir.WithOptions(mergeIntoTable, option)
-      case None => mergeIntoTable
-    }
-
-    outputClause match {
-      case Some(output) => WithOutputClause(withOptions, output)
-      case None => withOptions
-    }
+      outputClause match {
+        case Some(output) => WithOutputClause(withOptions, output)
+        case None => withOptions
+      }
   }
 
   private def buildWhenMatch(ctx: WhenMatchContext): ir.MergeAction = {
@@ -356,102 +387,116 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
     ir.UpdateAction(condition, setElements)
   }
 
-  override def visitUpdate(ctx: UpdateContext): ir.LogicalPlan = {
-    val target = ctx.ddlObject().accept(this)
-    val hints = buildTableHints(Option(ctx.withTableHints()))
-    val hintTarget = if (hints.nonEmpty) {
-      ir.TableWithHints(target, hints)
-    } else {
-      target
-    }
+  override def visitUpdate(ctx: UpdateContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val target = ctx.ddlObject().accept(this)
+      val hints = buildTableHints(Option(ctx.withTableHints()))
+      val hintTarget = if (hints.nonEmpty) {
+        ir.TableWithHints(target, hints)
+      } else {
+        target
+      }
 
-    val finalTarget = buildTop(Option(ctx.topClause()), hintTarget)
-    val output = Option(ctx.outputClause()).map(_.accept(this))
-    val setElements = ctx.updateElem().asScala.map(_.accept(vc.expressionBuilder))
+      val finalTarget = buildTop(Option(ctx.topClause()), hintTarget)
+      val output = Option(ctx.outputClause()).map(_.accept(this))
+      val setElements = ctx.updateElem().asScala.map(_.accept(vc.expressionBuilder))
 
-    val tableSourcesOption = Option(ctx.tableSources()).map(_.tableSource().asScala.map(_.accept(this)))
-    val sourceRelation = tableSourcesOption.map { tableSources =>
-      tableSources.tail.foldLeft(tableSources.head)(
-        ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
-    }
+      val tableSourcesOption = Option(ctx.tableSources()).map(_.tableSource().asScala.map(_.accept(this)))
+      val sourceRelation = tableSourcesOption.map { tableSources =>
+        tableSources.tail.foldLeft(tableSources.head)(
+          ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
+      }
 
-    val where = Option(ctx.updateWhereClause()) map (_.accept(vc.expressionBuilder))
-    val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
-    ir.UpdateTable(finalTarget, sourceRelation, setElements, where, output, optionClause)
+      val where = Option(ctx.updateWhereClause()) map (_.accept(vc.expressionBuilder))
+      val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
+      ir.UpdateTable(finalTarget, sourceRelation, setElements, where, output, optionClause)
   }
 
-  override def visitDelete(ctx: DeleteContext): ir.LogicalPlan = {
-    val target = ctx.ddlObject().accept(this)
-    val hints = buildTableHints(Option(ctx.withTableHints()))
-    val finalTarget = if (hints.nonEmpty) {
-      ir.TableWithHints(target, hints)
-    } else {
-      target
-    }
+  override def visitDelete(ctx: DeleteContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val target = ctx.ddlObject().accept(this)
+      val hints = buildTableHints(Option(ctx.withTableHints()))
+      val finalTarget = if (hints.nonEmpty) {
+        ir.TableWithHints(target, hints)
+      } else {
+        target
+      }
 
-    val output = Option(ctx.outputClause()).map(_.accept(this))
-    val tableSourcesOption = Option(ctx.tableSources()).map(_.tableSource().asScala.map(_.accept(this)))
-    val sourceRelation = tableSourcesOption.map { tableSources =>
-      tableSources.tail.foldLeft(tableSources.head)(
-        ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
-    }
+      val output = Option(ctx.outputClause()).map(_.accept(this))
+      val tableSourcesOption = Option(ctx.tableSources()).map(_.tableSource().asScala.map(_.accept(this)))
+      val sourceRelation = tableSourcesOption.map { tableSources =>
+        tableSources.tail.foldLeft(tableSources.head)(
+          ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
+      }
 
-    val where = Option(ctx.updateWhereClause()) map (_.accept(vc.expressionBuilder))
-    val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
-    ir.DeleteFromTable(finalTarget, sourceRelation, where, output, optionClause)
+      val where = Option(ctx.updateWhereClause()) map (_.accept(vc.expressionBuilder))
+      val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
+      ir.DeleteFromTable(finalTarget, sourceRelation, where, output, optionClause)
   }
 
-  override def visitInsert(ctx: InsertContext): ir.LogicalPlan = {
-    val target = ctx.ddlObject().accept(this)
-    val hints = buildTableHints(Option(ctx.withTableHints()))
-    val finalTarget = if (hints.nonEmpty) {
-      ir.TableWithHints(target, hints)
-    } else {
-      target
-    }
+  override def visitInsert(ctx: InsertContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val target = ctx.ddlObject().accept(this)
+      val hints = buildTableHints(Option(ctx.withTableHints()))
+      val finalTarget = if (hints.nonEmpty) {
+        ir.TableWithHints(target, hints)
+      } else {
+        target
+      }
 
-    val columns = Option(ctx.expressionList())
-      .map(_.expression().asScala.map(_.accept(vc.expressionBuilder)).collect { case col: ir.Column => col.columnName })
+      val columns = Option(ctx.expressionList())
+        .map(_.expression().asScala.map(_.accept(vc.expressionBuilder)).collect { case col: ir.Column =>
+          col.columnName
+        })
 
-    val output = Option(ctx.outputClause()).map(_.accept(this))
-    val values = ctx.insertStatementValue().accept(this)
-    val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
-    ir.InsertIntoTable(finalTarget, columns, values, output, optionClause, overwrite = false)
+      val output = Option(ctx.outputClause()).map(_.accept(this))
+      val values = ctx.insertStatementValue().accept(this)
+      val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
+      ir.InsertIntoTable(finalTarget, columns, values, output, optionClause, overwrite = false)
   }
 
-  override def visitInsertStatementValue(ctx: InsertStatementValueContext): ir.LogicalPlan = {
-    Option(ctx) match {
-      case Some(context) if context.derivedTable() != null => context.derivedTable().accept(this)
-      case Some(context) if context.VALUES() != null => DefaultValues()
-      case Some(context) => context.executeStatement().accept(this)
-    }
+  override def visitInsertStatementValue(ctx: InsertStatementValueContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      Option(ctx) match {
+        case Some(context) if context.derivedTable() != null => context.derivedTable().accept(this)
+        case Some(context) if context.VALUES() != null => DefaultValues()
+        case Some(context) => context.executeStatement().accept(this)
+      }
   }
 
-  override def visitOutputClause(ctx: OutputClauseContext): ir.LogicalPlan = {
-    val outputs = ctx.outputDmlListElem().asScala.map(_.accept(vc.expressionBuilder))
-    val target = Option(ctx.ddlObject()).map(_.accept(this))
-    val columns =
-      Option(ctx.columnNameList())
-        .map(_.id().asScala.map(id => ir.Column(None, vc.expressionBuilder.buildId(id))))
+  override def visitOutputClause(ctx: OutputClauseContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      val outputs = ctx.outputDmlListElem().asScala.map(_.accept(vc.expressionBuilder))
+      val target = Option(ctx.ddlObject()).map(_.accept(this))
+      val columns =
+        Option(ctx.columnNameList())
+          .map(_.id().asScala.map(id => ir.Column(None, vc.expressionBuilder.buildId(id))))
 
-    // Databricks SQL does not support the OUTPUT clause, but we may be able to translate
-    // the clause to SELECT statements executed before or after the INSERT/DELETE/UPDATE/MERGE
-    // is executed
-    Output(target, outputs, columns)
+      // Databricks SQL does not support the OUTPUT clause, but we may be able to translate
+      // the clause to SELECT statements executed before or after the INSERT/DELETE/UPDATE/MERGE
+      // is executed
+      Output(target, outputs, columns)
   }
 
-  override def visitDdlObject(ctx: DdlObjectContext): ir.LogicalPlan = {
-    ctx match {
-      case tableName if tableName.tableName() != null => tableName.tableName().accept(this)
-      case localId if localId.LOCAL_ID() != null => ir.LocalVarTable(ir.Id(localId.LOCAL_ID().getText))
-      // TODO: OPENROWSET and OPENQUERY
-      case _ =>
-        ir.UnresolvedRelation(
-          ruleText = contextText(ctx),
-          message = s"Unknown DDL object type ${ctx.getStart.getText} in TSqlRelationBuilder.visitDdlObject",
-          ruleName = vc.ruleName(ctx),
-          tokenName = Some(tokenName(ctx.getStart)))
-    }
+  override def visitDdlObject(ctx: DdlObjectContext): ir.LogicalPlan = errorCheck(ctx) match {
+    case Some(errorResult) => errorResult
+    case None =>
+      ctx match {
+        case tableName if tableName.tableName() != null => tableName.tableName().accept(this)
+        case localId if localId.LOCAL_ID() != null => ir.LocalVarTable(ir.Id(localId.LOCAL_ID().getText))
+        // TODO: OPENROWSET and OPENQUERY
+        case _ =>
+          ir.UnresolvedRelation(
+            ruleText = contextText(ctx),
+            message = s"Unknown DDL object type ${ctx.getStart.getText} in TSqlRelationBuilder.visitDdlObject",
+            ruleName = vc.ruleName(ctx),
+            tokenName = Some(tokenName(ctx.getStart)))
+      }
   }
 
   private def buildJoinPart(left: ir.LogicalPlan, ctx: JoinPartContext): ir.LogicalPlan = {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -20,11 +20,11 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
   // Concrete visitors
 
   override def visitCommonTableExpression(ctx: CommonTableExpressionContext): ir.LogicalPlan = {
-    val tableName = vc.expressionBuilder.visitId(ctx.id())
+    val tableName = vc.expressionBuilder.buildId(ctx.id())
     // Column list can be empty if the select specifies distinct column names
     val columns =
       Option(ctx.columnNameList())
-        .map(_.id().asScala.map(vc.expressionBuilder.visitId))
+        .map(_.id().asScala.map(vc.expressionBuilder.buildId))
         .getOrElse(Seq.empty)
     val query = ctx.selectStatement().accept(this)
     ir.SubqueryAlias(query, tableName, columns)
@@ -239,7 +239,7 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
 
   private def buildColumnAlias(ctx: TSqlParser.ColumnAliasContext): ir.Id = {
     ctx match {
-      case c if c.id() != null => vc.expressionBuilder.visitId(c.id())
+      case c if c.id() != null => vc.expressionBuilder.buildId(c.id())
       case _ => ir.Id(vc.expressionBuilder.removeQuotes(ctx.getText))
     }
   }
@@ -432,7 +432,7 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
     val target = Option(ctx.ddlObject()).map(_.accept(this))
     val columns =
       Option(ctx.columnNameList())
-        .map(_.id().asScala.map(id => ir.Column(None, vc.expressionBuilder.visitId(id))))
+        .map(_.id().asScala.map(id => ir.Column(None, vc.expressionBuilder.buildId(id))))
 
     // Databricks SQL does not support the OUTPUT clause, but we may be able to translate
     // the clause to SELECT statements executed before or after the INSERT/DELETE/UPDATE/MERGE
@@ -471,8 +471,8 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
       .fullColumnName()
       .asScala
       .map(_.accept(vc.expressionBuilder))
-    val variableColumnName = vc.expressionBuilder.visitId(ctx.unpivotClause().id(0))
-    val valueColumnName = vc.expressionBuilder.visitId(ctx.unpivotClause().id(1))
+    val variableColumnName = vc.expressionBuilder.buildId(ctx.unpivotClause().id(0))
+    val valueColumnName = vc.expressionBuilder.buildId(ctx.unpivotClause().id(1))
     ir.Unpivot(
       child = left,
       ids = unpivotColumns,


### PR DESCRIPTION
Here we ensure that all the TSQL IR builders check for error nodes in their incoming ParserContext objects, in order to ensure that parsing errors propagate all the way to code generation.