### PR TITLE
Handling any_keys_match from presto

### DIFF
--- a/src/databricks/labs/remorph/snow/databricks.py
+++ b/src/databricks/labs/remorph/snow/databricks.py
@@ -416,6 +416,7 @@ class Databricks(org_databricks.Databricks):  #
             exp.CurrentDate: _current_date,
             exp.Not: _not_sql,
             local_expression.ToArray: to_array,
+            local_expression.ArrayExists: rename_func("EXISTS"),
         }
 
         def preprocess(self, expression: exp.Expression) -> exp.Expression:

--- a/src/databricks/labs/remorph/snow/local_expression.py
+++ b/src/databricks/labs/remorph/snow/local_expression.py
@@ -172,3 +172,11 @@ class AliasInfo:
     name: str
     expression: exp.Expression
     is_same_name_as_column: bool
+
+
+class MapKeys(Func):
+    arg_types = {"this": True}
+
+
+class ArrayExists(Func):
+    arg_types = {"this": True, "expression": True}

--- a/src/databricks/labs/remorph/snow/presto.py
+++ b/src/databricks/labs/remorph/snow/presto.py
@@ -5,6 +5,8 @@ from sqlglot.errors import ParseError
 from sqlglot.dialects.dialect import locate_to_strposition
 from sqlglot.tokens import TokenType
 
+from databricks.labs.remorph.snow import local_expression
+
 
 def _build_approx_percentile(args: list) -> exp.Expression:
     if len(args) == 4:
@@ -33,6 +35,12 @@ def _build_approx_percentile(args: list) -> exp.Expression:
     return exp.ApproxQuantile.from_arg_list(args)
 
 
+def _build_any_keys_match(args: list) -> local_expression.ArrayExists:
+    return local_expression.ArrayExists(
+        this=local_expression.MapKeys(this=seq_get(args, 0)), expression=seq_get(args, 1)
+    )
+
+
 class Presto(presto):
 
     class Parser(presto.Parser):
@@ -42,6 +50,7 @@ class Presto(presto):
             **presto.Parser.FUNCTIONS,
             "APPROX_PERCENTILE": _build_approx_percentile,
             "STRPOS": locate_to_strposition,
+            "ANY_KEYS_MATCH": _build_any_keys_match,
         }
 
     class Tokenizer(presto.Tokenizer):

--- a/tests/resources/functional/presto/test_any_keys_match/test_any_keys_match_1.sql
+++ b/tests/resources/functional/presto/test_any_keys_match/test_any_keys_match_1.sql
@@ -1,0 +1,15 @@
+-- presto sql:
+SELECT
+  any_keys_match(
+    map(array ['a', 'b', 'c'], array [1, 2, 3]),
+    x -> x = 'a'
+  ) as col;
+
+-- databricks sql:
+SELECT
+  EXISTS(
+    MAP_KEYS(
+      MAP_FROM_ARRAYS(ARRAY('a', 'b', 'c'), ARRAY(1, 2, 3))
+    ),
+    x -> x = 'a'
+  ) AS col;

--- a/tests/resources/functional/presto/test_any_keys_match/test_any_keys_match_2.sql
+++ b/tests/resources/functional/presto/test_any_keys_match/test_any_keys_match_2.sql
@@ -1,0 +1,25 @@
+-- presto sql:
+SELECT
+  *,
+  any_keys_match(
+    metadata,
+    k -> (
+      k LIKE 'config_%'
+      OR k = 'active'
+    )
+  ) AS has_config_or_active
+FROM
+  your_table;
+
+-- databricks sql:
+SELECT
+  *,
+  EXISTS(
+    MAP_KEYS(metadata),
+    k -> (
+      k LIKE 'config_%'
+      OR k = 'active'
+    )
+  ) AS has_config_or_active
+FROM
+  your_table;


### PR DESCRIPTION
`any_keys_match` is a presto function to do a lambda function on map keys and returns a boolean. We don't have such a direct function in Databricks. We are handling it using existing functions and like the below.

Presto: select any_keys_match(data, x -> x = 'enable_bwob')
Databricks: select exists(map_keys(data), x -> x = 'enable_bwob')