### PR TITLE
Avoid processing escapes in interpolator arguments

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/generators/package.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/package.scala
@@ -28,7 +28,7 @@ package object generators {
           }
           while (failureOpt.isEmpty && arguments.hasNext) {
             try {
-              sb.append(StringContext.treatEscapes(arguments.next()))
+              sb.append(arguments.next())
               sb.append(StringContext.treatEscapes(stringParts.next()))
             } catch {
               case NonFatal(e) =>

--- a/tests/resources/functional/snowflake/functions/strings/regexp_substr_2.sql
+++ b/tests/resources/functional/snowflake/functions/strings/regexp_substr_2.sql
@@ -1,0 +1,10 @@
+-- snowflake sql:
+select id, string1,
+       regexp_substr(string1, 'the\\W+\\w+') as "SUBSTRING"
+    from demo2;
+
+-- databricks sql:
+
+select id, string1,
+	   REGEXP_EXTRACT(string1, 'the\\W+\\w+') as `SUBSTRING`
+    from demo2;


### PR DESCRIPTION
Calling `treatEscapes` on the interpolator's arguments was a mistake (calling it on string parts wasn't).

The reason is that string parts come from our scala program, like the `\n` in `code"$foo\n$bar"`, while arguments (may) come from the input query (and as such should be left as-is).