### PR TITLE
make hatch a pre-requisite

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -220,6 +220,9 @@ jobs:
           cache-dependency-path: '**/pyproject.toml'
           python-version: '3.10'
 
+      - name: Install hatch
+        run: pip install hatch==$HATCH_VERSION
+
       - name: Install Databricks CLI
         uses: databricks/setup-cli@main
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -149,6 +149,9 @@ jobs:
           cache-dependency-path: '**/pyproject.toml'
           python-version: '3.10'
 
+      - name: Install hatch
+        run: pip install hatch==$HATCH_VERSION
+
       - name: Initialize Python virtual environment for StandardInputPythonSubprocess
         run: make dev
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ clean:
 	rm -fr .venv clean htmlcov .mypy_cache .pytest_cache .ruff_cache .coverage coverage.xml
 
 dev:
-	pip3 install hatch
 	hatch env create
 	hatch run pip install -e '.[test]'
 	hatch run which python


### PR DESCRIPTION
Our current `make` script installs `hatch` which can be very flaky depending on the OS and how `python/pip` were installed.
This PR assumes `hatch` is already installed