### PR TITLE
[Snowflake] implement AST for positional column identifiers

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/dml.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/dml.scala
@@ -5,7 +5,7 @@ abstract class Modification extends LogicalPlan
 
 case class InsertIntoTable(
     target: LogicalPlan,
-    columns: Option[Seq[Id]],
+    columns: Option[Seq[NameOrPosition]],
     values: LogicalPlan,
     outputRelation: Option[LogicalPlan] = None,
     options: Option[Expression] = None,

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/extensions.scala
@@ -6,18 +6,25 @@ abstract class ToRefactor extends LeafExpression {
   override def dataType: DataType = UnresolvedType
 }
 
+sealed trait NameOrPosition extends LeafExpression
+
 // TODO: (nfx) refactor to align more with catalyst, replace with Name
-case class Id(id: String, caseSensitive: Boolean = false) extends ToRefactor
+case class Id(id: String, caseSensitive: Boolean = false) extends ToRefactor with NameOrPosition
 
 case class Name(name: String) extends LeafExpression {
   override def dataType: DataType = UnresolvedType
 }
 
-// TODO: (nfx) refactor to align more with catalyst
-case class ObjectReference(head: Id, tail: Id*) extends ToRefactor
+case class Position(index: Int) extends ToRefactor with NameOrPosition {}
 
 // TODO: (nfx) refactor to align more with catalyst
-case class Column(tableNameOrAlias: Option[ObjectReference], columnName: Id) extends ToRefactor with AstExtension {}
+case class ObjectReference(head: NameOrPosition, tail: NameOrPosition*) extends ToRefactor
+
+// TODO: (nfx) refactor to align more with catalyst
+case class Column(tableNameOrAlias: Option[ObjectReference], columnName: NameOrPosition)
+    extends ToRefactor
+    with AstExtension {}
+
 case class Identifier(name: String, isQuoted: Boolean) extends ToRefactor with AstExtension {}
 case class DollarAction() extends ToRefactor with AstExtension {}
 case class Distinct(expression: Expression) extends ToRefactor

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/TSqlCallMapper.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/TSqlCallMapper.scala
@@ -54,7 +54,7 @@ class TSqlCallMapper extends CallMapper {
     // many strings and aliases for "day", "month", "year", etc. We need to extract this string and
     // perform the translation based on what we get
     val interval = args.head match {
-      case Column(_, id) => id.id.toLowerCase()
+      case Column(_, Id(id, _)) => id.toLowerCase()
       case _ =>
         throw new IllegalArgumentException("DATEADD interval type is not valid. Should be 'day', 'month', 'year', etc.")
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
@@ -89,6 +89,13 @@ class SnowflakeExpressionBuilderSpec
           Column(Some(ObjectReference(Id("My Table", caseSensitive = true))), Id("x")))
       }
     }
+
+    "translate column positions" should {
+      "$1" in {
+        exampleExpr("$1", _.columnElem(), Column(None, Position(1)))
+      }
+    }
+
     "translate aliases" should {
       "x AS y" in {
         exampleExpr("1 AS y", _.selectListElem(), Alias(Literal(1), Id("y")))


### PR DESCRIPTION
Still unsupported on the generator side though (as Databricks doesn't support positional column identifiers, we'll need the table's schema in order to properly translate queries involving positional column ids).