### PR TITLE
[chore] Improved `ApplicationContext` to generically parse `--dialect` and `--source-queries` flags

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -220,6 +220,9 @@ jobs:
           cache-dependency-path: '**/pyproject.toml'
           python-version: '3.10'
 
+      - name: Install Databricks CLI
+        uses: databricks/setup-cli@main
+
       - name: Initialize Python virtual environment for StandardInputPythonSubprocess
         run: make dev
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -236,6 +236,9 @@ jobs:
 
       - name: Dry run coverage tests with make
         run: make dialect_coverage_report
+        env: # this is a temporary hack
+          DATABRICKS_HOST: any
+          DATABRICKS_TOKEN: any
 
       - name: Verify report file
         if: ${{ hashFiles('./test-reports/') == '' }}

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ integration:
 coverage:
 	hatch run coverage && open htmlcov/index.html
 
-build_core_jar:
+build_core_jar: dev-cli
 	mvn --file pom.xml -pl core package
 
 clean_coverage_dir:
@@ -50,7 +50,7 @@ python_coverage_report:
 	hatch -e sqlglot-latest run python src/databricks/labs/remorph/coverage/sqlglot_tsql_transpilation_coverage.py
 
 antlr_coverage_report: build_core_jar
-	java -jar $(wildcard core/target/remorph-core-*-SNAPSHOT.jar) '{"command": "debug-coverage", "flags":{"src": "$(abspath ${INPUT_DIR_PARENT})", "dst":"$(abspath ${OUTPUT_DIR})", "extractor": "full"}}'
+	databricks labs remorph debug-coverage --src $(abspath ${INPUT_DIR_PARENT}) --dst $(abspath ${OUTPUT_DIR}) --extractor full
 
 dialect_coverage_report: clean_coverage_dir antlr_coverage_report python_coverage_report
 	hatch run python src/databricks/labs/remorph/coverage/local_report.py
@@ -62,4 +62,4 @@ dev-cli:
 	mvn -f core/pom.xml dependency:build-classpath -Dmdep.outputFile=target/classpath.txt
 
 estimate-coverage: build_core_jar
-	java -jar $(wildcard core/target/remorph-core-*-SNAPSHOT.jar) '{"command": "debug-estimate", "flags":{"dst":"$(abspath ${OUTPUT_DIR})", "source-dialect": "snowflake", "console-output": "true"}}'
+	databricks labs remorph debug-estimate --dst $(abspath ${OUTPUT_DIR}) --dialect snowflake --console-output true

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ python_coverage_report:
 	hatch -e sqlglot-latest run python src/databricks/labs/remorph/coverage/sqlglot_tsql_transpilation_coverage.py
 
 antlr_coverage_report: build_core_jar
-	databricks labs remorph debug-coverage --src $(abspath ${INPUT_DIR_PARENT}) --dst $(abspath ${OUTPUT_DIR}) --extractor full
+	java -jar $(wildcard core/target/remorph-core-*-SNAPSHOT.jar) '{"command": "debug-coverage", "flags":{"src": "$(abspath ${INPUT_DIR_PARENT})", "dst":"$(abspath ${OUTPUT_DIR})", "extractor": "full"}}'
 
 dialect_coverage_report: clean_coverage_dir antlr_coverage_report python_coverage_report
 	hatch run python src/databricks/labs/remorph/coverage/local_report.py

--- a/core/src/main/scala/com/databricks/labs/remorph/ApplicationContext.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/ApplicationContext.scala
@@ -1,15 +1,14 @@
 package com.databricks.labs.remorph
 
-import com.databricks.labs.remorph.coverage.connections.SnowflakeConnectionFactory
 import com.databricks.labs.remorph.coverage.estimation.{EstimationAnalyzer, Estimator, JsonEstimationReporter, SummaryEstimationReporter}
 import com.databricks.labs.remorph.coverage.runners.EnvGetter
 import com.databricks.labs.remorph.coverage.{CoverageTest, EstimationReport}
-import com.databricks.labs.remorph.discovery.{FileQueryHistory, QueryHistoryProvider, SnowflakeQueryHistory}
+import com.databricks.labs.remorph.discovery.{FileQueryHistory, QueryHistoryProvider}
 import com.databricks.labs.remorph.generators.orchestration.FileSetGenerator
-import com.databricks.labs.remorph.parsers.PlanParser
-import com.databricks.labs.remorph.parsers.snowflake.SnowflakePlanParser
-import com.databricks.labs.remorph.parsers.tsql.TSqlPlanParser
 import com.databricks.labs.remorph.queries.ExampleDebugger
