### PR TITLE
TSQL: prevent selectListElem from ignoring valid columns when errorNodes are accumulated

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
@@ -239,12 +239,12 @@ class LogicalPlanGenerator(
     }
 
     // Don't put commas after unresolved expressions as they are error comments only
-    val generatedExpressions = proj.expressions.map { exp: ir.Expression => expr.generate(ctx, exp) -> exp }
-    val sqlParts = generatedExpressions
+    val sqlParts = proj.expressions
       .map {
-        case (OkResult(sqlStr), exp) if !exp.isInstanceOf[ir.Unresolved[_]] => s"$sqlStr, "
-        case (OkResult(sqlStr), _) => sqlStr
+        case u: ir.Unresolved[_] => expr.generate(ctx, u)
+        case exp: ir.Expression => expr.generate(ctx, exp).map(_ + ", ")
       }
+      .collect { case OkResult(sqlStr) => sqlStr }
       .mkString
       .stripSuffix(", ")
 

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.generators.sql
 
 import com.databricks.labs.remorph.generators.GeneratorContext
-import com.databricks.labs.remorph.{OkResult, intermediate => ir}
+import com.databricks.labs.remorph.{OkResult, PartialResult, intermediate => ir}
 
 class LogicalPlanGenerator(
     val expr: ExpressionGenerator,
@@ -244,7 +244,10 @@ class LogicalPlanGenerator(
         case u: ir.Unresolved[_] => expr.generate(ctx, u)
         case exp: ir.Expression => expr.generate(ctx, exp).map(_ + ", ")
       }
-      .collect { case OkResult(sqlStr) => sqlStr }
+      .collect {
+        case OkResult(sqlStr) => sqlStr
+        case PartialResult(output, _) => output // UnresolvedExpression returns PartialResult in the future
+      }
       .mkString
       .stripSuffix(", ")
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -82,8 +82,9 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
       // TODO: Check the logic here for all the elements of a query specification
       val select = ctx.selectOptionalClauses().accept(this)
 
-      val columns =
-        ctx.selectListElem().asScala.map(_.accept(vc.expressionBuilder))
+      // A single column definition could also hold an ErrorNode that it recovered from so we collect all of them
+      val columns: Seq[ir.Expression] =
+        ctx.selectListElem().asScala.flatMap(vc.expressionBuilder.buildSelectListElem)
       // Note that ALL is the default so we don't need to check for it
       ctx match {
         case c if c.DISTINCT() != null =>

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -424,10 +424,10 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
       when(mockCtx.getRuleIndex).thenReturn(SnowflakeParser.RULE_constraintAction)
 
       // Call the method with the mock instance
-      val result = vc.expressionBuilder.visitSelectListElem(mockCtx)
+      val result = vc.expressionBuilder.buildSelectListElem(mockCtx)
 
       // Verify the result
-      result shouldBe a[ir.UnresolvedExpression]
+      result shouldBe a[Seq[_]]
     }
 
     "cover default case in buildLocalAssign via visitSelectListElem" in {
@@ -442,9 +442,9 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
       when(expressionContextMock.accept(any())).thenReturn(null)
       when(selectListElemContextMock.expression()).thenReturn(expressionContextMock)
 
-      val result = vc.expressionBuilder.visitSelectListElem(selectListElemContextMock)
+      val result = vc.expressionBuilder.buildSelectListElem(selectListElemContextMock)
 
-      result shouldBe a[ir.UnresolvedExpression]
+      result shouldBe a[Seq[_]]
     }
 
     "translate CAST pseudo function calls with simple scalars" in {

--- a/tests/resources/functional/tsql/core_engine/test_invalid_syntax/syntax_error_1.sql
+++ b/tests/resources/functional/tsql/core_engine/test_invalid_syntax/syntax_error_1.sql
@@ -6,7 +6,7 @@ select col1,, col2 from table_name;
 
 -- databricks sql:
 SELECT
-    col1,
+  col1,
 /* The following issues were detected:
 
    Unparsed input - ErrorNode encountered
@@ -14,5 +14,6 @@ SELECT
     expecting one of: $Currency, 'String', @@Reference, @Local, Float, Identifier, Integer, Operator, Real, '$ACTION', '$NODE_ID', '$PARTITION'...
     Unparsable text: ,
  */
+  col2
 FROM
     table_name;


### PR DESCRIPTION
In code such as:

```tsql
SELECT col1, , col2 ...
```

Where the parser recovers nicely from the extraneous ',', the visit method would ignore the recovery and only return the errorNode output.

Here we use a builder method rather than a visit method and return a Seq[] rather than just a single IR node. The generator then receives all the valid column definitions.

We also modify the code generator such that it does not add ',' after the generated comments representing error nodes.