### PR TITLE
Refactor origin in tree node

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/expressions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/expressions.scala
@@ -4,7 +4,7 @@ import java.util.{UUID}
 
 // Expression used to refer to fields, functions and similar. This can be used everywhere
 // expressions in SQL appear.
-abstract class Expression extends TreeNode[Expression] {
+abstract class Expression(origin: Origin = Origin.empty) extends TreeNode[Expression](origin) {
   lazy val resolved: Boolean = childrenResolved
 
   def dataType: DataType

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/expressions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/expressions.scala
@@ -4,7 +4,8 @@ import java.util.{UUID}
 
 // Expression used to refer to fields, functions and similar. This can be used everywhere
 // expressions in SQL appear.
-abstract class Expression(origin: Origin = Origin.empty) extends TreeNode[Expression](origin) {
+abstract class Expression(_origin: Option[Origin] = Option.empty) extends TreeNode[Expression](_origin) {
+
   lazy val resolved: Boolean = childrenResolved
 
   def dataType: DataType

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/plans.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/plans.scala
@@ -6,7 +6,8 @@ package com.databricks.labs.remorph.intermediate
  * the [[Command]] type that is used to execute commands on the server. [[Plan]] is a union of Spark's LogicalPlan and
  * QueryPlan.
  */
-abstract class Plan[PlanType <: Plan[PlanType]](origin: Origin = Origin.empty) extends TreeNode[PlanType](origin) {
+abstract class Plan[PlanType <: Plan[PlanType]](_origin: Option[Origin] = Option.empty)
+    extends TreeNode[PlanType](_origin) {
   self: PlanType =>
 
   def output: Seq[Attribute]

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/plans.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/plans.scala
@@ -80,9 +80,7 @@ abstract class Plan[PlanType <: Plan[PlanType]] extends TreeNode[PlanType] {
     var changed = false
 
     @inline def transformExpression(e: Expression): Expression = {
-      val newE = CurrentOrigin.withOrigin(e.origin) {
-        f(e)
-      }
+      val newE = f(e)
       if (newE.fastEquals(e)) {
         e
       } else {

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/plans.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/plans.scala
@@ -6,7 +6,7 @@ package com.databricks.labs.remorph.intermediate
  * the [[Command]] type that is used to execute commands on the server. [[Plan]] is a union of Spark's LogicalPlan and
  * QueryPlan.
  */
-abstract class Plan[PlanType <: Plan[PlanType]] extends TreeNode[PlanType] {
+abstract class Plan[PlanType <: Plan[PlanType]](origin: Origin = Origin.empty) extends TreeNode[PlanType](origin) {
   self: PlanType =>
 
   def output: Seq[Attribute]

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/trees.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/trees.scala
@@ -54,13 +54,15 @@ class TreeNodeException[TreeType <: TreeNode[_]](@transient val tree: TreeType, 
 }
 
 // scalastyle:off
-abstract class TreeNode[BaseType <: TreeNode[BaseType]](@JsonIgnore origin: Origin) extends Product {
+abstract class TreeNode[BaseType <: TreeNode[BaseType]](_origin: Option[Origin] = Option.empty) extends Product {
   // scalastyle:on
   self: BaseType =>
 
   @JsonIgnore lazy val containsChild: Set[TreeNode[_]] = children.toSet
   private lazy val _hashCode: Int = productHash(this, scala.util.hashing.MurmurHash3.productSeed)
   private lazy val allChildren: Set[TreeNode[_]] = (children ++ innerChildren).toSet[TreeNode[_]]
+
+  def origin: Option[Origin] = _origin
 
   /**
    * Returns a Seq of the children of this node. Children should not change. Immutability required for containsChild

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/trees.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/trees.scala
@@ -12,33 +12,30 @@ import scala.util.control.NonFatal
 private class MutableInt(var i: Int)
 
 case class Origin(
-    startLine: Option[Int] = None,
-    startColumn: Option[Int] = None,
-    endLine: Option[Int] = None,
-    endColumn: Option[Int] = None,
-    startTokenIndex: Option[Int] = None,
-    endTokenIndex: Option[Int] = None)
+    startLine: Int,
+    startColumn: Int,
+    endLine: Int,
+    endColumn: Int,
+    startTokenIndex: Int,
+    endTokenIndex: Int)
 
 object Origin {
 
-  val empty: Origin = Origin()
-
-  def fromParseTree(tree: ParseTree): Origin = {
+  def fromParseTree(tree: ParseTree): Option[Origin] = {
     tree match {
-      case parserRuleContext: ParserRuleContext => Origin.fromParseRuleContext(parserRuleContext)
-      case other => Origin.empty
+      case parserRuleContext: ParserRuleContext => Some(Origin.fromParserRuleContext(parserRuleContext))
+      case other => Option.empty
     }
   }
 
-  def fromParseRuleContext(ctx: ParserRuleContext): Origin = {
+  def fromParserRuleContext(ctx: ParserRuleContext): Origin = {
     Origin(
-      startLine = Option(ctx.start.getLine),
-      startColumn = Option(ctx.start.getCharPositionInLine),
-      endLine = Option(ctx.stop.getLine),
-      endColumn = Option(ctx.stop.getCharPositionInLine + ctx.stop.getStopIndex - ctx.stop.getStartIndex),
-      startTokenIndex = Option(ctx.start.getTokenIndex),
-      endTokenIndex = Option(ctx.stop.getTokenIndex))
-
+      startLine = ctx.start.getLine,
+      startColumn = ctx.start.getCharPositionInLine,
+      endLine = ctx.stop.getLine,
+      endColumn = ctx.stop.getCharPositionInLine + ctx.stop.getStopIndex - ctx.stop.getStartIndex,
+      startTokenIndex = ctx.start.getTokenIndex,
+      endTokenIndex = ctx.stop.getTokenIndex)
   }
 }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/trees.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/trees.scala
@@ -272,8 +272,8 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]](@JsonIgnore origin: Orig
       .getOrElse(ctors.maxBy(_.getParameterTypes.length)) // fall back to older heuristic
 
     try {
-       val res = defaultCtor.newInstance(allArgs.toArray: _*).asInstanceOf[BaseType]
-        res
+      val res = defaultCtor.newInstance(allArgs.toArray: _*).asInstanceOf[BaseType]
+      res
     } catch {
       case e: java.lang.IllegalArgumentException =>
         throw new TreeNodeException(

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/workflows/JobNode.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/workflows/JobNode.scala
@@ -1,8 +1,8 @@
 package com.databricks.labs.remorph.intermediate.workflows
 
-import com.databricks.labs.remorph.intermediate.TreeNode
+import com.databricks.labs.remorph.intermediate.{Origin, TreeNode}
 
-abstract class JobNode extends TreeNode[JobNode]
+abstract class JobNode(origin: Origin = Origin.empty) extends TreeNode[JobNode](origin)
 
 abstract class LeafJobNode extends JobNode {
   override def children: Seq[JobNode] = Seq()

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/workflows/JobNode.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/workflows/JobNode.scala
@@ -2,7 +2,7 @@ package com.databricks.labs.remorph.intermediate.workflows
 
 import com.databricks.labs.remorph.intermediate.{Origin, TreeNode}
 
-abstract class JobNode(origin: Origin = Origin.empty) extends TreeNode[JobNode](origin)
+abstract class JobNode(_origin: Option[Origin] = Option.empty) extends TreeNode[JobNode](_origin)
 
 abstract class LeafJobNode extends JobNode {
   override def children: Seq[JobNode] = Seq()

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
@@ -20,6 +20,33 @@ class SnowflakeAstBuilder(override val vc: SnowflakeVisitorCoordinator)
     ir.UnresolvedRelation(ruleText = ruleText, message = message)
 
   // Concrete visitors
+  override def visit(tree: ParseTree): ir.LogicalPlan = {
+    CurrentOrigin.fromParseTree(tree)
+    val plan = super.visit(tree)
+    plan
+  }
+
+  override def visitChildren(node: RuleNode): ir.LogicalPlan = {
+    var result = this.defaultResult()
+    val n = node.getChildCount
+    var i = 0
+    while (i < n && this.shouldVisitNextChild(node, result)) {
+      val c = node.getChild(i)
+      CurrentOrigin.fromParseTree(c)
+      val childResult = c.accept(this)
+      result = this.aggregateResult(result, childResult)
+
+      i += 1
+    }
+    result
+  }
+
+  override def visitMany[R <: RuleContext](contexts: java.lang.Iterable[R]): Seq[ir.LogicalPlan] = {
+    contexts.asScala.map(ctx => {
+      CurrentOrigin.fromParseTree(ctx)
+      ctx.accept(this)
+    }).toSeq
+  }
 
   override def visitSnowflakeFile(ctx: SnowflakeFileContext): ir.LogicalPlan = {
     // This very top level visitor does not ignore any valid statements for the batch, instead


### PR DESCRIPTION
There is a need to transpile SQL comments. This requires populating TreeNode.origin when building the ir AST.

This PR:
 - moves the `origin` field of `TreeNode` to a 2nd parameter list such that it is ignored during comparisons, and refactors accordingly

Progresses #869 

Future PRs will expand this one (see #1182)