### PR TITLE
Improve Snowflake grammar to improve syntax error recovery

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -235,6 +235,7 @@ formatType: TYPE EQ typeFileformat formatTypeOptions*
 
 let
     // variable and resultset are covered under the same visitor since expr is common
+    // TODO: See if we can improve this rule to prevent it stopping error recovery
     : LET? id (dataType | RESULTSET)? (ASSIGN | DEFAULT) expr SEMI # letVariableAssignment
     | LET? id CURSOR FOR (selectStatement | id) SEMI               # letCursor
     ;

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -38,7 +38,7 @@ options {
 snowflakeFile: batch? EOF
     ;
 
-batch: sqlCommand (SEMI* sqlCommand)* SEMI*
+batch: SEMI* (sqlCommand SEMI*)+
     ;
 
 sqlCommand

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -235,7 +235,6 @@ formatType: TYPE EQ typeFileformat formatTypeOptions*
 
 let
     // variable and resultset are covered under the same visitor since expr is common
-    // TODO: See if we can improve this rule to prevent it stopping error recovery
     : LET id (dataType | RESULTSET)? (ASSIGN | DEFAULT) expr SEMI # letVariableAssignment
     | LET id CURSOR FOR (selectStatement | id) SEMI               # letCursor
     ;

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -236,8 +236,8 @@ formatType: TYPE EQ typeFileformat formatTypeOptions*
 let
     // variable and resultset are covered under the same visitor since expr is common
     // TODO: See if we can improve this rule to prevent it stopping error recovery
-    : LET? id (dataType | RESULTSET)? (ASSIGN | DEFAULT) expr SEMI # letVariableAssignment
-    | LET? id CURSOR FOR (selectStatement | id) SEMI               # letCursor
+    : LET id (dataType | RESULTSET)? (ASSIGN | DEFAULT) expr SEMI # letVariableAssignment
+    | LET id CURSOR FOR (selectStatement | id) SEMI               # letCursor
     ;
 
 returnStatement: RETURN expr SEMI

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/snowflake/SnowflakeParser.g4
@@ -35,10 +35,10 @@ options {
     tokenVocab = SnowflakeLexer;
 }
 
-snowflakeFile: batch? EOF
+snowflakeFile: SEMI* batch? EOF
     ;
 
-batch: SEMI* (sqlCommand SEMI*)+
+batch: (sqlCommand SEMI*)+
     ;
 
 sqlCommand

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -42,7 +42,7 @@ options {
 tSqlFile: batch? EOF
     ;
 
-batch: SEMI* executeBodyBatch? SEMI* (sqlClauses+ SEMI*)+
+batch: SEMI* executeBodyBatch? SEMI* (sqlClauses SEMI*)+
     ;
 
 // TODO: Properly sort out SEMI colons, which have been haphazzardly added in some

--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -39,10 +39,10 @@ options {
     tokenVocab = TSqlLexer;
 }
 
-tSqlFile: batch? EOF
+tSqlFile: SEMI* batch? EOF
     ;
 
-batch: SEMI* executeBodyBatch? SEMI* (sqlClauses SEMI*)+
+batch: executeBodyBatch? SEMI* (sqlClauses SEMI*)+
     ;
 
 // TODO: Properly sort out SEMI colons, which have been haphazzardly added in some

--- a/core/src/test/scala/com/databricks/labs/remorph/discovery/AnonymizerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/discovery/AnonymizerTest.scala
@@ -62,7 +62,7 @@ class AnonymizerTest extends AnyWordSpec with Matchers {
         Fingerprint(
           "id",
           new Timestamp(1725032011000L),
-          "974439bac46683c40b4925d1bfc199a4c211d322",
+          "9ac8ccf99e8b6569a1aadd41c11ab68861550711",
           Duration.ofMillis(300),
           "foo",
           WorkloadType.OTHER,

--- a/core/src/test/scala/com/databricks/labs/remorph/discovery/AnonymizerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/discovery/AnonymizerTest.scala
@@ -62,7 +62,7 @@ class AnonymizerTest extends AnyWordSpec with Matchers {
         Fingerprint(
           "id",
           new Timestamp(1725032011000L),
-          "9ac8ccf99e8b6569a1aadd41c11ab68861550711",
+          "8fa557010667ff17cb2acfd5065a2ac0f9b7a620",
           Duration.ofMillis(300),
           "foo",
           WorkloadType.OTHER,

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilderSpec.scala
@@ -55,9 +55,9 @@ class SnowflakeCommandBuilderSpec
     "LET X := 1;" in {
       example("LET X := 1;", _.let(), SetVariable(name = Id("X"), dataType = None, value = Literal(1)))
     }
-    "select_statement := 'SELECT * FROM table WHERE id = ' || id;" in {
+    "LET select_statement := 'SELECT * FROM table WHERE id = ' || id;" in {
       example(
-        "select_statement := 'SELECT * FROM table WHERE id = ' || id;",
+        "LET select_statement := 'SELECT * FROM table WHERE id = ' || id;",
         _.let(),
         SetVariable(
           name = Id("select_statement"),

--- a/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_1.sql
+++ b/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_1.sql
@@ -1,5 +1,5 @@
 -- Note that here we have two commas in the select clause and although in other circumstances,
--- the parser coudl notice that is an additional comma, in this case it is not able to do so because
+-- the parser could notice that is an additional comma, in this case it is not able to do so because
 -- what can be in between the comma is just about anything. Then because any ID is accepted as
 -- possibly being some kind of command, then the parser has to assume that the following tokens
 -- are some valid command.

--- a/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_1.sql
+++ b/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_1.sql
@@ -20,35 +20,11 @@ select col1,, col2 from table_name;
 
    Unparsed input - ErrorNode encountered
     Unparsable text: select
-    Unparsable text: parser recovered by ignoring: select col1
- */
-/* The following issues were detected:
-
-   Unimplemented visitor accept in class SnowflakeCommandBuilder
-    Mocked string
- */
-/* The following issues were detected:
-
-   Unimplemented visitor accept in class SnowflakeCommandBuilder
-    col1,,
- */
-/* The following issues were detected:
-
-   Unimplemented visitor accept in class SnowflakeCommandBuilder
-    Mocked string
- */
-/* The following issues were detected:
-
-   Unimplemented visitor accept in class SnowflakeCommandBuilder
-    col2 from
- */
-/* The following issues were detected:
-
-   Unimplemented visitor accept in class SnowflakeCommandBuilder
-    Mocked string
- */
-/* The following issues were detected:
-
-   Unimplemented visitor accept in class SnowflakeCommandBuilder
-    table_name
+    Unparsable text: col1
+    Unparsable text: ,
+    Unparsable text: ,
+    Unparsable text: col2
+    Unparsable text: from
+    Unparsable text: table_name
+    Unparsable text: parser recovered by ignoring: select col1,, col2 from table_name;
  */

--- a/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_2.sql
+++ b/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_2.sql
@@ -6,6 +6,6 @@
 
    Unparsed input - ErrorNode encountered
     Unparsable text: unexpected extra input '*' while parsing a Snowflake batch
-    expecting one of: $Identifier, End of batch, Identifier, Select Statement, Statement, '""', '(', 'BODY', 'CALL', 'CHARACTER', 'CURRENT_TIME', 'DECLARE'...
+    expecting one of: End of batch, Select Statement, Statement, '(', 'CALL', 'COMMENT', 'DECLARE', 'DESC', 'GET', 'LET', 'START', 'WITH'...
     Unparsable text: *
  */

--- a/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_2.sql
+++ b/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_2.sql
@@ -6,6 +6,6 @@
 
    Unparsed input - ErrorNode encountered
     Unparsable text: unexpected extra input '*' while parsing a Snowflake batch
-    expecting one of: End of batch, Select Statement, Statement, '(', 'CALL', 'COMMENT', 'DECLARE', 'DESC', 'GET', 'LET', 'START', 'WITH'...
+    expecting one of: End of batch, Select Statement, Statement, '(', ';', 'CALL', 'COMMENT', 'DECLARE', 'DESC', 'GET', 'LET', 'START'...
     Unparsable text: *
  */

--- a/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_3.sql
+++ b/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_3.sql
@@ -1,6 +1,3 @@
--- Because of the let command allows LET? it means that error recovery can't happen easily in Snowflake
--- because teh parser sees everything as valid.
--- TODO: TRy to rejig the parser so that error recovery can work athe top level batch
 -- snowflake sql:
 * ;
 SELECT 1 ;
@@ -10,20 +7,13 @@ SELECT A B FROM C ;
 /* The following issues were detected:
 
    Unparsed input - ErrorNode encountered
-    Unparsable text: '*' was unexpected while parsing a Snowflake batch
-    expecting one of: End of batch, Select Statement, Statement, '(', 'CALL', 'COMMENT', 'DECLARE', 'DESC', 'GET', 'LET', 'START', 'WITH'...
+    Unparsable text: unexpected extra input '*' while parsing a Snowflake batch
+    expecting one of: End of batch, Select Statement, Statement, '(', ';', 'CALL', 'COMMENT', 'DECLARE', 'DESC', 'GET', 'LET', 'START'...
     Unparsable text: *
-    Unparsable text: ;
-    Unparsable text: SELECT
-    Unparsable text: 1
-    Unparsable text: ;
-    Unparsable text: SELECT
-    Unparsable text: A
-    Unparsable text: B
-    Unparsable text: FROM
-    Unparsable text: C
-    Unparsable text: ;
-    Unparsable text: parser recovered by ignoring: * ;
-    SELECT 1 ;
-    SELECT A B FROM C ;
  */
+SELECT
+  1;
+SELECT
+  A AS B
+FROM
+  C;

--- a/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_3.sql
+++ b/tests/resources/functional/snowflake/core_engine/test_invalid_syntax/syntax_error_3.sql
@@ -11,7 +11,7 @@ SELECT A B FROM C ;
 
    Unparsed input - ErrorNode encountered
     Unparsable text: '*' was unexpected while parsing a Snowflake batch
-    expecting one of: $Identifier, End of batch, Identifier, Select Statement, Statement, '""', '(', 'BODY', 'CALL', 'CHARACTER', 'CURRENT_TIME', 'DECLARE'...
+    expecting one of: End of batch, Select Statement, Statement, '(', 'CALL', 'COMMENT', 'DECLARE', 'DESC', 'GET', 'LET', 'START', 'WITH'...
     Unparsable text: *
     Unparsable text: ;
     Unparsable text: SELECT


### PR DESCRIPTION
Here we improve the grammar specifications for both Snowflake and TSQL (less was needed) so that they both can recover equally when parsing more than one statement in a batch, when one or more statements are found to be in error.

The AST generator for Snowflake no longer eats good statements and assumes that they were all bad (TSQL already did this).

We now see that both parsers recover using the shortest number of tokens.

A minor modification to the grammar makes the `LET` keyword in an assignment non-optional, as per the Snowflake documentation. If the documentation was wrong, we will merely detect a missing `LET` keyword and recover sensibly by inserting it.