### PR TITLE
Implement text gatherers for additional error types

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/ParserCommon.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/ParserCommon.scala
@@ -139,9 +139,9 @@ trait ParserCommon[A] extends ParseTreeVisitor[A] with LazyLogging { self: Abstr
       .map(_.asScala)
       .getOrElse(Seq.empty)
       .collect { case e: ErrorNode =>
-        s"Unparsable text: ${e.getSymbol.getText}\n\n"
+        s"Unparsable text: ${e.getSymbol.getText}"
       }
-      .mkString
+      .mkString("\n")
 
     if (unparsedText.nonEmpty) {
       Some(unresolved(unparsedText, "Unparsed input - ErrorNode encountered"))

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/SqlErrorStrategy.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/SqlErrorStrategy.scala
@@ -57,9 +57,8 @@ abstract class SqlErrorStrategy extends DefaultErrorStrategy {
     msg.append(escapeWSAndQuote(input))
     recognizer.notifyErrorListeners(e.getOffendingToken, msg.toString(), e)
 
-    val errorNode = createErrorNode(e.getStartToken, input)
-
     // Here we add the error node to the current context so that we can report it in the correct place
+    val errorNode = createErrorNode(e.getStartToken, input)
     recognizer.getContext.addErrorNode(errorNode)
   }
 
@@ -71,6 +70,10 @@ abstract class SqlErrorStrategy extends DefaultErrorStrategy {
     msg.append("\nexpecting one of: ")
     msg.append(buildExpectedMessage(recognizer, e.getExpectedTokens))
     recognizer.notifyErrorListeners(e.getOffendingToken, msg.toString(), e)
+
+    // Here we add the error node to the current context so that we can report it in the correct place
+    val errorNode = createErrorNode(e.getOffendingToken, msg.toString())
+    recognizer.getContext.addErrorNode(errorNode)
   }
 
   override protected def reportUnwantedToken(recognizer: Parser): Unit = {
@@ -87,6 +90,10 @@ abstract class SqlErrorStrategy extends DefaultErrorStrategy {
     msg.append("\nexpecting one of: ")
     msg.append(buildExpectedMessage(recognizer, expecting))
     recognizer.notifyErrorListeners(t, msg.toString(), null)
+
+    // Here we add the error node to the current context so that we can report it in the correct place
+    val errorNode = createErrorNode(t, msg.toString())
+    recognizer.getContext.addErrorNode(errorNode)
   }
 
   override protected def reportMissingToken(recognizer: Parser): Unit = {
@@ -103,6 +110,10 @@ abstract class SqlErrorStrategy extends DefaultErrorStrategy {
     msg.append('\n')
     msg.append(generateMessage(recognizer, new InputMismatchException(recognizer)))
     recognizer.notifyErrorListeners(t, msg.toString(), null)
+
+    // Here we add the error node to the current context so that we can report it in the correct place
+    val errorNode = createErrorNode(t, msg.toString())
+    recognizer.getContext.addErrorNode(errorNode)
   }
 
   val capitalizedSort: Ordering[String] = Ordering.fromLessThan((a, b) =>

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
 import com.databricks.labs.remorph.parsers.ParserCommon
-import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser._
+import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser.{StringContext => _, _}
 import com.databricks.labs.remorph.{intermediate => ir}
 
 import scala.collection.JavaConverters._

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilder.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
 import com.databricks.labs.remorph.parsers.ParserCommon
-import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser._
+import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser.{StringContext => _, _}
 import com.databricks.labs.remorph.{intermediate => ir}
 
 class SnowflakeCommandBuilder(override val vc: SnowflakeVisitorCoordinator)

--- a/core/src/test/scala/com/databricks/labs/remorph/coverage/AcceptanceSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/coverage/AcceptanceSpec.scala
@@ -35,7 +35,10 @@ class SnowflakeAcceptanceSuite
             "test_skip_unsupported_operations/test_skip_unsupported_operations_7.sql",
             "test_skip_unsupported_operations/test_skip_unsupported_operations_9.sql",
             "test_skip_unsupported_operations/test_skip_unsupported_operations_10.sql"),
-          shouldFailParse = Set("core_engine/test_invalid_syntax/syntax_error_1.sql"))))
+          shouldFailParse = Set(
+            "core_engine/test_invalid_syntax/syntax_error_1.sql",
+            "core_engine/test_invalid_syntax/syntax_error_2.sql",
+            "core_engine/test_invalid_syntax/syntax_error_3.sql"))))
 
 class TSqlAcceptanceSuite
     extends AcceptanceSpec(
@@ -68,4 +71,8 @@ class TSqlAcceptanceSuite
             "functions/test_percent_rank_1.sql",
             "functions/test_percentile_cont_1.sql",
             "functions/test_percentile_disc_1.sql",
-            "select/test_cte_xml.sql"))))
+            "select/test_cte_xml.sql"),
+          shouldFailParse = Set(
+            "core_engine/test_invalid_syntax/syntax_error_1.sql",
+            "core_engine/test_invalid_syntax/syntax_error_2.sql",
+            "core_engine/test_invalid_syntax/syntax_error_3.sql"))))

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
@@ -1733,10 +1733,9 @@ class ExpressionGeneratorTest
       ir.And(ir.Id("a"), ir.UnresolvedExpression(ruleText = "bad text", message = "some error message")) generates
         """a AND /* The following issues were detected:
          |
-         |   some error message:
-         |
-         |   bad text
-         |*/""".stripMargin
+         |   some error message
+         |    bad text
+         | */""".stripMargin
     }
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
@@ -12,28 +12,25 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
       "!set error_flag = true;" transpilesTo
         """/* The following issues were detected:
           |
-          |   Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand:
-          |
-          |   !set error_flag = true;
-          |*/""".stripMargin
+          |   Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand
+          |    !set error_flag = true;
+          | */""".stripMargin
     }
     "transpile BANG without semicolon" in {
       "!print Include This Text" transpilesTo
         """/* The following issues were detected:
         |
-        |   Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand:
-        |
-        |   !print Include This Text
-        |*/""".stripMargin
+        |   Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand
+        |    !print Include This Text
+        | */""".stripMargin
     }
     "transpile BANG with options" in {
       "!options catch=true" transpilesTo
         """/* The following issues were detected:
           |
-          |   Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand:
-          |
-          |   !options catch=true
-          |*/""".stripMargin
+          |   Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand
+          |    !options catch=true
+          | */""".stripMargin
     }
     "transpile BANG with negative scenario unknown command" in {
       "!test unknown command".failsTranspilation
@@ -299,10 +296,9 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
       "EXECUTE TASK task1;" transpilesTo
         """/* The following issues were detected:
           |
-          |   Execute Task is not yet supported:
-          |
-          |   EXECUTE TASK task1
-          |*/""".stripMargin
+          |   Execute Task is not yet supported
+          |    EXECUTE TASK task1
+          | */""".stripMargin
     }
   }
 

--- a/tests/resources/functional/snowflake/core_engine/test_command/test_command_1.sql
+++ b/tests/resources/functional/snowflake/core_engine/test_command/test_command_1.sql
@@ -5,7 +5,6 @@
 -- databricks sql:
 /* The following issues were detected:
 
-   Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand:
-
-   !set exit_on_error = true;
-*/
+   Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand
+    !set exit_on_error = true;
+ */

--- a/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_1.sql
+++ b/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_1.sql
@@ -13,55 +13,42 @@ select col1,, col2 from table_name;
 -- databricks sql:
 /* The following issues were detected:
 
-   Unparsed input - ErrorNode encountered:
-
-   Unparsable text: select col1,,
-
-
-*/
+   Unparsed input - ErrorNode encountered
+    Unparsable text: select col1,,
+ */
 /* The following issues were detected:
 
-   Unparsed input - ErrorNode encountered:
-
-   Unparsable text: select
-
-Unparsable text: parser recovered by ignoring: select col1
-
-
-*/
+   Unparsed input - ErrorNode encountered
+    Unparsable text: select
+    Unparsable text: parser recovered by ignoring: select col1
+ */
 /* The following issues were detected:
 
-   Unimplemented visitor accept in class SnowflakeCommandBuilder:
-
-   Mocked string
-*/
+   Unimplemented visitor accept in class SnowflakeCommandBuilder
+    Mocked string
+ */
 /* The following issues were detected:
 
-   Unimplemented visitor accept in class SnowflakeCommandBuilder:
-
-   col1,,
-*/
+   Unimplemented visitor accept in class SnowflakeCommandBuilder
+    col1,,
+ */
 /* The following issues were detected:
 
-   Unimplemented visitor accept in class SnowflakeCommandBuilder:
-
-   Mocked string
-*/
+   Unimplemented visitor accept in class SnowflakeCommandBuilder
+    Mocked string
+ */
 /* The following issues were detected:
 
-   Unimplemented visitor accept in class SnowflakeCommandBuilder:
-
-   col2 from
-*/
+   Unimplemented visitor accept in class SnowflakeCommandBuilder
+    col2 from
+ */
 /* The following issues were detected:
 
-   Unimplemented visitor accept in class SnowflakeCommandBuilder:
-
-   Mocked string
-*/
+   Unimplemented visitor accept in class SnowflakeCommandBuilder
+    Mocked string
+ */
 /* The following issues were detected:
 
-   Unimplemented visitor accept in class SnowflakeCommandBuilder:
-
-   table_name
-*/
+   Unimplemented visitor accept in class SnowflakeCommandBuilder
+    table_name
+ */

--- a/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_2.sql
+++ b/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_2.sql
@@ -1,0 +1,11 @@
+-- snowflake sql:
+*
+
+-- databricks sql:
+/* The following issues were detected:
+
+   Unparsed input - ErrorNode encountered
+    Unparsable text: unexpected extra input '*' while parsing a Snowflake batch
+    expecting one of: $Identifier, End of batch, Identifier, Select Statement, Statement, '""', '(', 'BODY', 'CALL', 'CHARACTER', 'CURRENT_TIME', 'DECLARE'...
+    Unparsable text: *
+ */

--- a/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_3.sql
+++ b/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_3.sql
@@ -1,0 +1,29 @@
+-- Because of the let command allows LET? it means that error recovery can't happen easily in Snowflake
+-- because teh parser sees everything as valid.
+-- TODO: TRy to rejig the parser so that error recovery can work athe top level batch
+-- snowflake sql:
+* ;
+SELECT 1 ;
+SELECT A B FROM C ;
+
+-- databricks sql:
+/* The following issues were detected:
+
+   Unparsed input - ErrorNode encountered
+    Unparsable text: '*' was unexpected while parsing a Snowflake batch
+    expecting one of: $Identifier, End of batch, Identifier, Select Statement, Statement, '""', '(', 'BODY', 'CALL', 'CHARACTER', 'CURRENT_TIME', 'DECLARE'...
+    Unparsable text: *
+    Unparsable text: ;
+    Unparsable text: SELECT
+    Unparsable text: 1
+    Unparsable text: ;
+    Unparsable text: SELECT
+    Unparsable text: A
+    Unparsable text: B
+    Unparsable text: FROM
+    Unparsable text: C
+    Unparsable text: ;
+    Unparsable text: parser recovered by ignoring: * ;
+    SELECT 1 ;
+    SELECT A B FROM C ;
+ */

--- a/tests/resources/functional/snowflake/core_engine/test_skip_unsupported_operations/test_skip_unsupported_operations_1.sql
+++ b/tests/resources/functional/snowflake/core_engine/test_skip_unsupported_operations/test_skip_unsupported_operations_1.sql
@@ -5,7 +5,6 @@ ALTER SESSION SET QUERY_TAG = 'tag1';
 -- databricks sql:
 /* The following issues were detected:
 
-   Unknown ALTER command variant:
-
-   ALTER SESSION SET QUERY_TAG = 'tag1'
-*/
+   Unknown ALTER command variant
+    ALTER SESSION SET QUERY_TAG = 'tag1'
+ */

--- a/tests/resources/functional/snowflake/core_engine/test_skip_unsupported_operations/test_skip_unsupported_operations_5.sql
+++ b/tests/resources/functional/snowflake/core_engine/test_skip_unsupported_operations/test_skip_unsupported_operations_5.sql
@@ -5,7 +5,6 @@ CREATE STREAM mystream ON TABLE mytable;
 -- databricks sql:
 /* The following issues were detected:
 
-   CREATE STREAM UNSUPPORTED:
-
-   CREATE STREAM mystream ON TABLE mytable
-*/
+   CREATE STREAM UNSUPPORTED
+    CREATE STREAM mystream ON TABLE mytable
+ */

--- a/tests/resources/functional/snowflake/core_engine/test_skip_unsupported_operations/test_skip_unsupported_operations_6.sql
+++ b/tests/resources/functional/snowflake/core_engine/test_skip_unsupported_operations/test_skip_unsupported_operations_6.sql
@@ -5,7 +5,6 @@ ALTER STREAM mystream SET COMMENT = 'New comment for stream';
 -- databricks sql:
 /* The following issues were detected:
 
-   Unknown ALTER command variant:
-
-   ALTER STREAM mystream SET COMMENT = 'New comment for stream'
-*/
+   Unknown ALTER command variant
+    ALTER STREAM mystream SET COMMENT = 'New comment for stream'
+ */

--- a/tests/resources/functional/tsql/core_engine/test_invalid_syntax/syntax_error_1.sql
+++ b/tests/resources/functional/tsql/core_engine/test_invalid_syntax/syntax_error_1.sql
@@ -1,0 +1,18 @@
+-- Note that here we have two commas in the select clause and teh TSQL grammar not
+-- quite as bad as the Snowflake grammar, is able to see that it can delete
+
+-- tsql sql:
+select col1,, col2 from table_name;
+
+-- databricks sql:
+SELECT
+    col1,
+/* The following issues were detected:
+
+   Unparsed input - ErrorNode encountered
+    Unparsable text: unexpected extra input ',' while parsing a SELECT statement
+    expecting one of: $Currency, 'String', @@Reference, @Local, Float, Identifier, Integer, Operator, Real, '$ACTION', '$NODE_ID', '$PARTITION'...
+    Unparsable text: ,
+ */
+FROM
+    table_name;

--- a/tests/resources/functional/tsql/core_engine/test_invalid_syntax/syntax_error_2.sql
+++ b/tests/resources/functional/tsql/core_engine/test_invalid_syntax/syntax_error_2.sql
@@ -1,0 +1,11 @@
+-- tsql sql:
+*
+
+-- databricks sql:
+/* The following issues were detected:
+
+   Unparsed input - ErrorNode encountered
+    Unparsable text: unexpected extra input '*' while parsing a T-SQL batch
+    expecting one of: End of batch, Identifier, Select Statement, Statement, '$NODE_ID', '(', ';', 'BULK', 'EXTERNAL', 'IDENTITY', 'RAW', 'REPLICATE'...
+    Unparsable text: *
+ */

--- a/tests/resources/functional/tsql/core_engine/test_invalid_syntax/syntax_error_3.sql
+++ b/tests/resources/functional/tsql/core_engine/test_invalid_syntax/syntax_error_3.sql
@@ -1,0 +1,23 @@
+-- The TSql parser is much better than the Snowflake one because it does not have the
+-- super ambiguous LET statement that makes it impossible for batch level queries to
+-- recover from syntax errors. Note here how TSQL has stupid grammar though as A and B
+-- could be columns with a missing ',' but we cannot know.
+-- tsql sql:
+* ;
+SELECT 1 ;
+SELECT A B FROM C ;
+
+-- databricks sql:
+/* The following issues were detected:
+
+   Unparsed input - ErrorNode encountered
+    Unparsable text: unexpected extra input '*' while parsing a T-SQL batch
+    expecting one of: End of batch, Identifier, Select Statement, Statement, '$NODE_ID', '(', ';', 'BULK', 'EXTERNAL', 'IDENTITY', 'RAW', 'REPLICATE'...
+    Unparsable text: *
+ */
+SELECT
+  1;
+SELECT
+  A AS B
+FROM
+  C;


### PR DESCRIPTION
Here we add support for missing token errors, additional token errors and add functional test to verify the logic. We also improve the format of the comment output from the generator.