+import com.databricks.labs.remorph.support.SupportContext
+import com.databricks.labs.remorph.support.snowflake.SnowflakeContext
+import com.databricks.labs.remorph.support.tsql.TSqlContext
 import com.databricks.labs.remorph.transpilers._
 import com.databricks.sdk.WorkspaceClient
 import com.databricks.sdk.core.DatabricksConfig
@@ -18,22 +17,23 @@ import java.io.File
 import java.time.Instant
 
 trait ApplicationContext {
-  private def snowflakePlanParser: SnowflakePlanParser = new SnowflakePlanParser
+  def flags: Map[String, String]
+
+  def envGetter: EnvGetter = new EnvGetter()
+
+  private lazy val supportContext: SupportContext = flags.get("dialect") match {
+    case Some("snowflake") => new SnowflakeContext(envGetter)
+    case Some("tsql") => new TSqlContext(envGetter)
+    case Some(unknown) => throw new IllegalArgumentException(s"--dialect=$unknown is not supported")
+    case None => throw new IllegalArgumentException("--dialect is required")
+  }
+
+  lazy val queryHistoryProvider: QueryHistoryProvider = flags.get("source-queries") match {
+    case Some(folder) => new FileQueryHistory(new File(folder).toPath)
+    case None => supportContext.remoteQueryHistory
+  }
 
   protected val now = Instant.now
-  private def tsqlPlanParser: TSqlPlanParser = new TSqlPlanParser
-
-  def planParser(dialect: String): PlanParser[_] = dialect match {
-    case "snowflake" => snowflakePlanParser
-    case "tsql" => tsqlPlanParser
-    case _ => throw new IllegalArgumentException(s"Unsupported dialect: $dialect")
-  }
-
-  def transpiler(dialect: String): BaseTranspiler = dialect match {
-    case "snowflake" => new SnowflakeToDatabricksTranspiler
-    case "tsql" => new TSqlToDatabricksTranspiler
-    case _ => throw new IllegalArgumentException(s"Unsupported dialect: $dialect")
-  }
 
   def connectConfig: DatabricksConfig = new DatabricksConfig()
 
@@ -41,17 +41,12 @@ trait ApplicationContext {
 
   def prettyPrinter[T](v: T): Unit = pprint.pprintln[T](v)
 
-  def exampleDebugger: ExampleDebugger = new ExampleDebugger(planParser, prettyPrinter)
+  def exampleDebugger: ExampleDebugger =
+    new ExampleDebugger(supportContext.planParser, prettyPrinter, supportContext.name)
 
   def coverageTest: CoverageTest = new CoverageTest
 
-  def connectionFactory: SnowflakeConnectionFactory = new SnowflakeConnectionFactory(new EnvGetter)
-
-  def estimator(dialect: String): Estimator =
-    new Estimator(
-      new SnowflakeQueryHistory(connectionFactory.newConnection()),
-      planParser(dialect),
-      new EstimationAnalyzer())
+  def estimator: Estimator = new Estimator(queryHistoryProvider, supportContext.planParser, new EstimationAnalyzer())
 
   def jsonEstimationReporter(
       outputDir: os.Path,
@@ -62,12 +57,10 @@ trait ApplicationContext {
   def consoleEstimationReporter(outputDir: os.Path, estimate: EstimationReport): SummaryEstimationReporter =
     new SummaryEstimationReporter(outputDir, estimate)
 
-  def folderQueryHistoryProvider(folder: String): QueryHistoryProvider = new FileQueryHistory(new File(folder).toPath)
+  private def sqlGenerator: SqlGenerator = new SqlGenerator
 
-  def sqlGenerator: SqlGenerator = new SqlGenerator
+  private def pySparkGenerator: PySparkGenerator = new PySparkGenerator
 
-  def pySparkGenerator: PySparkGenerator = new PySparkGenerator
-
-  def fileSetGenerator(dialect: String): FileSetGenerator =
-    new FileSetGenerator(planParser(dialect), sqlGenerator, pySparkGenerator)
+  def fileSetGenerator: FileSetGenerator =
+    new FileSetGenerator(supportContext.planParser, sqlGenerator, pySparkGenerator)
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilder.scala
@@ -29,6 +29,7 @@ class SnowflakeDMLBuilder(override val vc: SnowflakeVisitorCoordinator)
         case u if u.updateStatement() != null => u.updateStatement().accept(this)
         case d if d.deleteStatement() != null => d.deleteStatement().accept(this)
         case m if m.mergeStatement() != null => m.mergeStatement().accept(this)
+        case _ => unresolved("dmlCommand", "everything is null")
       }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/queries/QueryExtractor.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/queries/QueryExtractor.scala
@@ -53,10 +53,8 @@ class CommentBasedQueryExtractor(inputDialect: String, targetDialect: String) ex
   }
 }
 
-class ExampleDebugger(getParser: String => PlanParser[_], prettyPrinter: Any => Unit) extends LazyLogging {
-  def debugExample(name: String, maybeDialect: Option[String]): Unit = {
-    val dialect = maybeDialect.getOrElse("snowflake")
-    val parser = getParser(dialect)
+class ExampleDebugger(parser: PlanParser[_], prettyPrinter: Any => Unit, dialect: String) extends LazyLogging {
+  def debugExample(name: String): Unit = {
     val extractor = new CommentBasedQueryExtractor(dialect, "databricks")
     extractor.extractQuery(new File(name)) match {
       case Some(ExampleQuery(query, _)) =>

--- a/core/src/main/scala/com/databricks/labs/remorph/support/ConnectionFactory.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/support/ConnectionFactory.scala
@@ -1,0 +1,7 @@
+package com.databricks.labs.remorph.support
+
+import java.sql.Connection
+
+trait ConnectionFactory {
+  def newConnection(): Connection
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/support/SupportContext.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/support/SupportContext.scala
@@ -1,0 +1,11 @@
+package com.databricks.labs.remorph.support
+
+import com.databricks.labs.remorph.discovery.QueryHistoryProvider
+import com.databricks.labs.remorph.parsers.PlanParser
+
+trait SupportContext {
+  def name: String
+  def planParser: PlanParser[_]
+  def connectionFactory: ConnectionFactory
+  def remoteQueryHistory: QueryHistoryProvider
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/support/snowflake/SnowflakeConnectionFactory.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/support/snowflake/SnowflakeConnectionFactory.scala
@@ -1,6 +1,7 @@
-package com.databricks.labs.remorph.coverage.connections
+package com.databricks.labs.remorph.support.snowflake
 
 import com.databricks.labs.remorph.coverage.runners.EnvGetter
+import com.databricks.labs.remorph.support.ConnectionFactory
 import net.snowflake.client.jdbc.internal.org.bouncycastle.jce.provider.BouncyCastleProvider
 
 import java.security.spec.PKCS8EncodedKeySpec
@@ -10,7 +11,7 @@ import java.util.{Base64, Properties}
 
 // TODO: This is not how we will handle connections in the future
 
-class SnowflakeConnectionFactory(env: EnvGetter) {
+class SnowflakeConnectionFactory(env: EnvGetter) extends ConnectionFactory {
   // scalastyle:off
   Class.forName("net.snowflake.client.jdbc.SnowflakeDriver")
   // scalastyle:on

--- a/core/src/main/scala/com/databricks/labs/remorph/support/snowflake/SnowflakeContext.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/support/snowflake/SnowflakeContext.scala
@@ -1,0 +1,16 @@
+package com.databricks.labs.remorph.support.snowflake
+
+import com.databricks.labs.remorph.coverage.runners.EnvGetter
+import com.databricks.labs.remorph.support.{ConnectionFactory, SupportContext}
+import com.databricks.labs.remorph.discovery.{QueryHistoryProvider, SnowflakeQueryHistory}
+import com.databricks.labs.remorph.parsers.PlanParser
+import com.databricks.labs.remorph.parsers.snowflake.SnowflakePlanParser
+
+class SnowflakeContext(private val envGetter: EnvGetter) extends SupportContext {
+  override def name: String = "snowflake"
+  override def planParser: PlanParser[_] = new SnowflakePlanParser
+  override lazy val connectionFactory: ConnectionFactory = new SnowflakeConnectionFactory(envGetter)
+  override lazy val remoteQueryHistory: QueryHistoryProvider = {
+    new SnowflakeQueryHistory(connectionFactory.newConnection())
+  }
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/support/tsql/SqlServerConnectionFactory.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/support/tsql/SqlServerConnectionFactory.scala
@@ -1,0 +1,18 @@
+package com.databricks.labs.remorph.support.tsql
+
+import com.databricks.labs.remorph.coverage.runners.EnvGetter
+import com.databricks.labs.remorph.support.ConnectionFactory
+
+import java.sql.{Connection, DriverManager}
+
+class SqlServerConnectionFactory(env: EnvGetter) extends ConnectionFactory {
+  // scalastyle:off
+  Class.forName("com.microsoft.sqlserver.jdbc.SQLServerDriver")
+  // scalastyle:on
+
+  private val url = env.get("TEST_TSQL_JDBC")
+  private val user = env.get("TEST_TSQL_USER")
+  private val pass = env.get("TEST_TSQL_PASS")
+
+  override def newConnection(): Connection = DriverManager.getConnection(url, user, pass)
+}

--- a/core/src/main/scala/com/databricks/labs/remorph/support/tsql/TSqlContext.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/support/tsql/TSqlContext.scala
@@ -1,0 +1,16 @@
+package com.databricks.labs.remorph.support.tsql
+
+import com.databricks.labs.remorph.coverage.runners.EnvGetter
+import com.databricks.labs.remorph.discovery.QueryHistoryProvider
+import com.databricks.labs.remorph.parsers.PlanParser
+import com.databricks.labs.remorph.parsers.tsql.TSqlPlanParser
+import com.databricks.labs.remorph.support.{ConnectionFactory, SupportContext}
+
+class TSqlContext(private val envGetter: EnvGetter) extends SupportContext {
+  override def name: String = "tsql"
+  override def planParser: PlanParser[_] = new TSqlPlanParser
+  override lazy val connectionFactory: ConnectionFactory = new SqlServerConnectionFactory(envGetter)
+  override def remoteQueryHistory: QueryHistoryProvider = {
+    throw new IllegalArgumentException("query history for SQLServer is not yet implemented")
+  }
+}

--- a/core/src/test/scala/com/databricks/labs/remorph/queries/ExampleDebuggerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/queries/ExampleDebuggerTest.scala
@@ -18,10 +18,10 @@ class ExampleDebuggerTest extends AnyWordSpec with Matchers with MockitoSugar wi
       when(parser.parse(any())).thenReturn(lift(OkResult(ParserRuleContext.EMPTY)))
       when(parser.visit(any())).thenReturn(lift(OkResult(NoopNode)))
 
-      val debugger = new ExampleDebugger(_ => parser, x => buf.append(x))
+      val debugger = new ExampleDebugger(parser, x => buf.append(x), "snowflake")
       val name = s"${NestedFiles.projectRoot}/tests/resources/functional/snowflake/nested_query_with_json_1.sql"
 
-      debugger.debugExample(name, None)
+      debugger.debugExample(name)
 
       buf.toString() should equal("NoopNode$\n")
     }

--- a/labs.yml
+++ b/labs.yml
@@ -65,18 +65,32 @@ commands:
   - name: debug-coverage
     description: "[INTERNAL] Run coverage tests"
     flags:
+      - name: dialect
+        description: sql dialect
       - name: src
         description: The parent directory under which test queries are laid out
       - name: dst
         description: The directory under which the report files will be written
       - name: extractor
         description: The strategy for extracting queries from the test files. Valid strategies are "full" (when files contain only one input query) and "comment" (when files contain an input query and the corresponding translation, separated by a comment stating the dialect of each query).
+  - name: debug-estimate
+    description: "[INTERNAL] estimate migration effort"
+    flags:
+      - name: dialect
+        description: sql dialect
+      - name: source-queries
+        description: The folder with queries. Otherwise will attempt to fetch query history for a dialect
+      - name: console-output
+        default: true
+        description: Output results to a folder
+      - name: dst
+        description: The directory for report
   - name: debug-bundle
     description: "[INTERNAL] Generate bundle for the translated queries"
     flags:
       - name: dialect
         description: sql dialect
-      - name: src
-        description: The directory with source SQL files
+      - name: source-queries
+        description: The folder with queries. Otherwise will attempt to fetch query history for a dialect
       - name: dst
         description: The directory for generated files

--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -27,6 +27,7 @@ def raise_validation_exception(msg: str) -> Exception:
 proxy_command(remorph, "debug-script")
 proxy_command(remorph, "debug-me")
 proxy_command(remorph, "debug-coverage")
+proxy_command(remorph, "debug-estimate")
 proxy_command(remorph, "debug-bundle")
 
 


### PR DESCRIPTION
i've noticed that debug-estimate command was never properly added. And we had few different ways to init query history and dialects. This PR fixes that.