### PR TITLE
Refactor parsing pipeline

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/lib/commonlex.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/lib/commonlex.g4
@@ -19,6 +19,10 @@
 // =================================================================================
 lexer grammar commonlex;
 
+ channels {
+     COMMENT_CHANNEL
+ }
+
 // TODO: Remove the use of DUMMY for unfinished Snoflake grammar productions
 DUMMY:
     'DUMMY'
@@ -1427,7 +1431,7 @@ WS: SPACE+ -> skip;
 
 // Comments
 SQL_COMMENT  : '/*' (SQL_COMMENT | .)*? '*/' -> channel(HIDDEN);
-LINE_COMMENT : ('--' | '//') ~[\r\n]*        -> channel(HIDDEN);
+LINE_COMMENT : ('--' | '//') ~[\r\n]*        -> channel(COMMENT_CHANNEL);
 
 // Identifiers
 ID              : ( [A-Z_] | FullWidthLetter) ( [A-Z_#$@0-9] | FullWidthLetter)*;

--- a/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/Estimator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/coverage/estimation/Estimator.scala
@@ -43,8 +43,7 @@ class Estimator(queryHistory: QueryHistoryProvider, planParser: PlanParser[_], a
     if (!parsedSet.contains(fingerprint)) {
       parsedSet += fingerprint
       planParser
-        .parse(Parsing(query.source, query.user.getOrElse("unknown") + "_" + query.id))
-        .flatMap(planParser.visit)
+        .parseLogicalPlan(Parsing(query.source, query.user.getOrElse("unknown") + "_" + query.id))
         .run(initialState) match {
         case KoResult(PARSE, error) =>
           Some(

--- a/core/src/main/scala/com/databricks/labs/remorph/discovery/Anonymizer.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/discovery/Anonymizer.scala
@@ -55,7 +55,7 @@ class Anonymizer(parser: PlanParser[_]) extends LazyLogging {
   def apply(query: String): String = fingerprint(query)
 
   private[discovery] def fingerprint(query: ExecutedQuery): Fingerprint = {
-    parser.parse(Parsing(query.source)).flatMap(parser.visit).run(Parsing(query.source)) match {
+    parser.parseLogicalPlan(Parsing(query.source)).run(Parsing(query.source)) match {
       case KoResult(WorkflowStage.PARSE, error) =>
         logger.warn(s"Failed to parse query: ${query.source} ${error.msg}")
         Fingerprint(

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/orchestration/rules/QueryHistoryToQueryNodes.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/orchestration/rules/QueryHistoryToQueryNodes.scala
@@ -15,8 +15,7 @@ class QueryHistoryToQueryNodes(val parser: PlanParser[_]) extends Rule[JobNode] 
   private def executedQuery(query: ExecutedQuery): JobNode = {
     val state = Parsing(query.source, query.id)
     parser
-      .parse(state)
-      .flatMap(parser.visit)
+      .parseLogicalPlan(state)
       .flatMap(parser.optimize)
       .run(state) match {
       case OkResult((_, plan)) => QueryPlan(plan, query)

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/py/ast.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/py/ast.scala
@@ -4,7 +4,7 @@ import com.databricks.labs.remorph.intermediate.{Binary, DataType, Expression, N
 
 // this is a subset of https://docs.python.org/3/library/ast.html
 
-abstract class Statement extends Plan[Statement](origin = Origin.empty) {
+abstract class Statement extends Plan[Statement]()(Origin.empty) {
   override def output: Seq[IRAttribute] = Nil
 }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/py/ast.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/py/ast.scala
@@ -1,10 +1,10 @@
 package com.databricks.labs.remorph.generators.py
 
-import com.databricks.labs.remorph.intermediate.{Binary, DataType, Expression, Name, Plan, StringType, UnresolvedType, Attribute => IRAttribute}
+import com.databricks.labs.remorph.intermediate.{Binary, DataType, Expression, Name, Origin, Plan, StringType, UnresolvedType, Attribute => IRAttribute}
 
 // this is a subset of https://docs.python.org/3/library/ast.html
 
-abstract class Statement extends Plan[Statement] {
+abstract class Statement extends Plan[Statement](origin = Origin.empty) {
   override def output: Seq[IRAttribute] = Nil
 }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/py/rules/PySparkStatements.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/py/rules/PySparkStatements.scala
@@ -30,7 +30,7 @@ class PySparkStatements(val expr: ir.Rule[ir.Expression]) extends ir.Rule[py.Sta
     case ir.NamedTable(name, _, _) => methodOf(ir.Name("spark"), "table", Seq(ir.StringLiteral(name)))
     case ir.NoTable() => methodOf(ir.Name("spark"), "emptyDataFrame", Seq())
     case ir.Filter(input, condition) => methodOf(plan(input), "filter", Seq(condition))
-    case ir.Project(input, projectList) => methodOf(plan(input), "select", projectList)
+    case ir.Project(input, projectList, _) => methodOf(plan(input), "select", projectList)
     case ir.Limit(input, limit) => methodOf(plan(input), "limit", Seq(limit))
     case ir.Offset(input, offset) => methodOf(plan(input), "offset", Seq(offset))
     case ir.Sort(input, sortList, _) => methodOf(plan(input), "orderBy", sortList)

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/py/rules/PySparkStatements.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/py/rules/PySparkStatements.scala
@@ -30,7 +30,7 @@ class PySparkStatements(val expr: ir.Rule[ir.Expression]) extends ir.Rule[py.Sta
     case ir.NamedTable(name, _, _) => methodOf(ir.Name("spark"), "table", Seq(ir.StringLiteral(name)))
     case ir.NoTable() => methodOf(ir.Name("spark"), "emptyDataFrame", Seq())
     case ir.Filter(input, condition) => methodOf(plan(input), "filter", Seq(condition))
-    case ir.Project(input, projectList, _) => methodOf(plan(input), "select", projectList)
+    case ir.Project(input, projectList) => methodOf(plan(input), "select", projectList)
     case ir.Limit(input, limit) => methodOf(plan(input), "limit", Seq(limit))
     case ir.Offset(input, offset) => methodOf(plan(input), "offset", Seq(offset))
     case ir.Sort(input, sortList, _) => methodOf(plan(input), "orderBy", sortList)

--- a/core/src/main/scala/com/databricks/labs/remorph/graph/TableGraph.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/graph/TableGraph.scala
@@ -107,7 +107,7 @@ class TableGraph(parser: PlanParser[_]) extends DependencyGraph with LazyLogging
   def buildDependency(queryHistory: QueryHistory, tableDefinition: Set[TableDefinition]): Unit = {
     queryHistory.queries.foreach { query =>
       try {
-        val plan = parser.parse(Parsing(query.source)).flatMap(parser.visit).run(Parsing(query.source))
+        val plan = parser.parseLogicalPlan(Parsing(query.source)).run(Parsing(query.source))
         plan match {
           case KoResult(_, error) =>
             logger.warn(s"Failed to produce plan from query: ${query.id}")

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/commands.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/commands.scala
@@ -5,11 +5,11 @@ trait Command extends LogicalPlan {
 }
 
 case class SqlCommand(sql: String, named_arguments: Map[String, Expression], pos_arguments: Seq[Expression])
-    extends LeafNode
+    extends LeafNode()()
     with Command
 
 case class CreateDataFrameViewCommand(child: Relation, name: String, is_global: Boolean, replace: Boolean)
-    extends LeafNode
+    extends LeafNode()()
     with Command
 
 abstract class TableSaveMethod
@@ -24,7 +24,7 @@ case object OverwriteSaveMode extends SaveMode
 case object ErrorIfExistsSaveMode extends SaveMode
 case object IgnoreSaveMode extends SaveMode
 
-case class SaveTable(table_name: String, save_method: TableSaveMethod) extends LeafNode with Command
+case class SaveTable(table_name: String, save_method: TableSaveMethod) extends LeafNode()() with Command
 
 case class BucketBy(bucket_column_names: Seq[String], num_buckets: Int)
 
@@ -39,7 +39,7 @@ case class WriteOperation(
     bucket_by: Option[BucketBy],
     options: Map[String, String],
     clustering_columns: Seq[String])
-    extends LeafNode
+    extends LeafNode()()
     with Command
 
 abstract class Mode
@@ -61,7 +61,7 @@ case class WriteOperationV2(
     mode: Mode,
     overwrite_condition: Option[Expression],
     clustering_columns: Seq[String])
-    extends LeafNode
+    extends LeafNode()()
     with Command
 
 case class Trigger(
@@ -85,11 +85,11 @@ case class WriteStreamOperationStart(
     sink_destination: SinkDestination,
     foreach_writer: Option[StreamingForeachFunction],
     foreach_batch: Option[StreamingForeachFunction])
-    extends LeafNode
+    extends LeafNode()()
     with Command
 
 // TODO: align snowflake and common IR implementations for `CreateVariable`
 case class CreateVariable(name: Id, dataType: DataType, defaultExpr: Option[Expression] = None, replace: Boolean)
-    extends LeafNode
+    extends LeafNode()()
     with Command
 

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/ddl.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/ddl.scala
@@ -112,11 +112,11 @@ case class ColumnDeclaration(
     virtualColumnDeclaration: Option[Expression] = Option.empty,
     constraints: Seq[Constraint] = Seq.empty)
 
-case class CreateTableCommand(name: String, columns: Seq[ColumnDeclaration]) extends Catalog {}
+case class CreateTableCommand(name: String, columns: Seq[ColumnDeclaration]) extends Catalog()() {}
 
 // TODO Need to introduce TableSpecBase, TableSpec and UnresolvedTableSpec
 
-case class ReplaceTableCommand(name: String, columns: Seq[ColumnDeclaration], orCreate: Boolean) extends Catalog
+case class ReplaceTableCommand(name: String, columns: Seq[ColumnDeclaration], orCreate: Boolean) extends Catalog()()
 
 case class ReplaceTableAsSelect(
     table_name: String,
@@ -124,7 +124,7 @@ case class ReplaceTableAsSelect(
     writeOptions: Map[String, String],
     orCreate: Boolean,
     isAnalyzed: Boolean = false)
-    extends Catalog
+    extends Catalog()()
 
 sealed trait TableAlteration
 case class AddColumn(columnDeclaration: Seq[ColumnDeclaration]) extends TableAlteration
@@ -149,31 +149,31 @@ case class DropColumns(columnNames: Seq[String]) extends TableAlteration
 case class RenameConstraint(oldName: String, newName: String) extends TableAlteration
 case class RenameColumn(oldName: String, newName: String) extends TableAlteration
 
-case class AlterTableCommand(tableName: String, alterations: Seq[TableAlteration]) extends Catalog {}
+case class AlterTableCommand(tableName: String, alterations: Seq[TableAlteration]) extends Catalog()() {}
 
 // Catalog API (experimental / unstable)
-abstract class Catalog extends LeafNode {
+abstract class Catalog()(origin: Origin = Origin.empty) extends LeafNode()(origin) {
   override def output: Seq[Attribute] = Seq.empty
 }
 
-case class SetCurrentDatabase(db_name: String) extends Catalog {}
-case class ListDatabases(pattern: Option[String]) extends Catalog {}
-case class ListTables(db_name: Option[String], pattern: Option[String]) extends Catalog {}
-case class ListFunctions(db_name: Option[String], pattern: Option[String]) extends Catalog {}
-case class ListColumns(table_name: String, db_name: Option[String]) extends Catalog {}
-case class GetDatabase(db_name: String) extends Catalog {}
-case class GetTable(table_name: String, db_name: Option[String]) extends Catalog {}
-case class GetFunction(function_name: String, db_name: Option[String]) extends Catalog {}
-case class DatabaseExists(db_name: String) extends Catalog {}
-case class TableExists(table_name: String, db_name: Option[String]) extends Catalog {}
-case class FunctionExists(function_name: String, db_name: Option[String]) extends Catalog {}
+case class SetCurrentDatabase(db_name: String) extends Catalog()() {}
+case class ListDatabases(pattern: Option[String]) extends Catalog()() {}
+case class ListTables(db_name: Option[String], pattern: Option[String]) extends Catalog()() {}
+case class ListFunctions(db_name: Option[String], pattern: Option[String]) extends Catalog()() {}
+case class ListColumns(table_name: String, db_name: Option[String]) extends Catalog()() {}
+case class GetDatabase(db_name: String) extends Catalog()() {}
+case class GetTable(table_name: String, db_name: Option[String]) extends Catalog()() {}
+case class GetFunction(function_name: String, db_name: Option[String]) extends Catalog()() {}
+case class DatabaseExists(db_name: String) extends Catalog()() {}
+case class TableExists(table_name: String, db_name: Option[String]) extends Catalog()() {}
+case class FunctionExists(function_name: String, db_name: Option[String]) extends Catalog()() {}
 case class CreateExternalTable(
     table_name: String,
     path: Option[String],
     source: Option[String],
     description: Option[String],
     override val schema: DataType)
-    extends Catalog {}
+    extends Catalog()() {}
 
 // As per Spark v2Commands
 case class CreateTable(
@@ -182,7 +182,7 @@ case class CreateTable(
     source: Option[String],
     description: Option[String],
     override val schema: DataType)
-    extends Catalog {}
+    extends Catalog()() {}
 
 // As per Spark v2Commands
 case class CreateTableAsSelect(
@@ -191,19 +191,19 @@ case class CreateTableAsSelect(
     path: Option[String],
     source: Option[String],
     description: Option[String])
-    extends Catalog {}
+    extends Catalog()() {}
 
-case class DropTempView(view_name: String) extends Catalog {}
-case class DropGlobalTempView(view_name: String) extends Catalog {}
-case class RecoverPartitions(table_name: String) extends Catalog {}
-case class IsCached(table_name: String) extends Catalog {}
-case class CacheTable(table_name: String, storage_level: StorageLevel) extends Catalog {}
-case class UncachedTable(table_name: String) extends Catalog {}
-case class ClearCache() extends Catalog {}
-case class RefreshTable(table_name: String) extends Catalog {}
-case class RefreshByPath(path: String) extends Catalog {}
-case class SetCurrentCatalog(catalog_name: String) extends Catalog {}
-case class ListCatalogs(pattern: Option[String]) extends Catalog {}
+case class DropTempView(view_name: String) extends Catalog()() {}
+case class DropGlobalTempView(view_name: String) extends Catalog()() {}
+case class RecoverPartitions(table_name: String) extends Catalog()() {}
+case class IsCached(table_name: String) extends Catalog()() {}
+case class CacheTable(table_name: String, storage_level: StorageLevel) extends Catalog()() {}
+case class UncachedTable(table_name: String) extends Catalog()() {}
+case class ClearCache() extends Catalog()() {}
+case class RefreshTable(table_name: String) extends Catalog()() {}
+case class RefreshByPath(path: String) extends Catalog()() {}
+case class SetCurrentCatalog(catalog_name: String) extends Catalog()() {}
+case class ListCatalogs(pattern: Option[String]) extends Catalog()() {}
 
 case class TableIdentifier(table: String, database: Option[String])
 case class CatalogTable(

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/dml.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/dml.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.intermediate
 
 // Used for DML other than SELECT
-abstract class Modification extends LogicalPlan
+abstract class Modification extends LogicalPlan(origin = Origin.empty)
 
 case class InsertIntoTable(
     target: LogicalPlan,

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/dml.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/dml.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.intermediate
 
 // Used for DML other than SELECT
-abstract class Modification extends LogicalPlan(origin = Origin.empty)
+abstract class Modification extends LogicalPlan()(Origin.empty)
 
 case class InsertIntoTable(
     target: LogicalPlan,

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/expressions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/expressions.scala
@@ -4,7 +4,7 @@ import java.util.{UUID}
 
 // Expression used to refer to fields, functions and similar. This can be used everywhere
 // expressions in SQL appear.
-abstract class Expression extends TreeNode[Expression] {
+abstract class Expression(origin: Origin = Origin.empty) extends TreeNode[Expression](origin) {
   lazy val resolved: Boolean = childrenResolved
 
   def dataType: DataType

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/expressions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/expressions.scala
@@ -4,7 +4,7 @@ import java.util.{UUID}
 
 // Expression used to refer to fields, functions and similar. This can be used everywhere
 // expressions in SQL appear.
-abstract class Expression(origin: Origin = Origin.empty) extends TreeNode[Expression](origin) {
+abstract class Expression(origin: Origin = Origin.empty) extends TreeNode[Expression]()(origin) {
   lazy val resolved: Boolean = childrenResolved
 
   def dataType: DataType

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/extensions.scala
@@ -73,17 +73,17 @@ case class ForceSeekHint(index: Option[Expression], indexColumns: Option[Seq[Exp
 
 // It was not clear whether the NamedTable options should be used for the alias. I'm assuming it is not what
 // they are for.
-case class TableAlias(child: LogicalPlan, alias: String, columns: Seq[Id] = Seq.empty) extends UnaryNode {
+case class TableAlias(child: LogicalPlan, alias: String, columns: Seq[Id] = Seq.empty) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = columns.map(c => AttributeReference(c.id, StringType))
 }
 
 // TODO: (nfx) refactor to align more with catalyst
 // TODO: remove this and replace with Hint(Hint(...), ...)
-case class TableWithHints(child: LogicalPlan, hints: Seq[TableHint]) extends UnaryNode {
+case class TableWithHints(child: LogicalPlan, hints: Seq[TableHint]) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class Batch(children: Seq[LogicalPlan]) extends LogicalPlan {
+case class Batch(children: Seq[LogicalPlan]) extends LogicalPlan(origin = Origin.empty) {
   override def output: Seq[Attribute] = children.lastOption.map(_.output).getOrElse(Seq()).toSeq
 }
 
@@ -137,7 +137,7 @@ case class RowSamplingFixedAmount(amount: BigDecimal) extends SamplingMethod
 case class BlockSampling(probability: BigDecimal) extends SamplingMethod
 
 // TODO: (nfx) refactor to align more with catalyst
-case class TableSample(input: LogicalPlan, samplingMethod: SamplingMethod, seed: Option[BigDecimal]) extends UnaryNode {
+case class TableSample(input: LogicalPlan, samplingMethod: SamplingMethod, seed: Option[BigDecimal]) extends UnaryNode(origin = Origin.empty) {
   override def child: LogicalPlan = input
   override def output: Seq[Attribute] = input.output
 }
@@ -176,12 +176,12 @@ case class TableFunction(functionCall: Expression) extends LeafNode {
   override def output: Seq[Attribute] = Seq.empty
 }
 
-case class Lateral(expr: LogicalPlan, outer: Boolean = false, isView: Boolean = false) extends UnaryNode {
+case class Lateral(expr: LogicalPlan, outer: Boolean = false, isView: Boolean = false) extends UnaryNode(origin = Origin.empty) {
   override def child: LogicalPlan = expr
   override def output: Seq[Attribute] = expr.output
 }
 
-case class PlanComment(child: LogicalPlan, text: String) extends UnaryNode {
+case class PlanComment(child: LogicalPlan, text: String) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -195,7 +195,7 @@ case class Options(
   override def dataType: DataType = UnresolvedType
 }
 
-case class WithOptions(input: LogicalPlan, options: Expression) extends UnaryNode {
+case class WithOptions(input: LogicalPlan, options: Expression) extends UnaryNode(origin = Origin.empty) {
   override def child: LogicalPlan = input
   override def output: Seq[Attribute] = input.output
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/extensions.scala
@@ -26,7 +26,7 @@ case object Noop extends LeafExpression {
   override def dataType: DataType = UnresolvedType
 }
 
-case object NoopNode extends LeafNode {
+case object NoopNode extends LeafNode()() {
   override def output: Seq[Attribute] = Seq.empty
 }
 
@@ -54,11 +54,11 @@ case class Assign(left: Expression, right: Expression) extends Binary(left, righ
 }
 
 // Some statements, such as SELECT, do not require a table specification
-case class NoTable() extends LeafNode {
+case class NoTable() extends LeafNode()() {
   override def output: Seq[Attribute] = Seq.empty
 }
 
-case class LocalVarTable(id: Id) extends LeafNode {
+case class LocalVarTable(id: Id) extends LeafNode()() {
   override def output: Seq[Attribute] = Seq.empty
 }
 
@@ -73,17 +73,18 @@ case class ForceSeekHint(index: Option[Expression], indexColumns: Option[Seq[Exp
 
 // It was not clear whether the NamedTable options should be used for the alias. I'm assuming it is not what
 // they are for.
-case class TableAlias(child: LogicalPlan, alias: String, columns: Seq[Id] = Seq.empty) extends UnaryNode(origin = Origin.empty) {
+case class TableAlias(child: LogicalPlan, alias: String, columns: Seq[Id] = Seq.empty)
+  extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = columns.map(c => AttributeReference(c.id, StringType))
 }
 
 // TODO: (nfx) refactor to align more with catalyst
 // TODO: remove this and replace with Hint(Hint(...), ...)
-case class TableWithHints(child: LogicalPlan, hints: Seq[TableHint]) extends UnaryNode(origin = Origin.empty) {
+case class TableWithHints(child: LogicalPlan, hints: Seq[TableHint]) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class Batch(children: Seq[LogicalPlan]) extends LogicalPlan(origin = Origin.empty) {
+case class Batch(children: Seq[LogicalPlan]) extends LogicalPlan()(Origin.empty) {
   override def output: Seq[Attribute] = children.lastOption.map(_.output).getOrElse(Seq()).toSeq
 }
 
@@ -104,7 +105,7 @@ case class CreateInlineUDF(
     acceptsNullParameters: Boolean,
     comment: Option[String],
     body: String)
-    extends Catalog {}
+    extends Catalog()() {}
 
 // Used for raw expressions that have no context
 case class Dot(left: Expression, right: Expression) extends Binary(left, right) {
@@ -137,7 +138,7 @@ case class RowSamplingFixedAmount(amount: BigDecimal) extends SamplingMethod
 case class BlockSampling(probability: BigDecimal) extends SamplingMethod
 
 // TODO: (nfx) refactor to align more with catalyst
-case class TableSample(input: LogicalPlan, samplingMethod: SamplingMethod, seed: Option[BigDecimal]) extends UnaryNode(origin = Origin.empty) {
+case class TableSample(input: LogicalPlan, samplingMethod: SamplingMethod, seed: Option[BigDecimal]) extends UnaryNode()(Origin.empty) {
   override def child: LogicalPlan = input
   override def output: Seq[Attribute] = input.output
 }
@@ -172,16 +173,17 @@ case object OuterApply extends JoinType
 
 // TODO: fix
 // @see https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-qry-select-tvf.html
-case class TableFunction(functionCall: Expression) extends LeafNode {
+case class TableFunction(functionCall: Expression) extends LeafNode()() {
   override def output: Seq[Attribute] = Seq.empty
 }
 
-case class Lateral(expr: LogicalPlan, outer: Boolean = false, isView: Boolean = false) extends UnaryNode(origin = Origin.empty) {
+case class Lateral(expr: LogicalPlan, outer: Boolean = false, isView: Boolean = false)
+  extends UnaryNode()(Origin.empty) {
   override def child: LogicalPlan = expr
   override def output: Seq[Attribute] = expr.output
 }
 
-case class PlanComment(child: LogicalPlan, text: String) extends UnaryNode(origin = Origin.empty) {
+case class PlanComment(child: LogicalPlan, text: String) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -195,7 +197,7 @@ case class Options(
   override def dataType: DataType = UnresolvedType
 }
 
-case class WithOptions(input: LogicalPlan, options: Expression) extends UnaryNode(origin = Origin.empty) {
+case class WithOptions(input: LogicalPlan, options: Expression) extends UnaryNode()(Origin.empty) {
   override def child: LogicalPlan = input
   override def output: Seq[Attribute] = input.output
 }
@@ -218,7 +220,7 @@ case class CreateTableParams(
     indices: Seq[Constraint], // Index Definitions (currently all unresolved)
     partition: Option[String], // Partitioning information but unsupported
     options: Option[Seq[GenericOption]] // Command level options
-) extends Catalog
+) extends Catalog()()
 
 // Though at least TSQL only needs the time based intervals, we are including all the interval types
 // supported by Spark SQL for completeness and future proofing

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/extensions.scala
@@ -74,7 +74,7 @@ case class ForceSeekHint(index: Option[Expression], indexColumns: Option[Seq[Exp
 // It was not clear whether the NamedTable options should be used for the alias. I'm assuming it is not what
 // they are for.
 case class TableAlias(child: LogicalPlan, alias: String, columns: Seq[Id] = Seq.empty)
-  extends UnaryNode()(Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = columns.map(c => AttributeReference(c.id, StringType))
 }
 
@@ -138,7 +138,8 @@ case class RowSamplingFixedAmount(amount: BigDecimal) extends SamplingMethod
 case class BlockSampling(probability: BigDecimal) extends SamplingMethod
 
 // TODO: (nfx) refactor to align more with catalyst
-case class TableSample(input: LogicalPlan, samplingMethod: SamplingMethod, seed: Option[BigDecimal]) extends UnaryNode()(Origin.empty) {
+case class TableSample(input: LogicalPlan, samplingMethod: SamplingMethod, seed: Option[BigDecimal])
+    extends UnaryNode()(Origin.empty) {
   override def child: LogicalPlan = input
   override def output: Seq[Attribute] = input.output
 }
@@ -178,7 +179,7 @@ case class TableFunction(functionCall: Expression) extends LeafNode()() {
 }
 
 case class Lateral(expr: LogicalPlan, outer: Boolean = false, isView: Boolean = false)
-  extends UnaryNode()(Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def child: LogicalPlan = expr
   override def output: Seq[Attribute] = expr.output
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/plans.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/plans.scala
@@ -80,9 +80,7 @@ abstract class Plan[PlanType <: Plan[PlanType]] extends TreeNode[PlanType] {
     var changed = false
 
     @inline def transformExpression(e: Expression): Expression = {
-      val newE = CurrentOrigin.withOrigin(e.origin) {
-        f(e)
-      }
+      val newE = f(e)
       if (newE.fastEquals(e)) {
         e
       } else {

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/plans.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/plans.scala
@@ -6,7 +6,7 @@ package com.databricks.labs.remorph.intermediate
  * the [[Command]] type that is used to execute commands on the server. [[Plan]] is a union of Spark's LogicalPlan and
  * QueryPlan.
  */
-abstract class Plan[PlanType <: Plan[PlanType]](origin: Origin) extends TreeNode[PlanType](origin) {
+abstract class Plan[PlanType <: Plan[PlanType]]()(origin: Origin) extends TreeNode[PlanType]()(origin) {
   self: PlanType =>
 
   def output: Seq[Attribute]
@@ -137,7 +137,7 @@ abstract class Plan[PlanType <: Plan[PlanType]](origin: Origin) extends TreeNode
   }
 }
 
-abstract class LogicalPlan(origin: Origin) extends Plan[LogicalPlan](origin) {
+abstract class LogicalPlan()(origin: Origin) extends Plan[LogicalPlan]()(origin) {
 
   /**
    * Returns true if this expression and all its children have been resolved to a specific schema and false if it still
@@ -164,17 +164,17 @@ abstract class LogicalPlan(origin: Origin) extends Plan[LogicalPlan](origin) {
 
 }
 
-abstract class LeafNode extends LogicalPlan(origin = Origin.empty) {
+abstract class LeafNode()(origin: Origin = Origin.empty) extends LogicalPlan()(origin) {
   override def children: Seq[LogicalPlan] = Nil
   override def producedAttributes: AttributeSet = outputSet
 }
 
-abstract class UnaryNode(origin: Origin) extends LogicalPlan(origin) {
+abstract class UnaryNode()(origin: Origin) extends LogicalPlan()(origin) {
   def child: LogicalPlan
   override def children: Seq[LogicalPlan] = child :: Nil
 }
 
-abstract class BinaryNode extends LogicalPlan(origin = Origin.empty) {
+abstract class BinaryNode extends LogicalPlan()(Origin.empty) {
   def left: LogicalPlan
   def right: LogicalPlan
   override def children: Seq[LogicalPlan] = Seq(left, right)

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/plans.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/plans.scala
@@ -6,7 +6,7 @@ package com.databricks.labs.remorph.intermediate
  * the [[Command]] type that is used to execute commands on the server. [[Plan]] is a union of Spark's LogicalPlan and
  * QueryPlan.
  */
-abstract class Plan[PlanType <: Plan[PlanType]] extends TreeNode[PlanType] {
+abstract class Plan[PlanType <: Plan[PlanType]](origin: Origin = Origin.empty) extends TreeNode[PlanType](origin) {
   self: PlanType =>
 
   def output: Seq[Attribute]

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/plans.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/plans.scala
@@ -6,7 +6,7 @@ package com.databricks.labs.remorph.intermediate
  * the [[Command]] type that is used to execute commands on the server. [[Plan]] is a union of Spark's LogicalPlan and
  * QueryPlan.
  */
-abstract class Plan[PlanType <: Plan[PlanType]](origin: Origin = Origin.empty) extends TreeNode[PlanType](origin) {
+abstract class Plan[PlanType <: Plan[PlanType]](origin: Origin) extends TreeNode[PlanType](origin) {
   self: PlanType =>
 
   def output: Seq[Attribute]
@@ -137,7 +137,7 @@ abstract class Plan[PlanType <: Plan[PlanType]](origin: Origin = Origin.empty) e
   }
 }
 
-abstract class LogicalPlan extends Plan[LogicalPlan] {
+abstract class LogicalPlan(origin: Origin) extends Plan[LogicalPlan](origin) {
 
   /**
    * Returns true if this expression and all its children have been resolved to a specific schema and false if it still
@@ -164,17 +164,17 @@ abstract class LogicalPlan extends Plan[LogicalPlan] {
 
 }
 
-abstract class LeafNode extends LogicalPlan {
+abstract class LeafNode extends LogicalPlan(origin = Origin.empty) {
   override def children: Seq[LogicalPlan] = Nil
   override def producedAttributes: AttributeSet = outputSet
 }
 
-abstract class UnaryNode extends LogicalPlan {
+abstract class UnaryNode(origin: Origin) extends LogicalPlan(origin) {
   def child: LogicalPlan
   override def children: Seq[LogicalPlan] = child :: Nil
 }
 
-abstract class BinaryNode extends LogicalPlan {
+abstract class BinaryNode extends LogicalPlan(origin = Origin.empty) {
   def left: LogicalPlan
   def right: LogicalPlan
   override def children: Seq[LogicalPlan] = Seq(left, right)

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/procedures/SetVariable.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/procedures/SetVariable.scala
@@ -2,4 +2,4 @@ package com.databricks.labs.remorph.intermediate.procedures
 
 import com.databricks.labs.remorph.intermediate._
 
-case class SetVariable(name: Id, value: Expression, dataType: Option[DataType] = None) extends LeafNode with Command
+case class SetVariable(name: Id, value: Expression, dataType: Option[DataType] = None) extends LeafNode()() with Command

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/procedures/Statement.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/procedures/Statement.scala
@@ -2,4 +2,4 @@ package com.databricks.labs.remorph.intermediate.procedures
 
 import com.databricks.labs.remorph.intermediate.{Command, LogicalPlan, Origin}
 
-abstract class Statement extends LogicalPlan(origin = Origin.empty) with Command
+abstract class Statement extends LogicalPlan()(Origin.empty) with Command

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/procedures/Statement.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/procedures/Statement.scala
@@ -1,5 +1,5 @@
 package com.databricks.labs.remorph.intermediate.procedures
 
-import com.databricks.labs.remorph.intermediate.{Command, LogicalPlan}
+import com.databricks.labs.remorph.intermediate.{Command, LogicalPlan, Origin}
 
-abstract class Statement extends LogicalPlan with Command
+abstract class Statement extends LogicalPlan(origin = Origin.empty) with Command

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/relations.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/relations.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.remorph.intermediate
 
-abstract class Relation extends LogicalPlan
+abstract class Relation extends LogicalPlan(origin = Origin.empty)
 
 abstract class RelationCommon extends Relation {}
 
@@ -29,7 +29,7 @@ case class DataSource(
   override def output: Seq[Attribute] = Seq.empty
 }
 
-case class Project(input: LogicalPlan, columns: Seq[Expression]) extends UnaryNode {
+case class Project(input: LogicalPlan, columns: Seq[Expression], origin: Origin) extends UnaryNode(origin) {
   override def child: LogicalPlan = input
   // TODO: add resolver for Star
   override def output: Seq[Attribute] = expressions.map {
@@ -41,7 +41,7 @@ case class Project(input: LogicalPlan, columns: Seq[Expression]) extends UnaryNo
   }
 }
 
-case class Filter(input: LogicalPlan, condition: Expression) extends UnaryNode {
+case class Filter(input: LogicalPlan, condition: Expression) extends UnaryNode(origin = Origin.empty) {
   override def child: LogicalPlan = input
   override def output: Seq[Attribute] = input.output
 }
@@ -78,15 +78,15 @@ case class SetOperation(
   override def output: Seq[Attribute] = left.output ++ right.output
 }
 
-case class Limit(child: LogicalPlan, limit: Expression) extends UnaryNode {
+case class Limit(child: LogicalPlan, limit: Expression) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class Offset(child: LogicalPlan, offset: Expression) extends UnaryNode {
+case class Offset(child: LogicalPlan, offset: Expression) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class Tail(child: LogicalPlan, limit: Int) extends UnaryNode {
+case class Tail(child: LogicalPlan, limit: Int) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -97,7 +97,7 @@ case class Aggregate(
     group_type: GroupType,
     grouping_expressions: Seq[Expression],
     pivot: Option[Pivot])
-    extends UnaryNode {
+    extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output ++ grouping_expressions.map(_.asInstanceOf[Attribute])
 }
 
@@ -119,11 +119,11 @@ case class SortOrder(
   override def dataType: DataType = child.dataType
 }
 
-case class Sort(child: LogicalPlan, order: Seq[SortOrder], is_global: Boolean = false) extends UnaryNode {
+case class Sort(child: LogicalPlan, order: Seq[SortOrder], is_global: Boolean = false) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class Drop(child: LogicalPlan, columns: Seq[Expression], column_names: Seq[String]) extends UnaryNode {
+case class Drop(child: LogicalPlan, columns: Seq[Expression], column_names: Seq[String]) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output diff columns.map(_.asInstanceOf[Attribute])
 }
 
@@ -132,11 +132,11 @@ case class Deduplicate(
     column_names: Seq[Expression],
     all_columns_as_keys: Boolean,
     within_watermark: Boolean)
-    extends UnaryNode {
+    extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class LocalRelation(child: LogicalPlan, data: Array[Byte], schemaString: String) extends UnaryNode {
+case class LocalRelation(child: LogicalPlan, data: Array[Byte], schemaString: String) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -155,7 +155,7 @@ case class Sample(
     with_replacement: Boolean,
     seed: Long,
     deterministic_order: Boolean)
-    extends UnaryNode {
+    extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -164,88 +164,88 @@ case class Range(start: Long, end: Long, step: Long, num_partitions: Int) extend
 }
 
 // TODO: most likely has to be SubqueryAlias(identifier: AliasIdentifier, child: LogicalPlan)
-case class SubqueryAlias(child: LogicalPlan, alias: Id, columnNames: Seq[Id] = Seq.empty) extends UnaryNode {
+case class SubqueryAlias(child: LogicalPlan, alias: Id, columnNames: Seq[Id] = Seq.empty) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class Repartition(child: LogicalPlan, num_partitions: Int, shuffle: Boolean) extends UnaryNode {
+case class Repartition(child: LogicalPlan, num_partitions: Int, shuffle: Boolean) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class ShowString(child: LogicalPlan, num_rows: Int, truncate: Int, vertical: Boolean) extends UnaryNode {
+case class ShowString(child: LogicalPlan, num_rows: Int, truncate: Int, vertical: Boolean) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class HtmlString(child: LogicalPlan, num_rows: Int, truncate: Int) extends UnaryNode {
+case class HtmlString(child: LogicalPlan, num_rows: Int, truncate: Int) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatSummary(child: LogicalPlan, statistics: Seq[String]) extends UnaryNode {
+case class StatSummary(child: LogicalPlan, statistics: Seq[String]) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatDescribe(child: LogicalPlan, cols: Seq[String]) extends UnaryNode {
+case class StatDescribe(child: LogicalPlan, cols: Seq[String]) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatCrosstab(child: LogicalPlan, col1: String, col2: String) extends UnaryNode {
+case class StatCrosstab(child: LogicalPlan, col1: String, col2: String) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatCov(child: LogicalPlan, col1: String, col2: String) extends UnaryNode {
+case class StatCov(child: LogicalPlan, col1: String, col2: String) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatCorr(child: LogicalPlan, col1: String, col2: String, method: String) extends UnaryNode {
+case class StatCorr(child: LogicalPlan, col1: String, col2: String, method: String) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
 case class StatApproxQuantile(child: LogicalPlan, cols: Seq[String], probabilities: Seq[Double], relative_error: Double)
-    extends UnaryNode {
+    extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatFreqItems(child: LogicalPlan, cols: Seq[String], support: Double) extends UnaryNode {
+case class StatFreqItems(child: LogicalPlan, cols: Seq[String], support: Double) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
 case class Fraction(stratum: Literal, fraction: Double)
 
-case class StatSampleBy(child: LogicalPlan, col: Expression, fractions: Seq[Fraction], seed: Long) extends UnaryNode {
+case class StatSampleBy(child: LogicalPlan, col: Expression, fractions: Seq[Fraction], seed: Long) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class NAFill(child: LogicalPlan, cols: Seq[String], values: Seq[Literal]) extends UnaryNode {
+case class NAFill(child: LogicalPlan, cols: Seq[String], values: Seq[Literal]) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class NADrop(child: LogicalPlan, cols: Seq[String], min_non_nulls: Int) extends UnaryNode {
+case class NADrop(child: LogicalPlan, cols: Seq[String], min_non_nulls: Int) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
 case class Replacement(old_value: Literal, new_value: Literal)
 
-case class NAReplace(child: LogicalPlan, cols: Seq[String], replacements: Seq[Replacement]) extends UnaryNode {
+case class NAReplace(child: LogicalPlan, cols: Seq[String], replacements: Seq[Replacement]) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class ToDF(child: LogicalPlan, column_names: Seq[String]) extends UnaryNode {
+case class ToDF(child: LogicalPlan, column_names: Seq[String]) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class WithColumnsRenamed(child: LogicalPlan, rename_columns_map: Map[String, String]) extends UnaryNode {
+case class WithColumnsRenamed(child: LogicalPlan, rename_columns_map: Map[String, String]) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class WithColumns(child: LogicalPlan, aliases: Seq[Alias]) extends UnaryNode {
+case class WithColumns(child: LogicalPlan, aliases: Seq[Alias]) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class WithWatermark(child: LogicalPlan, event_time: String, delay_threshold: String) extends UnaryNode {
+case class WithWatermark(child: LogicalPlan, event_time: String, delay_threshold: String) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class Hint(child: LogicalPlan, name: String, parameters: Seq[Expression]) extends UnaryNode {
+case class Hint(child: LogicalPlan, name: String, parameters: Seq[Expression]) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -259,21 +259,21 @@ case class Unpivot(
     values: Option[Values],
     variable_column_name: Id,
     value_column_name: Id)
-    extends UnaryNode {
+    extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class ToSchema(child: LogicalPlan, dataType: DataType) extends UnaryNode {
+case class ToSchema(child: LogicalPlan, dataType: DataType) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
 case class RepartitionByExpression(child: LogicalPlan, partition_exprs: Seq[Expression], num_partitions: Int)
-    extends UnaryNode {
+    extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
 case class MapPartitions(child: LogicalPlan, func: CommonInlineUserDefinedTableFunction, is_barrier: Boolean)
-    extends UnaryNode {
+    extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -287,7 +287,7 @@ case class GroupMap(
     is_map_groups_with_state: Boolean,
     output_mode: String,
     timeout_conf: String)
-    extends UnaryNode {
+    extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -311,7 +311,7 @@ case class ApplyInPandasWithState(
     state_schema: String,
     output_mode: String,
     timeout_conf: String)
-    extends UnaryNode {
+    extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -326,13 +326,13 @@ case class CommonInlineUserDefinedTableFunction(
   override def output: Seq[Attribute] = Seq.empty
 }
 
-case class CollectMetrics(child: LogicalPlan, name: String, metrics: Seq[Expression]) extends UnaryNode {
+case class CollectMetrics(child: LogicalPlan, name: String, metrics: Seq[Expression]) extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 
 }
 
 case class Parse(child: LogicalPlan, format: ParseFormat, dataType: DataType, options: Map[String, String])
-    extends UnaryNode {
+    extends UnaryNode(origin = Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/relations.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/relations.scala
@@ -120,12 +120,12 @@ case class SortOrder(
 }
 
 case class Sort(child: LogicalPlan, order: Seq[SortOrder], is_global: Boolean = false)
-  extends UnaryNode()(Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
 case class Drop(child: LogicalPlan, columns: Seq[Expression], column_names: Seq[String])
-  extends UnaryNode()(Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output diff columns.map(_.asInstanceOf[Attribute])
 }
 
@@ -138,7 +138,8 @@ case class Deduplicate(
   override def output: Seq[Attribute] = child.output
 }
 
-case class LocalRelation(child: LogicalPlan, data: Array[Byte], schemaString: String) extends UnaryNode()(Origin.empty) {
+case class LocalRelation(child: LogicalPlan, data: Array[Byte], schemaString: String)
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -167,47 +168,40 @@ case class Range(start: Long, end: Long, step: Long, num_partitions: Int) extend
 
 // TODO: most likely has to be SubqueryAlias(identifier: AliasIdentifier, child: LogicalPlan)
 case class SubqueryAlias(child: LogicalPlan, alias: Id, columnNames: Seq[Id] = Seq.empty)
-  extends UnaryNode()(Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class Repartition(child: LogicalPlan, num_partitions: Int, shuffle: Boolean)
-  extends UnaryNode()(Origin.empty) {
+case class Repartition(child: LogicalPlan, num_partitions: Int, shuffle: Boolean) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
 case class ShowString(child: LogicalPlan, num_rows: Int, truncate: Int, vertical: Boolean)
-  extends UnaryNode()(Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class HtmlString(child: LogicalPlan, num_rows: Int, truncate: Int)
-  extends UnaryNode()(Origin.empty) {
+case class HtmlString(child: LogicalPlan, num_rows: Int, truncate: Int) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatSummary(child: LogicalPlan, statistics: Seq[String])
-  extends UnaryNode()(Origin.empty) {
+case class StatSummary(child: LogicalPlan, statistics: Seq[String]) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatDescribe(child: LogicalPlan, cols: Seq[String])
-  extends UnaryNode()(Origin.empty) {
+case class StatDescribe(child: LogicalPlan, cols: Seq[String]) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatCrosstab(child: LogicalPlan, col1: String, col2: String)
-  extends UnaryNode()(Origin.empty) {
+case class StatCrosstab(child: LogicalPlan, col1: String, col2: String) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatCov(child: LogicalPlan, col1: String, col2: String)
-  extends UnaryNode()(Origin.empty) {
+case class StatCov(child: LogicalPlan, col1: String, col2: String) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatCorr(child: LogicalPlan, col1: String, col2: String, method: String)
-  extends UnaryNode()(Origin.empty) {
+case class StatCorr(child: LogicalPlan, col1: String, col2: String, method: String) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -216,15 +210,14 @@ case class StatApproxQuantile(child: LogicalPlan, cols: Seq[String], probabiliti
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatFreqItems(child: LogicalPlan, cols: Seq[String], support: Double)
-  extends UnaryNode()(Origin.empty) {
+case class StatFreqItems(child: LogicalPlan, cols: Seq[String], support: Double) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
 case class Fraction(stratum: Literal, fraction: Double)
 
 case class StatSampleBy(child: LogicalPlan, col: Expression, fractions: Seq[Fraction], seed: Long)
-  extends UnaryNode()(Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -238,7 +231,8 @@ case class NADrop(child: LogicalPlan, cols: Seq[String], min_non_nulls: Int) ext
 
 case class Replacement(old_value: Literal, new_value: Literal)
 
-case class NAReplace(child: LogicalPlan, cols: Seq[String], replacements: Seq[Replacement]) extends UnaryNode()(Origin.empty) {
+case class NAReplace(child: LogicalPlan, cols: Seq[String], replacements: Seq[Replacement])
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -246,7 +240,8 @@ case class ToDF(child: LogicalPlan, column_names: Seq[String]) extends UnaryNode
   override def output: Seq[Attribute] = child.output
 }
 
-case class WithColumnsRenamed(child: LogicalPlan, rename_columns_map: Map[String, String]) extends UnaryNode()(Origin.empty) {
+case class WithColumnsRenamed(child: LogicalPlan, rename_columns_map: Map[String, String])
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -254,7 +249,8 @@ case class WithColumns(child: LogicalPlan, aliases: Seq[Alias]) extends UnaryNod
   override def output: Seq[Attribute] = child.output
 }
 
-case class WithWatermark(child: LogicalPlan, event_time: String, delay_threshold: String) extends UnaryNode()(Origin.empty) {
+case class WithWatermark(child: LogicalPlan, event_time: String, delay_threshold: String)
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -340,7 +336,7 @@ case class CommonInlineUserDefinedTableFunction(
 }
 
 case class CollectMetrics(child: LogicalPlan, name: String, metrics: Seq[Expression])
-  extends UnaryNode()(Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/relations.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/relations.scala
@@ -1,15 +1,15 @@
 package com.databricks.labs.remorph.intermediate
 
-abstract class Relation extends LogicalPlan(origin = Origin.empty)
+abstract class Relation extends LogicalPlan()(Origin.empty)
 
 abstract class RelationCommon extends Relation {}
 
 case class SQL(query: String, named_arguments: Map[String, Expression], pos_arguments: Seq[Expression])
-    extends LeafNode {
+    extends LeafNode()(Origin.empty) {
   override def output: Seq[Attribute] = Seq.empty
 }
 
-abstract class Read(is_streaming: Boolean) extends LeafNode
+abstract class Read(is_streaming: Boolean) extends LeafNode()(Origin.empty)
 
 // TODO: replace it with TableIdentifier with catalog and schema filled
 // TODO: replace most (if not all) occurrences with UnresolvedRelation
@@ -29,7 +29,7 @@ case class DataSource(
   override def output: Seq[Attribute] = Seq.empty
 }
 
-case class Project(input: LogicalPlan, columns: Seq[Expression], origin: Origin) extends UnaryNode(origin) {
+case class Project(input: LogicalPlan, columns: Seq[Expression])(origin: Origin) extends UnaryNode()(origin) {
   override def child: LogicalPlan = input
   // TODO: add resolver for Star
   override def output: Seq[Attribute] = expressions.map {
@@ -41,7 +41,7 @@ case class Project(input: LogicalPlan, columns: Seq[Expression], origin: Origin)
   }
 }
 
-case class Filter(input: LogicalPlan, condition: Expression) extends UnaryNode(origin = Origin.empty) {
+case class Filter(input: LogicalPlan, condition: Expression) extends UnaryNode()(Origin.empty) {
   override def child: LogicalPlan = input
   override def output: Seq[Attribute] = input.output
 }
@@ -78,15 +78,15 @@ case class SetOperation(
   override def output: Seq[Attribute] = left.output ++ right.output
 }
 
-case class Limit(child: LogicalPlan, limit: Expression) extends UnaryNode(origin = Origin.empty) {
+case class Limit(child: LogicalPlan, limit: Expression) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class Offset(child: LogicalPlan, offset: Expression) extends UnaryNode(origin = Origin.empty) {
+case class Offset(child: LogicalPlan, offset: Expression) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class Tail(child: LogicalPlan, limit: Int) extends UnaryNode(origin = Origin.empty) {
+case class Tail(child: LogicalPlan, limit: Int) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -97,7 +97,7 @@ case class Aggregate(
     group_type: GroupType,
     grouping_expressions: Seq[Expression],
     pivot: Option[Pivot])
-    extends UnaryNode(origin = Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output ++ grouping_expressions.map(_.asInstanceOf[Attribute])
 }
 
@@ -119,11 +119,13 @@ case class SortOrder(
   override def dataType: DataType = child.dataType
 }
 
-case class Sort(child: LogicalPlan, order: Seq[SortOrder], is_global: Boolean = false) extends UnaryNode(origin = Origin.empty) {
+case class Sort(child: LogicalPlan, order: Seq[SortOrder], is_global: Boolean = false)
+  extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class Drop(child: LogicalPlan, columns: Seq[Expression], column_names: Seq[String]) extends UnaryNode(origin = Origin.empty) {
+case class Drop(child: LogicalPlan, columns: Seq[Expression], column_names: Seq[String])
+  extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output diff columns.map(_.asInstanceOf[Attribute])
 }
 
@@ -132,19 +134,19 @@ case class Deduplicate(
     column_names: Seq[Expression],
     all_columns_as_keys: Boolean,
     within_watermark: Boolean)
-    extends UnaryNode(origin = Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class LocalRelation(child: LogicalPlan, data: Array[Byte], schemaString: String) extends UnaryNode(origin = Origin.empty) {
+case class LocalRelation(child: LogicalPlan, data: Array[Byte], schemaString: String) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class CachedLocalRelation(hash: String) extends LeafNode {
+case class CachedLocalRelation(hash: String) extends LeafNode()() {
   override def output: Seq[Attribute] = Seq.empty
 }
 
-case class CachedRemoteRelation(relation_id: String) extends LeafNode {
+case class CachedRemoteRelation(relation_id: String) extends LeafNode()() {
   override def output: Seq[Attribute] = Seq.empty
 }
 
@@ -155,101 +157,112 @@ case class Sample(
     with_replacement: Boolean,
     seed: Long,
     deterministic_order: Boolean)
-    extends UnaryNode(origin = Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class Range(start: Long, end: Long, step: Long, num_partitions: Int) extends LeafNode {
+case class Range(start: Long, end: Long, step: Long, num_partitions: Int) extends LeafNode()() {
   override def output: Seq[Attribute] = Seq(AttributeReference("id", LongType))
 }
 
 // TODO: most likely has to be SubqueryAlias(identifier: AliasIdentifier, child: LogicalPlan)
-case class SubqueryAlias(child: LogicalPlan, alias: Id, columnNames: Seq[Id] = Seq.empty) extends UnaryNode(origin = Origin.empty) {
+case class SubqueryAlias(child: LogicalPlan, alias: Id, columnNames: Seq[Id] = Seq.empty)
+  extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class Repartition(child: LogicalPlan, num_partitions: Int, shuffle: Boolean) extends UnaryNode(origin = Origin.empty) {
+case class Repartition(child: LogicalPlan, num_partitions: Int, shuffle: Boolean)
+  extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class ShowString(child: LogicalPlan, num_rows: Int, truncate: Int, vertical: Boolean) extends UnaryNode(origin = Origin.empty) {
+case class ShowString(child: LogicalPlan, num_rows: Int, truncate: Int, vertical: Boolean)
+  extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class HtmlString(child: LogicalPlan, num_rows: Int, truncate: Int) extends UnaryNode(origin = Origin.empty) {
+case class HtmlString(child: LogicalPlan, num_rows: Int, truncate: Int)
+  extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatSummary(child: LogicalPlan, statistics: Seq[String]) extends UnaryNode(origin = Origin.empty) {
+case class StatSummary(child: LogicalPlan, statistics: Seq[String])
+  extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatDescribe(child: LogicalPlan, cols: Seq[String]) extends UnaryNode(origin = Origin.empty) {
+case class StatDescribe(child: LogicalPlan, cols: Seq[String])
+  extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatCrosstab(child: LogicalPlan, col1: String, col2: String) extends UnaryNode(origin = Origin.empty) {
+case class StatCrosstab(child: LogicalPlan, col1: String, col2: String)
+  extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatCov(child: LogicalPlan, col1: String, col2: String) extends UnaryNode(origin = Origin.empty) {
+case class StatCov(child: LogicalPlan, col1: String, col2: String)
+  extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatCorr(child: LogicalPlan, col1: String, col2: String, method: String) extends UnaryNode(origin = Origin.empty) {
+case class StatCorr(child: LogicalPlan, col1: String, col2: String, method: String)
+  extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
 case class StatApproxQuantile(child: LogicalPlan, cols: Seq[String], probabilities: Seq[Double], relative_error: Double)
-    extends UnaryNode(origin = Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class StatFreqItems(child: LogicalPlan, cols: Seq[String], support: Double) extends UnaryNode(origin = Origin.empty) {
+case class StatFreqItems(child: LogicalPlan, cols: Seq[String], support: Double)
+  extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
 case class Fraction(stratum: Literal, fraction: Double)
 
-case class StatSampleBy(child: LogicalPlan, col: Expression, fractions: Seq[Fraction], seed: Long) extends UnaryNode(origin = Origin.empty) {
+case class StatSampleBy(child: LogicalPlan, col: Expression, fractions: Seq[Fraction], seed: Long)
+  extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class NAFill(child: LogicalPlan, cols: Seq[String], values: Seq[Literal]) extends UnaryNode(origin = Origin.empty) {
+case class NAFill(child: LogicalPlan, cols: Seq[String], values: Seq[Literal]) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class NADrop(child: LogicalPlan, cols: Seq[String], min_non_nulls: Int) extends UnaryNode(origin = Origin.empty) {
+case class NADrop(child: LogicalPlan, cols: Seq[String], min_non_nulls: Int) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
 case class Replacement(old_value: Literal, new_value: Literal)
 
-case class NAReplace(child: LogicalPlan, cols: Seq[String], replacements: Seq[Replacement]) extends UnaryNode(origin = Origin.empty) {
+case class NAReplace(child: LogicalPlan, cols: Seq[String], replacements: Seq[Replacement]) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class ToDF(child: LogicalPlan, column_names: Seq[String]) extends UnaryNode(origin = Origin.empty) {
+case class ToDF(child: LogicalPlan, column_names: Seq[String]) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class WithColumnsRenamed(child: LogicalPlan, rename_columns_map: Map[String, String]) extends UnaryNode(origin = Origin.empty) {
+case class WithColumnsRenamed(child: LogicalPlan, rename_columns_map: Map[String, String]) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class WithColumns(child: LogicalPlan, aliases: Seq[Alias]) extends UnaryNode(origin = Origin.empty) {
+case class WithColumns(child: LogicalPlan, aliases: Seq[Alias]) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class WithWatermark(child: LogicalPlan, event_time: String, delay_threshold: String) extends UnaryNode(origin = Origin.empty) {
+case class WithWatermark(child: LogicalPlan, event_time: String, delay_threshold: String) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class Hint(child: LogicalPlan, name: String, parameters: Seq[Expression]) extends UnaryNode(origin = Origin.empty) {
+case class Hint(child: LogicalPlan, name: String, parameters: Seq[Expression]) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class Values(values: Seq[Seq[Expression]]) extends LeafNode { // TODO: fix it
+case class Values(values: Seq[Seq[Expression]]) extends LeafNode()() { // TODO: fix it
   override def output: Seq[Attribute] = Seq.empty
 }
 
@@ -259,21 +272,21 @@ case class Unpivot(
     values: Option[Values],
     variable_column_name: Id,
     value_column_name: Id)
-    extends UnaryNode(origin = Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
-case class ToSchema(child: LogicalPlan, dataType: DataType) extends UnaryNode(origin = Origin.empty) {
+case class ToSchema(child: LogicalPlan, dataType: DataType) extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
 case class RepartitionByExpression(child: LogicalPlan, partition_exprs: Seq[Expression], num_partitions: Int)
-    extends UnaryNode(origin = Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
 case class MapPartitions(child: LogicalPlan, func: CommonInlineUserDefinedTableFunction, is_barrier: Boolean)
-    extends UnaryNode(origin = Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -287,7 +300,7 @@ case class GroupMap(
     is_map_groups_with_state: Boolean,
     output_mode: String,
     timeout_conf: String)
-    extends UnaryNode(origin = Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -311,7 +324,7 @@ case class ApplyInPandasWithState(
     state_schema: String,
     output_mode: String,
     timeout_conf: String)
-    extends UnaryNode(origin = Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -322,17 +335,18 @@ case class CommonInlineUserDefinedTableFunction(
     deterministic: Boolean,
     arguments: Seq[Expression],
     python_udtf: Option[PythonUDTF])
-    extends LeafNode {
+    extends LeafNode()() {
   override def output: Seq[Attribute] = Seq.empty
 }
 
-case class CollectMetrics(child: LogicalPlan, name: String, metrics: Seq[Expression]) extends UnaryNode(origin = Origin.empty) {
+case class CollectMetrics(child: LogicalPlan, name: String, metrics: Seq[Expression])
+  extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 
 }
 
 case class Parse(child: LogicalPlan, format: ParseFormat, dataType: DataType, options: Map[String, String])
-    extends UnaryNode(origin = Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -351,7 +365,7 @@ case class AsOfJoin(
   override def output: Seq[Attribute] = left.output ++ right.output
 }
 
-case class Unknown() extends LeafNode {
+case class Unknown() extends LeafNode()() {
   override def output: Seq[Attribute] = Seq.empty
 }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/trees.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/trees.scala
@@ -272,8 +272,8 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]](@JsonIgnore origin: Orig
       .getOrElse(ctors.maxBy(_.getParameterTypes.length)) // fall back to older heuristic
 
     try {
-       val res = defaultCtor.newInstance(allArgs.toArray: _*).asInstanceOf[BaseType]
-        res
+      val res = defaultCtor.newInstance(allArgs.toArray: _*).asInstanceOf[BaseType]
+      res
     } catch {
       case e: java.lang.IllegalArgumentException =>
         throw new TreeNodeException(

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/trees.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/trees.scala
@@ -260,8 +260,8 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]()(val origin: Origin) ex
     val (defaultCtor, allArgs) = locateConstructor(ctors, newArgs, appendOrigin = false)
 
     try {
-       val res = defaultCtor.newInstance(allArgs.toArray: _*).asInstanceOf[BaseType]
-       res
+      val res = defaultCtor.newInstance(allArgs.toArray: _*).asInstanceOf[BaseType]
+      res
     } catch {
       case e: java.lang.IllegalArgumentException =>
         throw new TreeNodeException(
@@ -279,15 +279,14 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]()(val origin: Origin) ex
 
   @tailrec
   private def locateConstructor(
-         ctors: Array[Constructor[_]],
-         newArgs: Array[AnyRef],
-         appendOrigin: Boolean
-   ): (Constructor[_], Array[AnyRef]) = {
+      ctors: Array[Constructor[_]],
+      newArgs: Array[AnyRef],
+      appendOrigin: Boolean): (Constructor[_], Array[AnyRef]) = {
     var allArgs: Array[AnyRef] = if (otherCopyArgs.isEmpty) {
-        newArgs
-      } else {
-        newArgs ++ otherCopyArgs
-      }
+      newArgs
+    } else {
+      newArgs ++ otherCopyArgs
+    }
     allArgs = if (appendOrigin) {
       allArgs ++ Array(Origin.empty)
     } else {

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/unresolved.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/unresolved.scala
@@ -122,8 +122,7 @@ case class UnresolvedCommand(
     ruleText: String,
     message: String,
     ruleName: String = "rule name undetermined",
-    tokenName: Option[String] = None)
-    (origin: Origin)
+    tokenName: Option[String] = None)(origin: Origin)
     extends Catalog()(origin)
     with Command
     with UnwantedInGeneratorInput

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/unresolved.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/unresolved.scala
@@ -15,7 +15,7 @@ case class UnresolvedRelation(
     message: String = "",
     ruleName: String = "rule name undetermined",
     tokenName: Option[String] = None)
-    extends LeafNode
+    extends LeafNode()()
     with UnwantedInGeneratorInput
     with Unresolved[UnresolvedRelation] {
   override def output: Seq[Attribute] = Seq.empty
@@ -123,7 +123,8 @@ case class UnresolvedCommand(
     message: String,
     ruleName: String = "rule name undetermined",
     tokenName: Option[String] = None)
-    extends Catalog
+    (origin: Origin)
+    extends Catalog()(origin)
     with Command
     with UnwantedInGeneratorInput
     with Unresolved[UnresolvedCommand] {
@@ -131,7 +132,7 @@ case class UnresolvedCommand(
   override def children: Seq[LogicalPlan] = Seq.empty
 
   override def annotate(newRuleName: String, newTokenName: Option[String]): UnresolvedCommand =
-    copy(ruleName = newRuleName, tokenName = newTokenName)
+    copy(ruleName = newRuleName, tokenName = newTokenName)(origin = origin)
 }
 
 case class UnresolvedCatalog(
@@ -139,7 +140,7 @@ case class UnresolvedCatalog(
     message: String,
     ruleName: String = "rule name undetermined",
     tokenName: Option[String] = None)
-    extends Catalog
+    extends Catalog()()
     with UnwantedInGeneratorInput
     with Unresolved[UnresolvedCatalog] {
   override def output: Seq[Attribute] = Seq.empty
@@ -154,7 +155,7 @@ case class UnresolvedCTAS(
     message: String,
     ruleName: String = "rule name undetermined",
     tokenName: Option[String] = None)
-    extends Catalog
+    extends Catalog()()
     with Command
     with UnwantedInGeneratorInput
     with Unresolved[UnresolvedCTAS] {

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/workflows/JobNode.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/workflows/JobNode.scala
@@ -1,8 +1,8 @@
 package com.databricks.labs.remorph.intermediate.workflows
 
-import com.databricks.labs.remorph.intermediate.TreeNode
+import com.databricks.labs.remorph.intermediate.{Origin, TreeNode}
 
-abstract class JobNode extends TreeNode[JobNode]
+abstract class JobNode(origin: Origin = Origin.empty) extends TreeNode[JobNode](origin)
 
 abstract class LeafJobNode extends JobNode {
   override def children: Seq[JobNode] = Seq()

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/workflows/JobNode.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/workflows/JobNode.scala
@@ -2,7 +2,7 @@ package com.databricks.labs.remorph.intermediate.workflows
 
 import com.databricks.labs.remorph.intermediate.{Origin, TreeNode}
 
-abstract class JobNode(origin: Origin = Origin.empty) extends TreeNode[JobNode](origin)
+abstract class JobNode(override val origin: Origin = Origin.empty) extends TreeNode[JobNode]()(origin)
 
 abstract class LeafJobNode extends JobNode {
   override def children: Seq[JobNode] = Seq()

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/PlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/PlanParser.scala
@@ -1,7 +1,7 @@
 package com.databricks.labs.remorph.parsers
 
-import com.databricks.labs.remorph.intermediate.{ParsingErrors, PlanGenerationFailure, TranspileFailure}
-import com.databricks.labs.remorph.{BuildingAst, KoResult, OkResult, Optimizing, Parsing, PartialResult, Transformation, TransformationConstructors, WorkflowStage, intermediate => ir}
+import com.databricks.labs.remorph.intermediate.TranspileFailure
+import com.databricks.labs.remorph.{BuildingAst, KoResult, Optimizing, Parsing, Transformation, TransformationConstructors, WorkflowStage, intermediate => ir}
 import org.antlr.v4.runtime._
 import org.json4s.jackson.Serialization
 import org.json4s.{Formats, NoTypeHints}
@@ -12,61 +12,11 @@ trait PlanParser[P <: Parser] extends TransformationConstructors {
 
   implicit val formats: Formats = Serialization.formats(NoTypeHints)
 
-  protected def createLexer(input: CharStream): Lexer
-  protected def createParser(stream: TokenStream): P
-  protected def createTree(parser: P): ParserRuleContext
-  protected def createPlan(tree: ParserRuleContext): ir.LogicalPlan
-  protected def addErrorStrategy(parser: P): Unit
+  def parseLogicalPlan(parsing: Parsing): Transformation[ir.LogicalPlan]
   def dialect: String
 
   // TODO: This is probably not where the optimizer should be as this is a Plan "Parser" - it is here for now
   protected def createOptimizer: ir.Rules[ir.LogicalPlan]
-
-  /**
-   * Parse the input source code into a Parse tree
-   * @param input The source code with filename
-   * @return Returns a parse tree on success otherwise a description of the errors
-   */
-  def parse(input: Parsing): Transformation[ParserRuleContext] = {
-    val inputString = CharStreams.fromString(input.source)
-    val lexer = createLexer(inputString)
-    val tokenStream = new CommonTokenStream(lexer)
-    val parser = createParser(tokenStream)
-    addErrorStrategy(parser)
-    val errListener = new ProductionErrorCollector(input.source, input.filename)
-    parser.removeErrorListeners()
-    parser.addErrorListener(errListener)
-
-    update { case _ =>
-      input
-    }.flatMap { _ =>
-      val tree = createTree(parser)
-      if (errListener.errorCount > 0) {
-        lift(PartialResult(tree, ParsingErrors(errListener.errors)))
-      } else {
-        lift(OkResult(tree))
-      }
-    }
-  }
-
-  /**
-   * Visit the parse tree and create a logical plan
-   * @param tree The parse tree
-   * @return Returns a logical plan on success otherwise a description of the errors
-   */
-  def visit(tree: ParserRuleContext): Transformation[ir.LogicalPlan] = {
-    update {
-      case p: Parsing => BuildingAst(tree, Some(p))
-      case _ => BuildingAst(tree)
-    }.flatMap { _ =>
-      try {
-        ok(createPlan(tree))
-      } catch {
-        case NonFatal(e) =>
-          lift(KoResult(stage = WorkflowStage.PLAN, PlanGenerationFailure(e)))
-      }
-    }
-  }
 
   // TODO: This is probably not where the optimizer should be as this is a Plan "Parser" - it is here for now
   /**

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
@@ -1,5 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
+import com.databricks.labs.remorph.intermediate.Origin
 import com.databricks.labs.remorph.parsers.ParserCommon
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser.{StringContext => _, _}
 import com.databricks.labs.remorph.{intermediate => ir}
@@ -58,7 +59,7 @@ class SnowflakeAstBuilder(override val vc: SnowflakeVisitorCoordinator)
               ruleText = contextText(ctx),
               ruleName = vc.ruleName(ctx),
               tokenName = Some(tokenName(ctx.getStart)),
-              message = "Unknown command in SnowflakeAstBuilder.visitSqlCommand")
+              message = "Unknown command in SnowflakeAstBuilder.visitSqlCommand")(Origin.fromParseRuleContext(ctx))
         }
     }
   }
@@ -138,6 +139,6 @@ class SnowflakeAstBuilder(override val vc: SnowflakeVisitorCoordinator)
       ruleText = contextText(ctx),
       ruleName = vc.ruleName(ctx),
       tokenName = Some(tokenName(ctx.getStart)),
-      message = "Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand")
+      message = "Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand")(Origin.fromParseRuleContext(ctx))
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilder.scala
@@ -20,6 +20,33 @@ class SnowflakeAstBuilder(override val vc: SnowflakeVisitorCoordinator)
     ir.UnresolvedRelation(ruleText = ruleText, message = message)
 
   // Concrete visitors
+  override def visit(tree: ParseTree): ir.LogicalPlan = {
+    CurrentOrigin.fromParseTree(tree)
+    val plan = super.visit(tree)
+    plan
+  }
+
+  override def visitChildren(node: RuleNode): ir.LogicalPlan = {
+    var result = this.defaultResult()
+    val n = node.getChildCount
+    var i = 0
+    while (i < n && this.shouldVisitNextChild(node, result)) {
+      val c = node.getChild(i)
+      CurrentOrigin.fromParseTree(c)
+      val childResult = c.accept(this)
+      result = this.aggregateResult(result, childResult)
+
+      i += 1
+    }
+    result
+  }
+
+  override def visitMany[R <: RuleContext](contexts: java.lang.Iterable[R]): Seq[ir.LogicalPlan] = {
+    contexts.asScala.map(ctx => {
+      CurrentOrigin.fromParseTree(ctx)
+      ctx.accept(this)
+    }).toSeq
+  }
 
   override def visitSnowflakeFile(ctx: SnowflakeFileContext): ir.LogicalPlan = {
     // This very top level visitor does not ignore any valid statements for the batch, instead

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilder.scala
@@ -1,5 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
+import com.databricks.labs.remorph.intermediate.Origin
 import com.databricks.labs.remorph.intermediate.procedures.SetVariable
 import com.databricks.labs.remorph.parsers.ParserCommon
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser.{StringContext => _, _}
@@ -12,7 +13,7 @@ class SnowflakeCommandBuilder(override val vc: SnowflakeVisitorCoordinator)
   // The default result is returned when there is no visitor implemented, and we produce an unresolved
   // object to represent the input that we have no visitor for.
   protected override def unresolved(ruleText: String, message: String): ir.Command =
-    ir.UnresolvedCommand(ruleText, message)
+    ir.UnresolvedCommand(ruleText, message)(Origin.empty)
 
   // Concrete visitors
 
@@ -70,7 +71,7 @@ class SnowflakeCommandBuilder(override val vc: SnowflakeVisitorCoordinator)
       ruleText = contextText(ctx),
       message = "Execute Task is not yet supported",
       ruleName = vc.ruleName(ctx),
-      tokenName = Some(tokenName(ctx.getStart)))
+      tokenName = Some(tokenName(ctx.getStart)))(Origin.fromParseRuleContext(ctx))
   }
 
   override def visitOtherCommand(ctx: OtherCommandContext): ir.Command =

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilder.scala
@@ -1,5 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
+import com.databricks.labs.remorph.intermediate.Origin
 import com.databricks.labs.remorph.parsers.ParserCommon
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser.{StringContext => StrContext, _}
 import com.databricks.labs.remorph.{intermediate => ir}
@@ -197,14 +198,14 @@ class SnowflakeDDLBuilder(override val vc: SnowflakeVisitorCoordinator)
       ruleText = contextText(ctx),
       "CREATE STREAM UNSUPPORTED",
       ruleName = contextRuleName(ctx),
-      tokenName = Some("STREAM"))
+      tokenName = Some("STREAM"))(Origin.fromParseRuleContext(ctx))
 
   override def visitCreateTask(ctx: CreateTaskContext): ir.Catalog = {
     ir.UnresolvedCommand(
       ruleText = contextText(ctx),
       "CREATE TASK UNSUPPORTED",
       ruleName = "createTask",
-      tokenName = Some("TASK"))
+      tokenName = Some("TASK"))(Origin.fromParseRuleContext(ctx))
   }
 
   private def buildColumnDeclarations(ctx: Seq[ColumnDeclItemContext]): Seq[ir.ColumnDeclaration] = {
@@ -292,7 +293,7 @@ class SnowflakeDDLBuilder(override val vc: SnowflakeVisitorCoordinator)
       ruleText = contextText(ctx),
       message = "CREATE USER UNSUPPORTED",
       ruleName = "createUser",
-      tokenName = Some("USER"))
+      tokenName = Some("USER"))(Origin.fromParseRuleContext(ctx))
 
   override def visitAlterCommand(ctx: AlterCommandContext): ir.Catalog = errorCheck(ctx) match {
     case Some(errorResult) => errorResult
@@ -304,7 +305,7 @@ class SnowflakeDDLBuilder(override val vc: SnowflakeVisitorCoordinator)
             ruleText = contextText(ctx),
             ruleName = vc.ruleName(ctx),
             tokenName = Some(tokenName(ctx.getStart)),
-            message = s"Unknown ALTER command variant")
+            message = s"Unknown ALTER command variant")(Origin.fromParseRuleContext(ctx))
       }
   }
 
@@ -322,7 +323,7 @@ class SnowflakeDDLBuilder(override val vc: SnowflakeVisitorCoordinator)
             ruleText = contextText(ctx),
             message = "Unknown ALTER TABLE variant",
             ruleName = vc.ruleName(ctx),
-            tokenName = Some(tokenName(ctx.getStart)))
+            tokenName = Some(tokenName(ctx.getStart)))(Origin.fromParseRuleContext(ctx))
       }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakePlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakePlanParser.scala
@@ -5,7 +5,7 @@ import com.databricks.labs.remorph.parsers.{PlanParser, ProductionErrorCollector
 import com.databricks.labs.remorph.parsers.snowflake.rules._
 import com.databricks.labs.remorph.{BuildingAst, KoResult, Parsing, Transformation, WorkflowStage, intermediate => ir}
 import org.antlr.v4.runtime.tree.ParseTree
-import org.antlr.v4.runtime.{CharStreams, CommonTokenStream, Parser}
+import org.antlr.v4.runtime.{CharStreams, CommonTokenStream, Parser, TokenStream}
 
 import scala.util.control.NonFatal
 
@@ -31,7 +31,7 @@ class SnowflakePlanParser extends PlanParser[SnowflakeParser] {
         case _ => BuildingAst(tree)
       }.flatMap { _ =>
         try {
-          ok(createPlan(parser, tree))
+          ok(createPlan(tokens, tree))
         } catch {
           case NonFatal(e) =>
             lift(KoResult(stage = WorkflowStage.PLAN, PlanGenerationFailure(e)))
@@ -42,7 +42,7 @@ class SnowflakePlanParser extends PlanParser[SnowflakeParser] {
 
   }
 
-  private def createPlan(parser: Parser, tree: ParseTree): LogicalPlan = {
+  private def createPlan(tokens: TokenStream, tree: ParseTree): LogicalPlan = {
     val plan = vc.astBuilder.visit(tree)
     plan
   }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakePlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakePlanParser.scala
@@ -1,9 +1,13 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
-import com.databricks.labs.remorph.parsers.PlanParser
+import com.databricks.labs.remorph.intermediate.{LogicalPlan, ParsingErrors, PlanGenerationFailure}
+import com.databricks.labs.remorph.parsers.{PlanParser, ProductionErrorCollector}
 import com.databricks.labs.remorph.parsers.snowflake.rules._
-import com.databricks.labs.remorph.{intermediate => ir}
-import org.antlr.v4.runtime.{CharStream, Lexer, ParserRuleContext, TokenStream}
+import com.databricks.labs.remorph.{BuildingAst, KoResult, Parsing, Transformation, WorkflowStage, intermediate => ir}
+import org.antlr.v4.runtime.tree.ParseTree
+import org.antlr.v4.runtime.{CharStreams, CommonTokenStream, Parser}
+
+import scala.util.control.NonFatal
 
 class SnowflakePlanParser extends PlanParser[SnowflakeParser] {
 
@@ -15,6 +19,34 @@ class SnowflakePlanParser extends PlanParser[SnowflakeParser] {
   override protected def createPlan(tree: ParserRuleContext): ir.LogicalPlan = vc.astBuilder.visit(tree)
   override protected def addErrorStrategy(parser: SnowflakeParser): Unit =
     parser.setErrorHandler(new SnowflakeErrorStrategy)
+    val errListener = new ProductionErrorCollector(parsing.source, parsing.filename)
+    parser.removeErrorListeners()
+    parser.addErrorListener(errListener)
+    val tree = parser.snowflakeFile()
+    if (errListener.errorCount > 0) {
+      lift(KoResult(stage = WorkflowStage.PARSE, ParsingErrors(errListener.errors)))
+    } else {
+      update {
+        case p: Parsing => BuildingAst(tree, Some(p))
+        case _ => BuildingAst(tree)
+      }.flatMap { _ =>
+        try {
+          ok(createPlan(parser, tree))
+        } catch {
+          case NonFatal(e) =>
+            lift(KoResult(stage = WorkflowStage.PLAN, PlanGenerationFailure(e)))
+        }
+      }
+
+    }
+
+  }
+
+  private def createPlan(parser: Parser, tree: ParseTree): LogicalPlan = {
+    val plan = vc.astBuilder.visit(tree)
+    plan
+  }
+
   def dialect: String = "snowflake"
 
   // TODO: Note that this is not the correct place for the optimizer, but it is here for now

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
@@ -46,7 +46,7 @@ class SnowflakeRelationBuilder(override val vc: SnowflakeVisitorCoordinator)
       if (Option(allOrDistinct).exists(_.DISTINCT() != null)) {
         buildTop(top, buildDistinct(relation, expressions))
       } else {
-        ir.Project(buildTop(top, relation), expressions, Origin.fromParseRuleContext(ctx))
+        ir.Project(buildTop(top, relation), expressions)(Origin.fromParseRuleContext(ctx))
       }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
@@ -1,5 +1,6 @@
 package com.databricks.labs.remorph.parsers.snowflake
 
+import com.databricks.labs.remorph.intermediate.Origin
 import com.databricks.labs.remorph.parsers.ParserCommon
 import com.databricks.labs.remorph.parsers.snowflake.SnowflakeParser._
 import com.databricks.labs.remorph.{intermediate => ir}
@@ -45,7 +46,7 @@ class SnowflakeRelationBuilder(override val vc: SnowflakeVisitorCoordinator)
       if (Option(allOrDistinct).exists(_.DISTINCT() != null)) {
         buildTop(top, buildDistinct(relation, expressions))
       } else {
-        ir.Project(buildTop(top, relation), expressions)
+        ir.Project(buildTop(top, relation), expressions, Origin.fromParseRuleContext(ctx))
       }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
@@ -31,7 +31,7 @@ class TSqlPlanParser extends PlanParser[TSqlParser] {
         case _ => BuildingAst(tree)
       }.flatMap { _ =>
         try {
-          ok(createPlan(parser, tree))
+          ok(createPlan(tokens, tree))
         } catch {
           case NonFatal(e) =>
             lift(KoResult(stage = WorkflowStage.PLAN, PlanGenerationFailure(e)))
@@ -42,7 +42,7 @@ class TSqlPlanParser extends PlanParser[TSqlParser] {
 
   }
 
-  private def createPlan(parser: Parser, tree: ParseTree): LogicalPlan = {
+  private def createPlan(tokens: TokenStream, tree: ParseTree): LogicalPlan = {
     val plan = vc.astBuilder.visit(tree)
     plan
   }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
@@ -1,19 +1,51 @@
 package com.databricks.labs.remorph.parsers.tsql
 
-import com.databricks.labs.remorph.parsers.PlanParser
+import com.databricks.labs.remorph.intermediate.{LogicalPlan, ParsingErrors, PlanGenerationFailure}
+import com.databricks.labs.remorph.parsers.{PlanParser, ProductionErrorCollector}
 import com.databricks.labs.remorph.parsers.tsql.rules.{PullLimitUpwards, TSqlCallMapper, TopPercentToLimitSubquery, TrapInsertDefaultsAction}
-import com.databricks.labs.remorph.{intermediate => ir}
+import com.databricks.labs.remorph.{BuildingAst, KoResult, Parsing, Transformation, WorkflowStage, intermediate => ir}
 import org.antlr.v4.runtime._
+import org.antlr.v4.runtime.tree.ParseTree
+
+import scala.util.control.NonFatal
 
 class TSqlPlanParser extends PlanParser[TSqlParser] {
 
   val vc = new TSqlVisitorCoordinator(TSqlParser.VOCABULARY, TSqlParser.ruleNames)
 
-  override protected def createLexer(input: CharStream): Lexer = new TSqlLexer(input)
-  override protected def createParser(stream: TokenStream): TSqlParser = new TSqlParser(stream)
-  override protected def createTree(parser: TSqlParser): ParserRuleContext = parser.tSqlFile()
-  override protected def createPlan(tree: ParserRuleContext): ir.LogicalPlan = vc.astBuilder.visit(tree)
-  override protected def addErrorStrategy(parser: TSqlParser): Unit = parser.setErrorHandler(new TSqlErrorStrategy)
+  override def parse(parsing: Parsing): Transformation[LogicalPlan] = {
+    val input = CharStreams.fromString(parsing.source)
+    val lexer = new TSqlLexer(input)
+    val tokens = new CommonTokenStream(lexer)
+    val parser = new TSqlParser(tokens)
+    parser.setErrorHandler(new TSqlErrorStrategy)
+    val errListener = new ProductionErrorCollector(parsing.source, parsing.filename)
+    parser.removeErrorListeners()
+    parser.addErrorListener(errListener)
+    val tree = parser.tSqlFile()
+    if (errListener.errorCount > 0) {
+      lift(KoResult(stage = WorkflowStage.PARSE, ParsingErrors(errListener.errors)))
+    } else {
+      update {
+        case p: Parsing => BuildingAst(tree, Some(p))
+        case _ => BuildingAst(tree)
+      }.flatMap { _ =>
+        try {
+          ok(createPlan(parser, tree))
+        } catch {
+          case NonFatal(e) =>
+            lift(KoResult(stage = WorkflowStage.PLAN, PlanGenerationFailure(e)))
+        }
+      }
+
+    }
+
+  }
+
+  private def createPlan(parser: Parser, tree: ParseTree): LogicalPlan = {
+    val plan = vc.astBuilder.visit(tree)
+    plan
+  }
   def dialect: String = "tsql"
 
   // TODO: Note that this is not the correct place for the optimizer, but it is here for now

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlPlanParser.scala
@@ -13,7 +13,7 @@ class TSqlPlanParser extends PlanParser[TSqlParser] {
 
   val vc = new TSqlVisitorCoordinator(TSqlParser.VOCABULARY, TSqlParser.ruleNames)
 
-  override def parse(parsing: Parsing): Transformation[LogicalPlan] = {
+  override def parseLogicalPlan(parsing: Parsing): Transformation[LogicalPlan] = {
     val input = CharStreams.fromString(parsing.source)
     val lexer = new TSqlLexer(input)
     val tokens = new CommonTokenStream(lexer)

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -1,5 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql
 
+import com.databricks.labs.remorph.intermediate.Origin
 import com.databricks.labs.remorph.parsers.ParserCommon
 import com.databricks.labs.remorph.parsers.tsql.TSqlParser.{StringContext => _, _}
 import com.databricks.labs.remorph.parsers.tsql.rules.{InsertDefaultsAction, TopPercent}
@@ -87,11 +88,12 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
       val columns: Seq[ir.Expression] =
         ctx.selectListElem().asScala.flatMap(vc.expressionBuilder.buildSelectListElem)
       // Note that ALL is the default so we don't need to check for it
+      val origin = Origin.fromParseRuleContext(ctx)
       ctx match {
         case c if c.DISTINCT() != null =>
-          ir.Project(buildTop(Option(ctx.topClause()), buildDistinct(select, columns)), columns)
+          ir.Project(buildTop(Option(ctx.topClause()), buildDistinct(select, columns)), columns, origin)
         case _ =>
-          ir.Project(buildTop(Option(ctx.topClause()), select), columns)
+          ir.Project(buildTop(Option(ctx.topClause()), select), columns, origin)
       }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -91,9 +91,9 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
       val origin = Origin.fromParseRuleContext(ctx)
       ctx match {
         case c if c.DISTINCT() != null =>
-          ir.Project(buildTop(Option(ctx.topClause()), buildDistinct(select, columns)), columns, origin)
+          ir.Project(buildTop(Option(ctx.topClause()), buildDistinct(select, columns)), columns)(origin)
         case _ =>
-          ir.Project(buildTop(Option(ctx.topClause()), select), columns, origin)
+          ir.Project(buildTop(Option(ctx.topClause()), select), columns)(origin)
       }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/relations.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/relations.scala
@@ -2,7 +2,7 @@ package com.databricks.labs.remorph.parsers.tsql
 
 import com.databricks.labs.remorph.intermediate._
 
-case class DerivedRows(rows: Seq[Seq[Expression]]) extends LeafNode {
+case class DerivedRows(rows: Seq[Seq[Expression]]) extends LeafNode()() {
   override def output: Seq[Attribute] = rows.flatten.map(e => AttributeReference(e.toString, e.dataType))
 }
 
@@ -23,13 +23,13 @@ case class BackupDatabase(
     flags: Map[String, Boolean],
     autoFlags: Seq[String],
     values: Map[String, Expression])
-    extends Catalog {}
+    extends Catalog()() {}
 
 case class ColumnAliases(input: LogicalPlan, aliases: Seq[Id]) extends RelationCommon {
   override def output: Seq[Attribute] = aliases.map(a => AttributeReference(a.id, StringType))
   override def children: Seq[LogicalPlan] = Seq(input)
 }
 
-case class DefaultValues() extends LeafNode {
+case class DefaultValues() extends LeafNode()() {
   override def output: Seq[Attribute] = Seq.empty
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/PullLimitUpwards.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/PullLimitUpwards.scala
@@ -5,8 +5,8 @@ import com.databricks.labs.remorph.intermediate._
 // TSQL has "SELECT TOP N * FROM .." vs "SELECT * FROM .. LIMIT N", so we fix it here
 object PullLimitUpwards extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformUp {
-    case Project(Limit(child, limit), exprs, _) =>
-      Limit(Project(child, exprs, Origin.empty), limit)
+    case Project(Limit(child, limit), exprs) =>
+      Limit(Project(child, exprs)(Origin.empty), limit)
     case Filter(Limit(child, limit), cond) =>
       Limit(Filter(child, cond), limit)
     case Sort(Limit(child, limit), order, global) =>

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/PullLimitUpwards.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/PullLimitUpwards.scala
@@ -5,8 +5,8 @@ import com.databricks.labs.remorph.intermediate._
 // TSQL has "SELECT TOP N * FROM .." vs "SELECT * FROM .. LIMIT N", so we fix it here
 object PullLimitUpwards extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformUp {
-    case Project(Limit(child, limit), exprs) =>
-      Limit(Project(child, exprs), limit)
+    case Project(Limit(child, limit), exprs, _) =>
+      Limit(Project(child, exprs, Origin.empty), limit)
     case Filter(Limit(child, limit), cond) =>
       Limit(Filter(child, cond), limit)
     case Sort(Limit(child, limit), order, global) =>

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/TopPercentToLimitSubquery.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/TopPercentToLimitSubquery.scala
@@ -5,7 +5,7 @@ import com.databricks.labs.remorph.intermediate._
 import java.util.concurrent.atomic.AtomicLong
 
 case class TopPercent(child: LogicalPlan, percentage: Expression, with_ties: Boolean = false)
-  extends UnaryNode()(Origin.empty) {
+    extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -51,14 +51,13 @@ class TopPercentToLimitSubquery extends Rule[LogicalPlan] {
             SubqueryAlias(
               Project(
                 UnresolvedRelation(originalCteName, message = s"Unresolved $originalCteName"),
-                reProject ++ Seq(Alias(Window(NTile(Literal(100)), sort_order = order), Id(percentileColName))))
-              (Origin.empty),
+                reProject ++ Seq(Alias(Window(NTile(Literal(100)), sort_order = order), Id(percentileColName))))(
+                Origin.empty),
               Id(withPercentileCteName))),
           Filter(
             Project(
               UnresolvedRelation(withPercentileCteName, message = s"Unresolved $withPercentileCteName"),
-              reProject)
-            (Origin.empty),
+              reProject)(Origin.empty),
             LessThanOrEqual(
               UnresolvedAttribute(
                 percentileColName,
@@ -81,14 +80,12 @@ class TopPercentToLimitSubquery extends Rule[LogicalPlan] {
         SubqueryAlias(
           Project(
             UnresolvedRelation(ruleText = originalCteName, message = s"Unresolved relation $originalCteName"),
-            Seq(Alias(Count(Seq(Star())), Id("count"))))
-          (Origin.empty),
+            Seq(Alias(Count(Seq(Star())), Id("count"))))(Origin.empty),
           Id(countedCteName))),
       Limit(
         Project(
           UnresolvedRelation(ruleText = originalCteName, message = s"Unresolved relation $originalCteName"),
-          Seq(Star()))
-        (Origin.empty),
+          Seq(Star()))(Origin.empty),
         ScalarSubquery(
           Project(
             UnresolvedRelation(
@@ -96,7 +93,6 @@ class TopPercentToLimitSubquery extends Rule[LogicalPlan] {
               message = s"Unresolved relation $countedCteName",
               ruleName = "N/A",
               tokenName = Some("N/A")),
-            Seq(Cast(Multiply(Divide(Id("count"), percentage), Literal(100)), LongType)))
-          (Origin.empty))))
+            Seq(Cast(Multiply(Divide(Id("count"), percentage), Literal(100)), LongType)))(Origin.empty))))
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/TopPercentToLimitSubquery.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/rules/TopPercentToLimitSubquery.scala
@@ -4,7 +4,8 @@ import com.databricks.labs.remorph.intermediate._
 
 import java.util.concurrent.atomic.AtomicLong
 
-case class TopPercent(child: LogicalPlan, percentage: Expression, with_ties: Boolean = false) extends UnaryNode(origin=Origin.empty) {
+case class TopPercent(child: LogicalPlan, percentage: Expression, with_ties: Boolean = false)
+  extends UnaryNode()(Origin.empty) {
   override def output: Seq[Attribute] = child.output
 }
 
@@ -21,8 +22,8 @@ class TopPercentToLimitSubquery extends Rule[LogicalPlan] {
 
   /** See [[PullLimitUpwards]] */
   private def normalize(plan: LogicalPlan): LogicalPlan = plan transformUp {
-    case Project(TopPercent(child, limit, withTies), exprs, _) =>
-      TopPercent(Project(child, exprs, origin = Origin.empty), limit, withTies)
+    case Project(TopPercent(child, limit, withTies), exprs) =>
+      TopPercent(Project(child, exprs)(Origin.empty), limit, withTies)
     case Filter(TopPercent(child, limit, withTies), cond) =>
       TopPercent(Filter(child, cond), limit, withTies)
     case Sort(TopPercent(child, limit, withTies), order, global) =>
@@ -40,7 +41,7 @@ class TopPercentToLimitSubquery extends Rule[LogicalPlan] {
       case Sort(child, order, _) =>
         // TODO: this is (temporary) hack due to the lack of star resolution. otherwise child.output is fine
         val reProject = child.find(_.isInstanceOf[Project]).map(_.asInstanceOf[Project]) match {
-          case Some(Project(_, expressions, _)) => expressions
+          case Some(Project(_, expressions)) => expressions
           case None =>
             throw new IllegalArgumentException("Cannot find a projection")
         }
@@ -50,14 +51,14 @@ class TopPercentToLimitSubquery extends Rule[LogicalPlan] {
             SubqueryAlias(
               Project(
                 UnresolvedRelation(originalCteName, message = s"Unresolved $originalCteName"),
-                reProject ++ Seq(Alias(Window(NTile(Literal(100)), sort_order = order), Id(percentileColName))),
-                origin = Origin.empty),
+                reProject ++ Seq(Alias(Window(NTile(Literal(100)), sort_order = order), Id(percentileColName))))
+              (Origin.empty),
               Id(withPercentileCteName))),
           Filter(
             Project(
               UnresolvedRelation(withPercentileCteName, message = s"Unresolved $withPercentileCteName"),
-              reProject,
-              origin = Origin.empty),
+              reProject)
+            (Origin.empty),
             LessThanOrEqual(
               UnresolvedAttribute(
                 percentileColName,
@@ -80,14 +81,14 @@ class TopPercentToLimitSubquery extends Rule[LogicalPlan] {
         SubqueryAlias(
           Project(
             UnresolvedRelation(ruleText = originalCteName, message = s"Unresolved relation $originalCteName"),
-            Seq(Alias(Count(Seq(Star())), Id("count"))),
-            origin = Origin.empty),
+            Seq(Alias(Count(Seq(Star())), Id("count"))))
+          (Origin.empty),
           Id(countedCteName))),
       Limit(
         Project(
           UnresolvedRelation(ruleText = originalCteName, message = s"Unresolved relation $originalCteName"),
-          Seq(Star()),
-          origin = Origin.empty),
+          Seq(Star()))
+        (Origin.empty),
         ScalarSubquery(
           Project(
             UnresolvedRelation(
@@ -95,7 +96,7 @@ class TopPercentToLimitSubquery extends Rule[LogicalPlan] {
               message = s"Unresolved relation $countedCteName",
               ruleName = "N/A",
               tokenName = Some("N/A")),
-            Seq(Cast(Multiply(Divide(Id("count"), percentage), Literal(100)), LongType)),
-            origin = Origin.empty))))
+            Seq(Cast(Multiply(Divide(Id("count"), percentage), Literal(100)), LongType)))
+          (Origin.empty))))
   }
 }

--- a/core/src/main/scala/com/databricks/labs/remorph/queries/QueryExtractor.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/queries/QueryExtractor.scala
@@ -58,7 +58,7 @@ class ExampleDebugger(parser: PlanParser[_], prettyPrinter: Any => Unit, dialect
     val extractor = new CommentBasedQueryExtractor(dialect, "databricks")
     extractor.extractQuery(new File(name)) match {
       case Some(ExampleQuery(query, _)) =>
-        parser.parse(Parsing(query)).run(Parsing(query)) match {
+        parser.parseLogicalPlan(Parsing(query)).run(Parsing(query)) match {
           case com.databricks.labs.remorph.KoResult(_, error) =>
             logger.error(s"Failed to parse query: $query ${error.msg}")
           case PartialResult((_, plan), error) =>

--- a/core/src/main/scala/com/databricks/labs/remorph/queries/QueryExtractor.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/queries/QueryExtractor.scala
@@ -58,7 +58,7 @@ class ExampleDebugger(parser: PlanParser[_], prettyPrinter: Any => Unit, dialect
     val extractor = new CommentBasedQueryExtractor(dialect, "databricks")
     extractor.extractQuery(new File(name)) match {
       case Some(ExampleQuery(query, _)) =>
-        parser.parse(Parsing(query)).flatMap(parser.visit).run(Parsing(query)) match {
+        parser.parse(Parsing(query)).run(Parsing(query)) match {
           case com.databricks.labs.remorph.KoResult(_, error) =>
             logger.error(s"Failed to parse query: $query ${error.msg}")
           case PartialResult((_, plan), error) =>

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/Transpiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/Transpiler.scala
@@ -53,7 +53,7 @@ abstract class BaseTranspiler extends Transpiler with Formatter with Transformat
 
   implicit val formats: Formats = Serialization.formats(NoTypeHints)
 
-  protected def parse(input: Parsing): Transformation[ir.LogicalPlan] = planParser.parse(input)
+  protected def parse(input: Parsing): Transformation[ir.LogicalPlan] = planParser.parseLogicalPlan(input)
 
   // TODO: optimizer really should be its own thing and not part of PlanParser
   // I have put it here for now until we discuss^h^h^h^h^h^h^hSerge dictates where it should go ;)

--- a/core/src/main/scala/com/databricks/labs/remorph/transpilers/Transpiler.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/transpilers/Transpiler.scala
@@ -5,7 +5,6 @@ import com.databricks.labs.remorph.{Generating, Optimizing, Parsing, Transformat
 import com.github.vertical_blank.sqlformatter.SqlFormatter
 import com.github.vertical_blank.sqlformatter.core.FormatConfig
 import com.github.vertical_blank.sqlformatter.languages.Dialect
-import org.antlr.v4.runtime.ParserRuleContext
 import org.json4s.jackson.Serialization
 import org.json4s.{Formats, NoTypeHints}
 
@@ -54,9 +53,7 @@ abstract class BaseTranspiler extends Transpiler with Formatter with Transformat
 
   implicit val formats: Formats = Serialization.formats(NoTypeHints)
 
-  protected def parse(input: Parsing): Transformation[ParserRuleContext] = planParser.parse(input)
-
-  protected def visit(tree: ParserRuleContext): Transformation[ir.LogicalPlan] = planParser.visit(tree)
+  protected def parse(input: Parsing): Transformation[ir.LogicalPlan] = planParser.parse(input)
 
   // TODO: optimizer really should be its own thing and not part of PlanParser
   // I have put it here for now until we discuss^h^h^h^h^h^h^hSerge dictates where it should go ;)
@@ -84,6 +81,6 @@ abstract class BaseTranspiler extends Transpiler with Formatter with Transformat
   }
 
   override def transpile(input: Parsing): Transformation[String] = {
-    set(input).flatMap(_ => parse(input)).flatMap(visit).flatMap(optimize).flatMap(generate)
+    set(input).flatMap(_ => parse(input)).flatMap(optimize).flatMap(generate)
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/discovery/AnonymizerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/discovery/AnonymizerTest.scala
@@ -62,7 +62,7 @@ class AnonymizerTest extends AnyWordSpec with Matchers {
         Fingerprint(
           "id",
           new Timestamp(1725032011000L),
-          "290f4d72ca8faeb28873d8fff779ce93ed5cdb69",
+          "93f60d8795c8bffa2aafe174ae8a867b42235755",
           Duration.ofMillis(300),
           "foo",
           WorkloadType.OTHER,

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
@@ -1672,7 +1672,8 @@ class ExpressionGeneratorTest
         ir.Id("c1"),
         Seq(
           ir.ScalarSubquery(
-            ir.Project(namedTable("table1"), Seq(ir.Id("column1")))(Origin.empty)))) generates "c1 IN (SELECT column1 FROM table1)"
+            ir.Project(namedTable("table1"), Seq(ir.Id("column1")))(
+              Origin.empty)))) generates "c1 IN (SELECT column1 FROM table1)"
 
       ir.In(ir.Id("c1"), Seq(ir.Literal(1), ir.Literal(2), ir.Literal(3))) generates "c1 IN (1, 2, 3)"
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
@@ -1672,7 +1672,7 @@ class ExpressionGeneratorTest
         ir.Id("c1"),
         Seq(
           ir.ScalarSubquery(
-            ir.Project(namedTable("table1"), Seq(ir.Id("column1")), origin = Origin.empty)))) generates "c1 IN (SELECT column1 FROM table1)"
+            ir.Project(namedTable("table1"), Seq(ir.Id("column1")))(Origin.empty)))) generates "c1 IN (SELECT column1 FROM table1)"
 
       ir.In(ir.Id("c1"), Seq(ir.Literal(1), ir.Literal(2), ir.Literal(3))) generates "c1 IN (1, 2, 3)"
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/ExpressionGeneratorTest.scala
@@ -1,6 +1,7 @@
 package com.databricks.labs.remorph.generators.sql
 
 import com.databricks.labs.remorph.generators.{GeneratorContext, GeneratorTestCommon}
+import com.databricks.labs.remorph.intermediate.Origin
 import com.databricks.labs.remorph.{Generating, intermediate => ir}
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
@@ -1671,7 +1672,7 @@ class ExpressionGeneratorTest
         ir.Id("c1"),
         Seq(
           ir.ScalarSubquery(
-            ir.Project(namedTable("table1"), Seq(ir.Id("column1")))))) generates "c1 IN (SELECT column1 FROM table1)"
+            ir.Project(namedTable("table1"), Seq(ir.Id("column1")), origin = Origin.empty)))) generates "c1 IN (SELECT column1 FROM table1)"
 
       ir.In(ir.Id("c1"), Seq(ir.Literal(1), ir.Literal(2), ir.Literal(3))) generates "c1 IN (1, 2, 3)"
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGeneratorTest.scala
@@ -1,6 +1,7 @@
 package com.databricks.labs.remorph.generators.sql
 
 import com.databricks.labs.remorph.generators.{GeneratorContext, GeneratorTestCommon}
+import com.databricks.labs.remorph.intermediate.Origin
 import com.databricks.labs.remorph.{Generating, intermediate => ir}
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -14,14 +15,14 @@ class LogicalPlanGeneratorTest extends AnyWordSpec with GeneratorTestCommon[ir.L
     Generating(optimizedPlan = plan, currentNode = plan, ctx = GeneratorContext(generator))
   "Project" should {
     "transpile to SELECT" in {
-      ir.Project(namedTable("t1"), Seq(ir.Id("c1"))) generates "SELECT c1 FROM t1"
-      ir.Project(namedTable("t1"), Seq(ir.Star(None))) generates "SELECT * FROM t1"
-      ir.Project(ir.NoTable(), Seq(ir.Literal(1))) generates "SELECT 1"
+      ir.Project(namedTable("t1"), Seq(ir.Id("c1")), origin = Origin.empty) generates "SELECT c1 FROM t1"
+      ir.Project(namedTable("t1"), Seq(ir.Star(None)), origin = Origin.empty) generates "SELECT * FROM t1"
+      ir.Project(ir.NoTable(), Seq(ir.Literal(1)), origin = Origin.empty) generates "SELECT 1"
     }
 
     "transpile to SELECT with COMMENTS" in {
       ir.WithOptions(
-        ir.Project(namedTable("t"), Seq(ir.Star(None))),
+        ir.Project(namedTable("t"), Seq(ir.Star(None)), origin = Origin.empty),
         ir.Options(
           Map("MAXRECURSION" -> ir.Literal(10), "OPTIMIZE" -> ir.Column(None, ir.Id("FOR", caseSensitive = true))),
           Map("SOMESTROPT" -> "STRINGOPTION"),
@@ -57,7 +58,7 @@ class LogicalPlanGeneratorTest extends AnyWordSpec with GeneratorTestCommon[ir.L
   "Filter" should {
     "transpile to WHERE" in {
       ir.Filter(
-        ir.Project(namedTable("t1"), Seq(ir.Id("c1"))),
+        ir.Project(namedTable("t1"), Seq(ir.Id("c1")), origin = Origin.empty),
         ir.CallFunction("IS_DATE", Seq(ir.Id("c2")))) generates "SELECT c1 FROM t1 WHERE IS_DATE(c2)"
     }
   }

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGeneratorTest.scala
@@ -15,14 +15,14 @@ class LogicalPlanGeneratorTest extends AnyWordSpec with GeneratorTestCommon[ir.L
     Generating(optimizedPlan = plan, currentNode = plan, ctx = GeneratorContext(generator))
   "Project" should {
     "transpile to SELECT" in {
-      ir.Project(namedTable("t1"), Seq(ir.Id("c1")), origin = Origin.empty) generates "SELECT c1 FROM t1"
-      ir.Project(namedTable("t1"), Seq(ir.Star(None)), origin = Origin.empty) generates "SELECT * FROM t1"
-      ir.Project(ir.NoTable(), Seq(ir.Literal(1)), origin = Origin.empty) generates "SELECT 1"
+      ir.Project(namedTable("t1"), Seq(ir.Id("c1")))(Origin.empty) generates "SELECT c1 FROM t1"
+      ir.Project(namedTable("t1"), Seq(ir.Star(None)))(Origin.empty) generates "SELECT * FROM t1"
+      ir.Project(ir.NoTable(), Seq(ir.Literal(1)))(Origin.empty) generates "SELECT 1"
     }
 
     "transpile to SELECT with COMMENTS" in {
       ir.WithOptions(
-        ir.Project(namedTable("t"), Seq(ir.Star(None)), origin = Origin.empty),
+        ir.Project(namedTable("t"), Seq(ir.Star(None)))(Origin.empty),
         ir.Options(
           Map("MAXRECURSION" -> ir.Literal(10), "OPTIMIZE" -> ir.Column(None, ir.Id("FOR", caseSensitive = true))),
           Map("SOMESTROPT" -> "STRINGOPTION"),
@@ -58,7 +58,7 @@ class LogicalPlanGeneratorTest extends AnyWordSpec with GeneratorTestCommon[ir.L
   "Filter" should {
     "transpile to WHERE" in {
       ir.Filter(
-        ir.Project(namedTable("t1"), Seq(ir.Id("c1")), origin = Origin.empty),
+        ir.Project(namedTable("t1"), Seq(ir.Id("c1")))(Origin.empty),
         ir.CallFunction("IS_DATE", Seq(ir.Id("c2")))) generates "SELECT c1 FROM t1 WHERE IS_DATE(c2)"
     }
   }

--- a/core/src/test/scala/com/databricks/labs/remorph/intermediate/TreeTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/intermediate/TreeTest.scala
@@ -1,0 +1,19 @@
+package com.databricks.labs.remorph.intermediate
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+case class TestNode(name: String)(origin: Origin) extends TreeNode[TestNode]()(origin) {
+  override def children: Seq[TestNode] = Seq()
+}
+
+class TreeTest extends AnyWordSpec with Matchers {
+  "TreeNode" should {
+    "be equal" in {
+      val n1 = TestNode(name = "John")(Origin.empty)
+      val n2 = TestNode(name = "John")(Origin(startLine = Some(12)))
+      n1 must equal(n2)
+    }
+  }
+
+}

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
@@ -15,28 +15,21 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
     "translate a simple SELECT query" in {
       singleQueryExample(
         query = "SELECT a FROM TABLE",
-        expectedAst = Project(
-          NamedTable("TABLE", Map.empty, is_streaming = false),
-          Seq(Id("a")))
-        (Origin.empty))
+        expectedAst = Project(NamedTable("TABLE", Map.empty, is_streaming = false), Seq(Id("a")))(Origin.empty))
     }
 
     "translate a simple SELECT query with an aliased column" in {
       singleQueryExample(
         query = "SELECT a AS aa FROM b",
-        expectedAst = Project(
-          NamedTable("b", Map.empty, is_streaming = false),
-          Seq(Alias(Id("a"), Id("aa"))))
-        (Origin.empty))
+        expectedAst =
+          Project(NamedTable("b", Map.empty, is_streaming = false), Seq(Alias(Id("a"), Id("aa"))))(Origin.empty))
     }
 
     "translate a simple SELECT query involving multiple columns" in {
       singleQueryExample(
         query = "SELECT a, b, c FROM table_x",
-        expectedAst = Project(
-          NamedTable("table_x", Map.empty, is_streaming = false),
-          Seq(Id("a"), Id("b"), Id("c")))
-          (Origin.empty))
+        expectedAst =
+          Project(NamedTable("table_x", Map.empty, is_streaming = false), Seq(Id("a"), Id("b"), Id("c")))(Origin.empty))
     }
 
     "translate a SELECT query involving multiple columns and aliases" in {
@@ -44,8 +37,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         query = "SELECT a, b AS bb, c FROM table_x",
         expectedAst = Project(
           NamedTable("table_x", Map.empty, is_streaming = false),
-          Seq(Id("a"), Alias(Id("b"), Id("bb")), Id("c")))
-          (Origin.empty))
+          Seq(Id("a"), Alias(Id("b"), Id("bb")), Id("c")))(Origin.empty))
     }
 
     val simpleJoinAst =
@@ -109,26 +101,19 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
       "SELECT a FROM table_x NATURAL JOIN table_y" in {
         singleQueryExample(
           query = "SELECT a FROM table_x NATURAL JOIN table_y",
-          expectedAst = Project(
-            simpleJoinAst.copy(join_type = NaturalJoin(UnspecifiedJoin)),
-            Seq(Id("a")))
-            (Origin.empty))
+          expectedAst =
+            Project(simpleJoinAst.copy(join_type = NaturalJoin(UnspecifiedJoin)), Seq(Id("a")))(Origin.empty))
       }
       "SELECT a FROM table_x NATURAL LEFT JOIN table_y" in {
         singleQueryExample(
           query = "SELECT a FROM table_x NATURAL LEFT JOIN table_y",
-          expectedAst = Project(
-            simpleJoinAst.copy(join_type = NaturalJoin(LeftOuterJoin)),
-            Seq(Id("a")))
-            (Origin.empty))
+          expectedAst = Project(simpleJoinAst.copy(join_type = NaturalJoin(LeftOuterJoin)), Seq(Id("a")))(Origin.empty))
       }
       "SELECT a FROM table_x NATURAL RIGHT JOIN table_y" in {
         singleQueryExample(
           query = "SELECT a FROM table_x NATURAL RIGHT JOIN table_y",
-          expectedAst = Project(
-            simpleJoinAst.copy(join_type = NaturalJoin(RightOuterJoin)),
-            Seq(Id("a")))
-            (Origin.empty))
+          expectedAst =
+            Project(simpleJoinAst.copy(join_type = NaturalJoin(RightOuterJoin)), Seq(Id("a")))(Origin.empty))
       }
     }
 
@@ -145,11 +130,9 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
       expectedOperatorTranslations.foreach { case (op, expectedPredicate) =>
         singleQueryExample(
           query = s"SELECT a, b FROM c WHERE a $op b",
-          expectedAst =
-            Project(
-              Filter(NamedTable("c", Map.empty, is_streaming = false), expectedPredicate),
-              Seq(Id("a"), Id("b")))
-              (Origin.empty))
+          expectedAst = Project(
+            Filter(NamedTable("c", Map.empty, is_streaming = false), expectedPredicate),
+            Seq(Id("a"), Id("b")))(Origin.empty))
       }
     }
 
@@ -161,8 +144,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             Filter(
               NamedTable("c", Map.empty, is_streaming = false),
               And(Equals(Id("a"), Id("b")), Equals(Id("b"), Id("a")))),
-            Seq(Id("a"), Id("b")))
-            (Origin.empty))
+            Seq(Id("a"), Id("b")))(Origin.empty))
       }
       "SELECT a, b FROM c WHERE a = b OR b = a" in {
         singleQueryExample(
@@ -171,16 +153,14 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             Filter(
               NamedTable("c", Map.empty, is_streaming = false),
               Or(Equals(Id("a"), Id("b")), Equals(Id("b"), Id("a")))),
-            Seq(Id("a"), Id("b")))
-            (Origin.empty))
+            Seq(Id("a"), Id("b")))(Origin.empty))
       }
       "SELECT a, b FROM c WHERE NOT a = b" in {
         singleQueryExample(
           query = "SELECT a, b FROM c WHERE NOT a = b",
           expectedAst = Project(
             Filter(NamedTable("c", Map.empty, is_streaming = false), Not(Equals(Id("a"), Id("b")))),
-            Seq(Id("a"), Id("b")))
-            (Origin.empty))
+            Seq(Id("a"), Id("b")))(Origin.empty))
       }
     }
 
@@ -193,8 +173,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             group_type = GroupBy,
             grouping_expressions = Seq(simplyNamedColumn("a")),
             pivot = None),
-          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b")))))
-          (Origin.empty))
+          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b")))))(Origin.empty))
     }
 
     "translate a query with a GROUP BY and ORDER BY clauses" in {
@@ -208,8 +187,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
               grouping_expressions = Seq(simplyNamedColumn("a")),
               pivot = None),
             Seq(SortOrder(Id("a"), Ascending, NullsLast))),
-          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b")))))
-          (Origin.empty))
+          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b")))))(Origin.empty))
     }
 
     "translate a query with GROUP BY HAVING clause" in {
@@ -223,8 +201,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
               grouping_expressions = Seq(simplyNamedColumn("a")),
               pivot = None),
             GreaterThan(CallFunction("COUNT", Seq(Id("b"))), Literal(1))),
-          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b")))))
-          (Origin.empty))
+          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b")))))(Origin.empty))
     }
 
     "translate a query with ORDER BY" should {
@@ -233,32 +210,28 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           query = "SELECT a FROM b ORDER BY a",
           expectedAst = Project(
             Sort(NamedTable("b", Map.empty, is_streaming = false), Seq(SortOrder(Id("a"), Ascending, NullsLast))),
-            Seq(Id("a")))
-            (Origin.empty))
+            Seq(Id("a")))(Origin.empty))
       }
       "SELECT a FROM b ORDER BY a DESC" in {
         singleQueryExample(
           "SELECT a FROM b ORDER BY a DESC",
           Project(
             Sort(NamedTable("b", Map.empty, is_streaming = false), Seq(SortOrder(Id("a"), Descending, NullsFirst))),
-            Seq(Id("a")))
-            (Origin.empty))
+            Seq(Id("a")))(Origin.empty))
       }
       "SELECT a FROM b ORDER BY a NULLS FIRST" in {
         singleQueryExample(
           query = "SELECT a FROM b ORDER BY a NULLS FIRST",
           expectedAst = Project(
             Sort(NamedTable("b", Map.empty, is_streaming = false), Seq(SortOrder(Id("a"), Ascending, NullsFirst))),
-            Seq(Id("a")))
-            (Origin.empty))
+            Seq(Id("a")))(Origin.empty))
       }
       "SELECT a FROM b ORDER BY a DESC NULLS LAST" in {
         singleQueryExample(
           query = "SELECT a FROM b ORDER BY a DESC NULLS LAST",
           expectedAst = Project(
             Sort(NamedTable("b", Map.empty, is_streaming = false), Seq(SortOrder(Id("a"), Descending, NullsLast))),
-            Seq(Id("a")))
-            (Origin.empty))
+            Seq(Id("a")))(Origin.empty))
       }
     }
 
@@ -266,26 +239,21 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
       "SELECT a FROM b LIMIT 5" in {
         singleQueryExample(
           query = "SELECT a FROM b LIMIT 5",
-          expectedAst = Project(
-            Limit(NamedTable("b", Map.empty, is_streaming = false), Literal(5)),
-            Seq(Id("a")))
-            (Origin.empty))
+          expectedAst =
+            Project(Limit(NamedTable("b", Map.empty, is_streaming = false), Literal(5)), Seq(Id("a")))(Origin.empty))
       }
       "SELECT a FROM b LIMIT 5 OFFSET 10" in {
         singleQueryExample(
           query = "SELECT a FROM b LIMIT 5 OFFSET 10",
           expectedAst = Project(
             Offset(Limit(NamedTable("b", Map.empty, is_streaming = false), Literal(5)), Literal(10)),
-            Seq(Id("a")))
-            (Origin.empty))
+            Seq(Id("a")))(Origin.empty))
       }
       "SELECT a FROM b OFFSET 10 FETCH FIRST 42" in {
         singleQueryExample(
           query = "SELECT a FROM b OFFSET 10 FETCH FIRST 42",
-          expectedAst = Project(
-            Offset(NamedTable("b", Map.empty, is_streaming = false), Literal(10)),
-            Seq(Id("a")))
-            (Origin.empty))
+          expectedAst =
+            Project(Offset(NamedTable("b", Map.empty, is_streaming = false), Literal(10)), Seq(Id("a")))(Origin.empty))
       }
     }
 
@@ -298,8 +266,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             group_type = Pivot,
             grouping_expressions = Seq(CallFunction("SUM", Seq(simplyNamedColumn("a")))),
             pivot = Some(Pivot(simplyNamedColumn("c"), Seq(Literal("foo"), Literal("bar"))))),
-          Seq(Id("a")))
-          (Origin.empty))
+          Seq(Id("a")))(Origin.empty))
     }
 
     "translate a query with UNPIVOT" in {
@@ -312,8 +279,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             values = None,
             variable_column_name = Id("c"),
             value_column_name = Id("d")),
-          Seq(Id("a")))
-          (Origin.empty))
+          Seq(Id("a")))(Origin.empty))
     }
 
     "translate queries with WITH clauses" should {
@@ -340,7 +306,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
                 Seq(Id("b"), Id("c"), Id("d"))),
               SubqueryAlias(
                 Project(namedTable("f"), Seq(Id("xx"), Id("yy")))(Origin.empty),
-                Id("aa"), Seq(Id("bb"), Id("cc")))),
+                Id("aa"),
+                Seq(Id("bb"), Id("cc")))),
             Project(namedTable("a"), Seq(Id("b"), Id("c"), Id("d")))(Origin.empty)))
       }
     }
@@ -363,8 +330,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
                 pivot = None),
               GreaterThanOrEqual(CallFunction("AVG", Seq(Id("c1"))), Literal(5))),
             GreaterThan(CallFunction("MIN", Seq(Id("r"))), Literal(6))),
-          Seq(Id("c2"), Alias(Window(CallFunction("SUM", Seq(Id("c3"))), Seq(Id("c2")), Seq(), None), Id("r"))))
-          (Origin.empty))
+          Seq(Id("c2"), Alias(Window(CallFunction("SUM", Seq(Id("c3"))), Seq(Id("c2")), Seq(), None), Id("r"))))(
+          Origin.empty))
     }
 
     "translate a query with set operators" should {
@@ -535,10 +502,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         singleQueryExample(
           "select * from a where b = &ids",
           // Note when we truly process &vars we should get Variable, not Id
-          Project(
-            Filter(namedTable("a"), Equals(Id("b"), Id("$ids"))),
-            Seq(Star()))
-            (Origin.empty))
+          Project(Filter(namedTable("a"), Equals(Id("b"), Id("$ids"))), Seq(Star()))(Origin.empty))
       }
     }
 
@@ -578,8 +542,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
                     Id("employee_id", false),
                     Id("manager_id", false),
                     Id("employee_name", false),
-                    Alias(Literal(1, IntegerType), Id("level", false))))
-                  (Origin.empty),
+                    Alias(Literal(1, IntegerType), Id("level", false))))(Origin.empty),
                 Id("employee_hierarchy", false),
                 Seq.empty)),
             Project(
@@ -589,8 +552,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
                   SortOrder(Id("level", false), Ascending, NullsLast),
                   SortOrder(Id("employee_id", false), Ascending, NullsLast)),
                 false),
-              Seq(Star(None)))
-              (Origin.empty)))
+              Seq(Star(None)))(Origin.empty)))
       }
 
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
@@ -17,8 +17,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         query = "SELECT a FROM TABLE",
         expectedAst = Project(
           NamedTable("TABLE", Map.empty, is_streaming = false),
-          Seq(Id("a")),
-          origin = Origin.empty))
+          Seq(Id("a")))
+        (Origin.empty))
     }
 
     "translate a simple SELECT query with an aliased column" in {
@@ -26,8 +26,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         query = "SELECT a AS aa FROM b",
         expectedAst = Project(
           NamedTable("b", Map.empty, is_streaming = false),
-          Seq(Alias(Id("a"), Id("aa"))),
-          origin = Origin.empty))
+          Seq(Alias(Id("a"), Id("aa"))))
+        (Origin.empty))
     }
 
     "translate a simple SELECT query involving multiple columns" in {
@@ -35,8 +35,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         query = "SELECT a, b, c FROM table_x",
         expectedAst = Project(
           NamedTable("table_x", Map.empty, is_streaming = false),
-          Seq(Id("a"), Id("b"), Id("c")),
-          origin = Origin.empty))
+          Seq(Id("a"), Id("b"), Id("c")))
+          (Origin.empty))
     }
 
     "translate a SELECT query involving multiple columns and aliases" in {
@@ -44,8 +44,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         query = "SELECT a, b AS bb, c FROM table_x",
         expectedAst = Project(
           NamedTable("table_x", Map.empty, is_streaming = false),
-          Seq(Id("a"), Alias(Id("b"), Id("bb")), Id("c")),
-          origin = Origin.empty))
+          Seq(Id("a"), Alias(Id("b"), Id("bb")), Id("c")))
+          (Origin.empty))
     }
 
     val simpleJoinAst =
@@ -60,49 +60,49 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
     "translate a query with a JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x JOIN table_y",
-        expectedAst = Project(simpleJoinAst, Seq(Id("a")), origin = Origin.empty))
+        expectedAst = Project(simpleJoinAst, Seq(Id("a")))(Origin.empty))
     }
 
     "translate a query with a INNER JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x INNER JOIN table_y",
-        expectedAst = Project(simpleJoinAst.copy(join_type = InnerJoin), Seq(Id("a")), origin = Origin.empty))
+        expectedAst = Project(simpleJoinAst.copy(join_type = InnerJoin), Seq(Id("a")))(Origin.empty))
     }
 
     "translate a query with a CROSS JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x CROSS JOIN table_y",
-        expectedAst = Project(simpleJoinAst.copy(join_type = CrossJoin), Seq(Id("a")), origin = Origin.empty))
+        expectedAst = Project(simpleJoinAst.copy(join_type = CrossJoin), Seq(Id("a")))(Origin.empty))
     }
 
     "translate a query with a LEFT JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x LEFT JOIN table_y",
-        expectedAst = Project(simpleJoinAst.copy(join_type = LeftOuterJoin), Seq(Id("a")), origin = Origin.empty))
+        expectedAst = Project(simpleJoinAst.copy(join_type = LeftOuterJoin), Seq(Id("a")))(Origin.empty))
     }
 
     "translate a query with a LEFT OUTER JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x LEFT OUTER JOIN table_y",
-        expectedAst = Project(simpleJoinAst.copy(join_type = LeftOuterJoin), Seq(Id("a")), origin = Origin.empty))
+        expectedAst = Project(simpleJoinAst.copy(join_type = LeftOuterJoin), Seq(Id("a")))(Origin.empty))
     }
 
     "translate a query with a RIGHT JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x RIGHT JOIN table_y",
-        expectedAst = Project(simpleJoinAst.copy(join_type = RightOuterJoin), Seq(Id("a")), origin = Origin.empty))
+        expectedAst = Project(simpleJoinAst.copy(join_type = RightOuterJoin), Seq(Id("a")))(Origin.empty))
     }
 
     "translate a query with a RIGHT OUTER JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x RIGHT OUTER JOIN table_y",
-        expectedAst = Project(simpleJoinAst.copy(join_type = RightOuterJoin), Seq(Id("a")), origin = Origin.empty))
+        expectedAst = Project(simpleJoinAst.copy(join_type = RightOuterJoin), Seq(Id("a")))(Origin.empty))
     }
 
     "translate a query with a FULL JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x FULL JOIN table_y",
-        expectedAst = Project(simpleJoinAst.copy(join_type = FullOuterJoin), Seq(Id("a")), origin = Origin.empty))
+        expectedAst = Project(simpleJoinAst.copy(join_type = FullOuterJoin), Seq(Id("a")))(Origin.empty))
     }
 
     "translate a query with a NATURAL JOIN" should {
@@ -111,24 +111,24 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           query = "SELECT a FROM table_x NATURAL JOIN table_y",
           expectedAst = Project(
             simpleJoinAst.copy(join_type = NaturalJoin(UnspecifiedJoin)),
-            Seq(Id("a")),
-            origin = Origin.empty))
+            Seq(Id("a")))
+            (Origin.empty))
       }
       "SELECT a FROM table_x NATURAL LEFT JOIN table_y" in {
         singleQueryExample(
           query = "SELECT a FROM table_x NATURAL LEFT JOIN table_y",
           expectedAst = Project(
             simpleJoinAst.copy(join_type = NaturalJoin(LeftOuterJoin)),
-            Seq(Id("a")),
-            origin = Origin.empty))
+            Seq(Id("a")))
+            (Origin.empty))
       }
       "SELECT a FROM table_x NATURAL RIGHT JOIN table_y" in {
         singleQueryExample(
           query = "SELECT a FROM table_x NATURAL RIGHT JOIN table_y",
           expectedAst = Project(
             simpleJoinAst.copy(join_type = NaturalJoin(RightOuterJoin)),
-            Seq(Id("a")),
-            origin = Origin.empty))
+            Seq(Id("a")))
+            (Origin.empty))
       }
     }
 
@@ -148,8 +148,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           expectedAst =
             Project(
               Filter(NamedTable("c", Map.empty, is_streaming = false), expectedPredicate),
-              Seq(Id("a"), Id("b")),
-              origin = Origin.empty))
+              Seq(Id("a"), Id("b")))
+              (Origin.empty))
       }
     }
 
@@ -161,8 +161,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             Filter(
               NamedTable("c", Map.empty, is_streaming = false),
               And(Equals(Id("a"), Id("b")), Equals(Id("b"), Id("a")))),
-            Seq(Id("a"), Id("b")),
-            origin = Origin.empty))
+            Seq(Id("a"), Id("b")))
+            (Origin.empty))
       }
       "SELECT a, b FROM c WHERE a = b OR b = a" in {
         singleQueryExample(
@@ -171,16 +171,16 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             Filter(
               NamedTable("c", Map.empty, is_streaming = false),
               Or(Equals(Id("a"), Id("b")), Equals(Id("b"), Id("a")))),
-            Seq(Id("a"), Id("b")),
-            origin = Origin.empty))
+            Seq(Id("a"), Id("b")))
+            (Origin.empty))
       }
       "SELECT a, b FROM c WHERE NOT a = b" in {
         singleQueryExample(
           query = "SELECT a, b FROM c WHERE NOT a = b",
           expectedAst = Project(
             Filter(NamedTable("c", Map.empty, is_streaming = false), Not(Equals(Id("a"), Id("b")))),
-            Seq(Id("a"), Id("b")),
-            origin = Origin.empty))
+            Seq(Id("a"), Id("b")))
+            (Origin.empty))
       }
     }
 
@@ -193,8 +193,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             group_type = GroupBy,
             grouping_expressions = Seq(simplyNamedColumn("a")),
             pivot = None),
-          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b")))),
-          origin = Origin.empty))
+          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b")))))
+          (Origin.empty))
     }
 
     "translate a query with a GROUP BY and ORDER BY clauses" in {
@@ -208,8 +208,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
               grouping_expressions = Seq(simplyNamedColumn("a")),
               pivot = None),
             Seq(SortOrder(Id("a"), Ascending, NullsLast))),
-          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b")))),
-          origin = Origin.empty))
+          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b")))))
+          (Origin.empty))
     }
 
     "translate a query with GROUP BY HAVING clause" in {
@@ -223,8 +223,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
               grouping_expressions = Seq(simplyNamedColumn("a")),
               pivot = None),
             GreaterThan(CallFunction("COUNT", Seq(Id("b"))), Literal(1))),
-          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b")))),
-          origin = Origin.empty))
+          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b")))))
+          (Origin.empty))
     }
 
     "translate a query with ORDER BY" should {
@@ -233,32 +233,32 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           query = "SELECT a FROM b ORDER BY a",
           expectedAst = Project(
             Sort(NamedTable("b", Map.empty, is_streaming = false), Seq(SortOrder(Id("a"), Ascending, NullsLast))),
-            Seq(Id("a")),
-            origin = Origin.empty))
+            Seq(Id("a")))
+            (Origin.empty))
       }
       "SELECT a FROM b ORDER BY a DESC" in {
         singleQueryExample(
           "SELECT a FROM b ORDER BY a DESC",
           Project(
             Sort(NamedTable("b", Map.empty, is_streaming = false), Seq(SortOrder(Id("a"), Descending, NullsFirst))),
-            Seq(Id("a")),
-            origin = Origin.empty))
+            Seq(Id("a")))
+            (Origin.empty))
       }
       "SELECT a FROM b ORDER BY a NULLS FIRST" in {
         singleQueryExample(
           query = "SELECT a FROM b ORDER BY a NULLS FIRST",
           expectedAst = Project(
             Sort(NamedTable("b", Map.empty, is_streaming = false), Seq(SortOrder(Id("a"), Ascending, NullsFirst))),
-            Seq(Id("a")),
-            origin = Origin.empty))
+            Seq(Id("a")))
+            (Origin.empty))
       }
       "SELECT a FROM b ORDER BY a DESC NULLS LAST" in {
         singleQueryExample(
           query = "SELECT a FROM b ORDER BY a DESC NULLS LAST",
           expectedAst = Project(
             Sort(NamedTable("b", Map.empty, is_streaming = false), Seq(SortOrder(Id("a"), Descending, NullsLast))),
-            Seq(Id("a")),
-            origin = Origin.empty))
+            Seq(Id("a")))
+            (Origin.empty))
       }
     }
 
@@ -268,24 +268,24 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           query = "SELECT a FROM b LIMIT 5",
           expectedAst = Project(
             Limit(NamedTable("b", Map.empty, is_streaming = false), Literal(5)),
-            Seq(Id("a")),
-            origin = Origin.empty))
+            Seq(Id("a")))
+            (Origin.empty))
       }
       "SELECT a FROM b LIMIT 5 OFFSET 10" in {
         singleQueryExample(
           query = "SELECT a FROM b LIMIT 5 OFFSET 10",
           expectedAst = Project(
             Offset(Limit(NamedTable("b", Map.empty, is_streaming = false), Literal(5)), Literal(10)),
-            Seq(Id("a")),
-            origin = Origin.empty))
+            Seq(Id("a")))
+            (Origin.empty))
       }
       "SELECT a FROM b OFFSET 10 FETCH FIRST 42" in {
         singleQueryExample(
           query = "SELECT a FROM b OFFSET 10 FETCH FIRST 42",
           expectedAst = Project(
             Offset(NamedTable("b", Map.empty, is_streaming = false), Literal(10)),
-            Seq(Id("a")),
-            origin = Origin.empty))
+            Seq(Id("a")))
+            (Origin.empty))
       }
     }
 
@@ -298,8 +298,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             group_type = Pivot,
             grouping_expressions = Seq(CallFunction("SUM", Seq(simplyNamedColumn("a")))),
             pivot = Some(Pivot(simplyNamedColumn("c"), Seq(Literal("foo"), Literal("bar"))))),
-          Seq(Id("a")),
-          origin = Origin.empty))
+          Seq(Id("a")))
+          (Origin.empty))
     }
 
     "translate a query with UNPIVOT" in {
@@ -312,8 +312,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             values = None,
             variable_column_name = Id("c"),
             value_column_name = Id("d")),
-          Seq(Id("a")),
-          origin = Origin.empty))
+          Seq(Id("a")))
+          (Origin.empty))
     }
 
     "translate queries with WITH clauses" should {
@@ -323,10 +323,10 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           expectedAst = WithCTE(
             Seq(
               SubqueryAlias(
-                Project(namedTable("e"), Seq(Id("x"), Id("y"), Id("z")), origin = Origin.empty),
+                Project(namedTable("e"), Seq(Id("x"), Id("y"), Id("z")))(Origin.empty),
                 Id("a"),
                 Seq(Id("b"), Id("c"), Id("d")))),
-            Project(namedTable("a"), Seq(Id("b"), Id("c"), Id("d")), origin = Origin.empty)))
+            Project(namedTable("a"), Seq(Id("b"), Id("c"), Id("d")))(Origin.empty)))
       }
       "WITH a (b, c, d) AS (SELECT x, y, z FROM e), aa (bb, cc) AS (SELECT xx, yy FROM f) SELECT b, c, d FROM a" in {
         singleQueryExample(
@@ -335,13 +335,13 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           expectedAst = WithCTE(
             Seq(
               SubqueryAlias(
-                Project(namedTable("e"), Seq(Id("x"), Id("y"), Id("z")), origin = Origin.empty),
+                Project(namedTable("e"), Seq(Id("x"), Id("y"), Id("z")))(Origin.empty),
                 Id("a"),
                 Seq(Id("b"), Id("c"), Id("d"))),
               SubqueryAlias(
-                Project(namedTable("f"), Seq(Id("xx"), Id("yy")), origin = Origin.empty),
+                Project(namedTable("f"), Seq(Id("xx"), Id("yy")))(Origin.empty),
                 Id("aa"), Seq(Id("bb"), Id("cc")))),
-            Project(namedTable("a"), Seq(Id("b"), Id("c"), Id("d")), origin = Origin.empty)))
+            Project(namedTable("a"), Seq(Id("b"), Id("c"), Id("d")))(Origin.empty)))
       }
     }
 
@@ -363,8 +363,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
                 pivot = None),
               GreaterThanOrEqual(CallFunction("AVG", Seq(Id("c1"))), Literal(5))),
             GreaterThan(CallFunction("MIN", Seq(Id("r"))), Literal(6))),
-          Seq(Id("c2"), Alias(Window(CallFunction("SUM", Seq(Id("c3"))), Seq(Id("c2")), Seq(), None), Id("r"))),
-          origin = Origin.empty))
+          Seq(Id("c2"), Alias(Window(CallFunction("SUM", Seq(Id("c3"))), Seq(Id("c2")), Seq(), None), Id("r"))))
+          (Origin.empty))
     }
 
     "translate a query with set operators" should {
@@ -372,8 +372,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         singleQueryExample(
           "SELECT a FROM t1 UNION SELECT b FROM t2",
           SetOperation(
-            Project(namedTable("t1"), Seq(Id("a")), origin = Origin.empty),
-            Project(namedTable("t2"), Seq(Id("b")), origin = Origin.empty),
+            Project(namedTable("t1"), Seq(Id("a")))(Origin.empty),
+            Project(namedTable("t2"), Seq(Id("b")))(Origin.empty),
             UnionSetOp,
             is_all = false,
             by_name = false,
@@ -383,8 +383,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         singleQueryExample(
           "SELECT a FROM t1 UNION ALL SELECT b FROM t2",
           SetOperation(
-            Project(namedTable("t1"), Seq(Id("a")), origin = Origin.empty),
-            Project(namedTable("t2"), Seq(Id("b")), origin = Origin.empty),
+            Project(namedTable("t1"), Seq(Id("a")))(Origin.empty),
+            Project(namedTable("t2"), Seq(Id("b")))(Origin.empty),
             UnionSetOp,
             is_all = true,
             by_name = false,
@@ -394,8 +394,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         singleQueryExample(
           "SELECT a FROM t1 MINUS SELECT b FROM t2",
           SetOperation(
-            Project(namedTable("t1"), Seq(Id("a")), origin = Origin.empty),
-            Project(namedTable("t2"), Seq(Id("b")), origin = Origin.empty),
+            Project(namedTable("t1"), Seq(Id("a")))(Origin.empty),
+            Project(namedTable("t2"), Seq(Id("b")))(Origin.empty),
             ExceptSetOp,
             is_all = false,
             by_name = false,
@@ -405,8 +405,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         singleQueryExample(
           "SELECT a FROM t1 EXCEPT SELECT b FROM t2",
           SetOperation(
-            Project(namedTable("t1"), Seq(Id("a")), origin = Origin.empty),
-            Project(namedTable("t2"), Seq(Id("b")), origin = Origin.empty),
+            Project(namedTable("t1"), Seq(Id("a")))(Origin.empty),
+            Project(namedTable("t2"), Seq(Id("b")))(Origin.empty),
             ExceptSetOp,
             is_all = false,
             by_name = false,
@@ -416,8 +416,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         singleQueryExample(
           "SELECT a FROM t1 INTERSECT SELECT b FROM t2",
           SetOperation(
-            Project(namedTable("t1"), Seq(Id("a")), origin = Origin.empty),
-            Project(namedTable("t2"), Seq(Id("b")), origin = Origin.empty),
+            Project(namedTable("t1"), Seq(Id("a")))(Origin.empty),
+            Project(namedTable("t2"), Seq(Id("b")))(Origin.empty),
             IntersectSetOp,
             is_all = false,
             by_name = false,
@@ -429,18 +429,18 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           SetOperation(
             SetOperation(
               SetOperation(
-                Project(namedTable("t1"), Seq(Id("a")), origin = Origin.empty),
-                Project(namedTable("t2"), Seq(Id("b")), origin = Origin.empty),
+                Project(namedTable("t1"), Seq(Id("a")))(Origin.empty),
+                Project(namedTable("t2"), Seq(Id("b")))(Origin.empty),
                 IntersectSetOp,
                 is_all = false,
                 by_name = false,
                 allow_missing_columns = false),
-              Project(namedTable("t3"), Seq(Id("c")), origin = Origin.empty),
+              Project(namedTable("t3"), Seq(Id("c")))(Origin.empty),
               ExceptSetOp,
               is_all = false,
               by_name = false,
               allow_missing_columns = false),
-            Project(namedTable("t4"), Seq(Id("d")), origin = Origin.empty),
+            Project(namedTable("t4"), Seq(Id("d")))(Origin.empty),
             UnionSetOp,
             is_all = false,
             by_name = false,
@@ -459,8 +459,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         Batch(
           Seq(
             CreateTableCommand("t1", Seq(ColumnDeclaration("x", StringType))),
-            Project(namedTable("t1"), Seq(Id("x")), origin = Origin.empty),
-            Project(namedTable("t3"), Seq(Literal(3)), origin = Origin.empty))))
+            Project(namedTable("t1"), Seq(Id("x")))(Origin.empty),
+            Project(namedTable("t3"), Seq(Literal(3)))(Origin.empty))))
     }
 
     // Tests below are just meant to verify that SnowflakeAstBuilder properly delegates DML commands
@@ -498,7 +498,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           ruleText = "!set error_flag = true;",
           ruleName = "snowSqlCommand",
           tokenName = Some("SQLCOMMAND"),
-          message = "Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand"))
+          message = "Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand")(Origin.empty))
 
       example(
         "!set dfsdfds",
@@ -507,7 +507,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           ruleText = "!set dfsdfds",
           ruleName = "snowSqlCommand",
           tokenName = Some("SQLCOMMAND"),
-          message = "Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand"))
+          message = "Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand")(Origin.empty))
       assertThrows[Exception] {
         example(
           "!",
@@ -516,7 +516,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             ruleText = "!",
             ruleName = "snowSqlCommand",
             tokenName = Some("SQLCOMMAND"),
-            message = "Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand"))
+            message = "Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand")(Origin.empty))
       }
       assertThrows[Exception] {
         example(
@@ -526,7 +526,7 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             ruleText = "!badcommand",
             ruleName = "snowSqlCommand",
             tokenName = Some("SQLCOMMAND"),
-            message = "Unknown command in SnowflakeAstBuilder.visitSqlCommand"))
+            message = "Unknown command in SnowflakeAstBuilder.visitSqlCommand")(Origin.empty))
       }
     }
 
@@ -537,8 +537,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           // Note when we truly process &vars we should get Variable, not Id
           Project(
             Filter(namedTable("a"), Equals(Id("b"), Id("$ids"))),
-            Seq(Star()),
-            origin = Origin.empty))
+            Seq(Star()))
+            (Origin.empty))
       }
     }
 
@@ -578,8 +578,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
                     Id("employee_id", false),
                     Id("manager_id", false),
                     Id("employee_name", false),
-                    Alias(Literal(1, IntegerType), Id("level", false))),
-                  origin = Origin.empty),
+                    Alias(Literal(1, IntegerType), Id("level", false))))
+                  (Origin.empty),
                 Id("employee_hierarchy", false),
                 Seq.empty)),
             Project(
@@ -589,8 +589,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
                   SortOrder(Id("level", false), Ascending, NullsLast),
                   SortOrder(Id("employee_id", false), Ascending, NullsLast)),
                 false),
-              Seq(Star(None)),
-              origin = Origin.empty)))
+              Seq(Star(None)))
+              (Origin.empty)))
       }
 
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
@@ -15,19 +15,28 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
     "translate a simple SELECT query" in {
       singleQueryExample(
         query = "SELECT a FROM TABLE",
-        expectedAst = Project(NamedTable("TABLE", Map.empty, is_streaming = false), Seq(Id("a"))))
+        expectedAst = Project(
+          NamedTable("TABLE", Map.empty, is_streaming = false),
+          Seq(Id("a")),
+          origin = Origin.empty))
     }
 
     "translate a simple SELECT query with an aliased column" in {
       singleQueryExample(
         query = "SELECT a AS aa FROM b",
-        expectedAst = Project(NamedTable("b", Map.empty, is_streaming = false), Seq(Alias(Id("a"), Id("aa")))))
+        expectedAst = Project(
+          NamedTable("b", Map.empty, is_streaming = false),
+          Seq(Alias(Id("a"), Id("aa"))),
+          origin = Origin.empty))
     }
 
     "translate a simple SELECT query involving multiple columns" in {
       singleQueryExample(
         query = "SELECT a, b, c FROM table_x",
-        expectedAst = Project(NamedTable("table_x", Map.empty, is_streaming = false), Seq(Id("a"), Id("b"), Id("c"))))
+        expectedAst = Project(
+          NamedTable("table_x", Map.empty, is_streaming = false),
+          Seq(Id("a"), Id("b"), Id("c")),
+          origin = Origin.empty))
     }
 
     "translate a SELECT query involving multiple columns and aliases" in {
@@ -35,7 +44,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         query = "SELECT a, b AS bb, c FROM table_x",
         expectedAst = Project(
           NamedTable("table_x", Map.empty, is_streaming = false),
-          Seq(Id("a"), Alias(Id("b"), Id("bb")), Id("c"))))
+          Seq(Id("a"), Alias(Id("b"), Id("bb")), Id("c")),
+          origin = Origin.empty))
     }
 
     val simpleJoinAst =
@@ -50,66 +60,75 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
     "translate a query with a JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x JOIN table_y",
-        expectedAst = Project(simpleJoinAst, Seq(Id("a"))))
+        expectedAst = Project(simpleJoinAst, Seq(Id("a")), origin = Origin.empty))
     }
 
     "translate a query with a INNER JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x INNER JOIN table_y",
-        expectedAst = Project(simpleJoinAst.copy(join_type = InnerJoin), Seq(Id("a"))))
+        expectedAst = Project(simpleJoinAst.copy(join_type = InnerJoin), Seq(Id("a")), origin = Origin.empty))
     }
 
     "translate a query with a CROSS JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x CROSS JOIN table_y",
-        expectedAst = Project(simpleJoinAst.copy(join_type = CrossJoin), Seq(Id("a"))))
+        expectedAst = Project(simpleJoinAst.copy(join_type = CrossJoin), Seq(Id("a")), origin = Origin.empty))
     }
 
     "translate a query with a LEFT JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x LEFT JOIN table_y",
-        expectedAst = Project(simpleJoinAst.copy(join_type = LeftOuterJoin), Seq(Id("a"))))
+        expectedAst = Project(simpleJoinAst.copy(join_type = LeftOuterJoin), Seq(Id("a")), origin = Origin.empty))
     }
 
     "translate a query with a LEFT OUTER JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x LEFT OUTER JOIN table_y",
-        expectedAst = Project(simpleJoinAst.copy(join_type = LeftOuterJoin), Seq(Id("a"))))
+        expectedAst = Project(simpleJoinAst.copy(join_type = LeftOuterJoin), Seq(Id("a")), origin = Origin.empty))
     }
 
     "translate a query with a RIGHT JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x RIGHT JOIN table_y",
-        expectedAst = Project(simpleJoinAst.copy(join_type = RightOuterJoin), Seq(Id("a"))))
+        expectedAst = Project(simpleJoinAst.copy(join_type = RightOuterJoin), Seq(Id("a")), origin = Origin.empty))
     }
 
     "translate a query with a RIGHT OUTER JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x RIGHT OUTER JOIN table_y",
-        expectedAst = Project(simpleJoinAst.copy(join_type = RightOuterJoin), Seq(Id("a"))))
+        expectedAst = Project(simpleJoinAst.copy(join_type = RightOuterJoin), Seq(Id("a")), origin = Origin.empty))
     }
 
     "translate a query with a FULL JOIN" in {
       singleQueryExample(
         query = "SELECT a FROM table_x FULL JOIN table_y",
-        expectedAst = Project(simpleJoinAst.copy(join_type = FullOuterJoin), Seq(Id("a"))))
+        expectedAst = Project(simpleJoinAst.copy(join_type = FullOuterJoin), Seq(Id("a")), origin = Origin.empty))
     }
 
     "translate a query with a NATURAL JOIN" should {
       "SELECT a FROM table_x NATURAL JOIN table_y" in {
         singleQueryExample(
           query = "SELECT a FROM table_x NATURAL JOIN table_y",
-          expectedAst = Project(simpleJoinAst.copy(join_type = NaturalJoin(UnspecifiedJoin)), Seq(Id("a"))))
+          expectedAst = Project(
+            simpleJoinAst.copy(join_type = NaturalJoin(UnspecifiedJoin)),
+            Seq(Id("a")),
+            origin = Origin.empty))
       }
       "SELECT a FROM table_x NATURAL LEFT JOIN table_y" in {
         singleQueryExample(
           query = "SELECT a FROM table_x NATURAL LEFT JOIN table_y",
-          expectedAst = Project(simpleJoinAst.copy(join_type = NaturalJoin(LeftOuterJoin)), Seq(Id("a"))))
+          expectedAst = Project(
+            simpleJoinAst.copy(join_type = NaturalJoin(LeftOuterJoin)),
+            Seq(Id("a")),
+            origin = Origin.empty))
       }
       "SELECT a FROM table_x NATURAL RIGHT JOIN table_y" in {
         singleQueryExample(
           query = "SELECT a FROM table_x NATURAL RIGHT JOIN table_y",
-          expectedAst = Project(simpleJoinAst.copy(join_type = NaturalJoin(RightOuterJoin)), Seq(Id("a"))))
+          expectedAst = Project(
+            simpleJoinAst.copy(join_type = NaturalJoin(RightOuterJoin)),
+            Seq(Id("a")),
+            origin = Origin.empty))
       }
     }
 
@@ -127,7 +146,10 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         singleQueryExample(
           query = s"SELECT a, b FROM c WHERE a $op b",
           expectedAst =
-            Project(Filter(NamedTable("c", Map.empty, is_streaming = false), expectedPredicate), Seq(Id("a"), Id("b"))))
+            Project(
+              Filter(NamedTable("c", Map.empty, is_streaming = false), expectedPredicate),
+              Seq(Id("a"), Id("b")),
+              origin = Origin.empty))
       }
     }
 
@@ -139,7 +161,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             Filter(
               NamedTable("c", Map.empty, is_streaming = false),
               And(Equals(Id("a"), Id("b")), Equals(Id("b"), Id("a")))),
-            Seq(Id("a"), Id("b"))))
+            Seq(Id("a"), Id("b")),
+            origin = Origin.empty))
       }
       "SELECT a, b FROM c WHERE a = b OR b = a" in {
         singleQueryExample(
@@ -148,14 +171,16 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             Filter(
               NamedTable("c", Map.empty, is_streaming = false),
               Or(Equals(Id("a"), Id("b")), Equals(Id("b"), Id("a")))),
-            Seq(Id("a"), Id("b"))))
+            Seq(Id("a"), Id("b")),
+            origin = Origin.empty))
       }
       "SELECT a, b FROM c WHERE NOT a = b" in {
         singleQueryExample(
           query = "SELECT a, b FROM c WHERE NOT a = b",
           expectedAst = Project(
             Filter(NamedTable("c", Map.empty, is_streaming = false), Not(Equals(Id("a"), Id("b")))),
-            Seq(Id("a"), Id("b"))))
+            Seq(Id("a"), Id("b")),
+            origin = Origin.empty))
       }
     }
 
@@ -168,7 +193,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             group_type = GroupBy,
             grouping_expressions = Seq(simplyNamedColumn("a")),
             pivot = None),
-          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b"))))))
+          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b")))),
+          origin = Origin.empty))
     }
 
     "translate a query with a GROUP BY and ORDER BY clauses" in {
@@ -182,7 +208,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
               grouping_expressions = Seq(simplyNamedColumn("a")),
               pivot = None),
             Seq(SortOrder(Id("a"), Ascending, NullsLast))),
-          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b"))))))
+          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b")))),
+          origin = Origin.empty))
     }
 
     "translate a query with GROUP BY HAVING clause" in {
@@ -196,7 +223,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
               grouping_expressions = Seq(simplyNamedColumn("a")),
               pivot = None),
             GreaterThan(CallFunction("COUNT", Seq(Id("b"))), Literal(1))),
-          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b"))))))
+          Seq(Id("a"), CallFunction("COUNT", Seq(Id("b")))),
+          origin = Origin.empty))
     }
 
     "translate a query with ORDER BY" should {
@@ -205,28 +233,32 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           query = "SELECT a FROM b ORDER BY a",
           expectedAst = Project(
             Sort(NamedTable("b", Map.empty, is_streaming = false), Seq(SortOrder(Id("a"), Ascending, NullsLast))),
-            Seq(Id("a"))))
+            Seq(Id("a")),
+            origin = Origin.empty))
       }
       "SELECT a FROM b ORDER BY a DESC" in {
         singleQueryExample(
           "SELECT a FROM b ORDER BY a DESC",
           Project(
             Sort(NamedTable("b", Map.empty, is_streaming = false), Seq(SortOrder(Id("a"), Descending, NullsFirst))),
-            Seq(Id("a"))))
+            Seq(Id("a")),
+            origin = Origin.empty))
       }
       "SELECT a FROM b ORDER BY a NULLS FIRST" in {
         singleQueryExample(
           query = "SELECT a FROM b ORDER BY a NULLS FIRST",
           expectedAst = Project(
             Sort(NamedTable("b", Map.empty, is_streaming = false), Seq(SortOrder(Id("a"), Ascending, NullsFirst))),
-            Seq(Id("a"))))
+            Seq(Id("a")),
+            origin = Origin.empty))
       }
       "SELECT a FROM b ORDER BY a DESC NULLS LAST" in {
         singleQueryExample(
           query = "SELECT a FROM b ORDER BY a DESC NULLS LAST",
           expectedAst = Project(
             Sort(NamedTable("b", Map.empty, is_streaming = false), Seq(SortOrder(Id("a"), Descending, NullsLast))),
-            Seq(Id("a"))))
+            Seq(Id("a")),
+            origin = Origin.empty))
       }
     }
 
@@ -234,19 +266,26 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
       "SELECT a FROM b LIMIT 5" in {
         singleQueryExample(
           query = "SELECT a FROM b LIMIT 5",
-          expectedAst = Project(Limit(NamedTable("b", Map.empty, is_streaming = false), Literal(5)), Seq(Id("a"))))
+          expectedAst = Project(
+            Limit(NamedTable("b", Map.empty, is_streaming = false), Literal(5)),
+            Seq(Id("a")),
+            origin = Origin.empty))
       }
       "SELECT a FROM b LIMIT 5 OFFSET 10" in {
         singleQueryExample(
           query = "SELECT a FROM b LIMIT 5 OFFSET 10",
           expectedAst = Project(
             Offset(Limit(NamedTable("b", Map.empty, is_streaming = false), Literal(5)), Literal(10)),
-            Seq(Id("a"))))
+            Seq(Id("a")),
+            origin = Origin.empty))
       }
       "SELECT a FROM b OFFSET 10 FETCH FIRST 42" in {
         singleQueryExample(
           query = "SELECT a FROM b OFFSET 10 FETCH FIRST 42",
-          expectedAst = Project(Offset(NamedTable("b", Map.empty, is_streaming = false), Literal(10)), Seq(Id("a"))))
+          expectedAst = Project(
+            Offset(NamedTable("b", Map.empty, is_streaming = false), Literal(10)),
+            Seq(Id("a")),
+            origin = Origin.empty))
       }
     }
 
@@ -259,7 +298,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             group_type = Pivot,
             grouping_expressions = Seq(CallFunction("SUM", Seq(simplyNamedColumn("a")))),
             pivot = Some(Pivot(simplyNamedColumn("c"), Seq(Literal("foo"), Literal("bar"))))),
-          Seq(Id("a"))))
+          Seq(Id("a")),
+          origin = Origin.empty))
     }
 
     "translate a query with UNPIVOT" in {
@@ -272,7 +312,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             values = None,
             variable_column_name = Id("c"),
             value_column_name = Id("d")),
-          Seq(Id("a"))))
+          Seq(Id("a")),
+          origin = Origin.empty))
     }
 
     "translate queries with WITH clauses" should {
@@ -282,10 +323,10 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           expectedAst = WithCTE(
             Seq(
               SubqueryAlias(
-                Project(namedTable("e"), Seq(Id("x"), Id("y"), Id("z"))),
+                Project(namedTable("e"), Seq(Id("x"), Id("y"), Id("z")), origin = Origin.empty),
                 Id("a"),
                 Seq(Id("b"), Id("c"), Id("d")))),
-            Project(namedTable("a"), Seq(Id("b"), Id("c"), Id("d")))))
+            Project(namedTable("a"), Seq(Id("b"), Id("c"), Id("d")), origin = Origin.empty)))
       }
       "WITH a (b, c, d) AS (SELECT x, y, z FROM e), aa (bb, cc) AS (SELECT xx, yy FROM f) SELECT b, c, d FROM a" in {
         singleQueryExample(
@@ -294,11 +335,13 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           expectedAst = WithCTE(
             Seq(
               SubqueryAlias(
-                Project(namedTable("e"), Seq(Id("x"), Id("y"), Id("z"))),
+                Project(namedTable("e"), Seq(Id("x"), Id("y"), Id("z")), origin = Origin.empty),
                 Id("a"),
                 Seq(Id("b"), Id("c"), Id("d"))),
-              SubqueryAlias(Project(namedTable("f"), Seq(Id("xx"), Id("yy"))), Id("aa"), Seq(Id("bb"), Id("cc")))),
-            Project(namedTable("a"), Seq(Id("b"), Id("c"), Id("d")))))
+              SubqueryAlias(
+                Project(namedTable("f"), Seq(Id("xx"), Id("yy")), origin = Origin.empty),
+                Id("aa"), Seq(Id("bb"), Id("cc")))),
+            Project(namedTable("a"), Seq(Id("b"), Id("c"), Id("d")), origin = Origin.empty)))
       }
     }
 
@@ -320,7 +363,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
                 pivot = None),
               GreaterThanOrEqual(CallFunction("AVG", Seq(Id("c1"))), Literal(5))),
             GreaterThan(CallFunction("MIN", Seq(Id("r"))), Literal(6))),
-          Seq(Id("c2"), Alias(Window(CallFunction("SUM", Seq(Id("c3"))), Seq(Id("c2")), Seq(), None), Id("r")))))
+          Seq(Id("c2"), Alias(Window(CallFunction("SUM", Seq(Id("c3"))), Seq(Id("c2")), Seq(), None), Id("r"))),
+          origin = Origin.empty))
     }
 
     "translate a query with set operators" should {
@@ -328,8 +372,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         singleQueryExample(
           "SELECT a FROM t1 UNION SELECT b FROM t2",
           SetOperation(
-            Project(namedTable("t1"), Seq(Id("a"))),
-            Project(namedTable("t2"), Seq(Id("b"))),
+            Project(namedTable("t1"), Seq(Id("a")), origin = Origin.empty),
+            Project(namedTable("t2"), Seq(Id("b")), origin = Origin.empty),
             UnionSetOp,
             is_all = false,
             by_name = false,
@@ -339,8 +383,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         singleQueryExample(
           "SELECT a FROM t1 UNION ALL SELECT b FROM t2",
           SetOperation(
-            Project(namedTable("t1"), Seq(Id("a"))),
-            Project(namedTable("t2"), Seq(Id("b"))),
+            Project(namedTable("t1"), Seq(Id("a")), origin = Origin.empty),
+            Project(namedTable("t2"), Seq(Id("b")), origin = Origin.empty),
             UnionSetOp,
             is_all = true,
             by_name = false,
@@ -350,8 +394,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         singleQueryExample(
           "SELECT a FROM t1 MINUS SELECT b FROM t2",
           SetOperation(
-            Project(namedTable("t1"), Seq(Id("a"))),
-            Project(namedTable("t2"), Seq(Id("b"))),
+            Project(namedTable("t1"), Seq(Id("a")), origin = Origin.empty),
+            Project(namedTable("t2"), Seq(Id("b")), origin = Origin.empty),
             ExceptSetOp,
             is_all = false,
             by_name = false,
@@ -361,8 +405,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         singleQueryExample(
           "SELECT a FROM t1 EXCEPT SELECT b FROM t2",
           SetOperation(
-            Project(namedTable("t1"), Seq(Id("a"))),
-            Project(namedTable("t2"), Seq(Id("b"))),
+            Project(namedTable("t1"), Seq(Id("a")), origin = Origin.empty),
+            Project(namedTable("t2"), Seq(Id("b")), origin = Origin.empty),
             ExceptSetOp,
             is_all = false,
             by_name = false,
@@ -372,8 +416,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         singleQueryExample(
           "SELECT a FROM t1 INTERSECT SELECT b FROM t2",
           SetOperation(
-            Project(namedTable("t1"), Seq(Id("a"))),
-            Project(namedTable("t2"), Seq(Id("b"))),
+            Project(namedTable("t1"), Seq(Id("a")), origin = Origin.empty),
+            Project(namedTable("t2"), Seq(Id("b")), origin = Origin.empty),
             IntersectSetOp,
             is_all = false,
             by_name = false,
@@ -385,18 +429,18 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           SetOperation(
             SetOperation(
               SetOperation(
-                Project(namedTable("t1"), Seq(Id("a"))),
-                Project(namedTable("t2"), Seq(Id("b"))),
+                Project(namedTable("t1"), Seq(Id("a")), origin = Origin.empty),
+                Project(namedTable("t2"), Seq(Id("b")), origin = Origin.empty),
                 IntersectSetOp,
                 is_all = false,
                 by_name = false,
                 allow_missing_columns = false),
-              Project(namedTable("t3"), Seq(Id("c"))),
+              Project(namedTable("t3"), Seq(Id("c")), origin = Origin.empty),
               ExceptSetOp,
               is_all = false,
               by_name = false,
               allow_missing_columns = false),
-            Project(namedTable("t4"), Seq(Id("d"))),
+            Project(namedTable("t4"), Seq(Id("d")), origin = Origin.empty),
             UnionSetOp,
             is_all = false,
             by_name = false,
@@ -415,8 +459,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         Batch(
           Seq(
             CreateTableCommand("t1", Seq(ColumnDeclaration("x", StringType))),
-            Project(namedTable("t1"), Seq(Id("x"))),
-            Project(namedTable("t3"), Seq(Literal(3))))))
+            Project(namedTable("t1"), Seq(Id("x")), origin = Origin.empty),
+            Project(namedTable("t3"), Seq(Literal(3)), origin = Origin.empty))))
     }
 
     // Tests below are just meant to verify that SnowflakeAstBuilder properly delegates DML commands
@@ -491,7 +535,10 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         singleQueryExample(
           "select * from a where b = &ids",
           // Note when we truly process &vars we should get Variable, not Id
-          Project(Filter(namedTable("a"), Equals(Id("b"), Id("$ids"))), Seq(Star())))
+          Project(
+            Filter(namedTable("a"), Equals(Id("b"), Id("$ids"))),
+            Seq(Star()),
+            origin = Origin.empty))
       }
     }
 
@@ -531,7 +578,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
                     Id("employee_id", false),
                     Id("manager_id", false),
                     Id("employee_name", false),
-                    Alias(Literal(1, IntegerType), Id("level", false)))),
+                    Alias(Literal(1, IntegerType), Id("level", false))),
+                  origin = Origin.empty),
                 Id("employee_hierarchy", false),
                 Seq.empty)),
             Project(
@@ -541,7 +589,8 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
                   SortOrder(Id("level", false), Ascending, NullsLast),
                   SortOrder(Id("employee_id", false), Ascending, NullsLast)),
                 false),
-              Seq(Star(None)))))
+              Seq(Star(None)),
+              origin = Origin.empty)))
       }
 
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilderSpec.scala
@@ -47,10 +47,8 @@ class SnowflakeCommandBuilderSpec
           dataType = StructType(Seq()),
           defaultExpr = Some(
             ScalarSubquery(
-              Project(
-                NamedTable("some_table", Map(), is_streaming = false),
-                Seq(Id("col1", caseSensitive = false)))
-                (Origin.empty))),
+              Project(NamedTable("some_table", Map(), is_streaming = false), Seq(Id("col1", caseSensitive = false)))(
+                Origin.empty))),
           replace = false))
     }
   }
@@ -88,10 +86,8 @@ class SnowflakeCommandBuilderSpec
           name = Id("query_statement"),
           dataType = Some(StructType(Seq(StructField("col1", UnresolvedType)))),
           value = ScalarSubquery(
-            Project(
-              NamedTable("some_table", Map(), is_streaming = false),
-              Seq(Id("col1", caseSensitive = false)))
-              (Origin.empty))))
+            Project(NamedTable("some_table", Map(), is_streaming = false), Seq(Id("col1", caseSensitive = false)))(
+              Origin.empty))))
     }
   }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilderSpec.scala
@@ -47,7 +47,10 @@ class SnowflakeCommandBuilderSpec
           dataType = StructType(Seq()),
           defaultExpr = Some(
             ScalarSubquery(
-              Project(NamedTable("some_table", Map(), is_streaming = false), Seq(Id("col1", caseSensitive = false))))),
+              Project(
+                NamedTable("some_table", Map(), is_streaming = false),
+                Seq(Id("col1", caseSensitive = false)),
+                origin = Origin.empty))),
           replace = false))
     }
   }
@@ -85,7 +88,10 @@ class SnowflakeCommandBuilderSpec
           name = Id("query_statement"),
           dataType = Some(StructType(Seq(StructField("col1", UnresolvedType)))),
           value = ScalarSubquery(
-            Project(NamedTable("some_table", Map(), is_streaming = false), Seq(Id("col1", caseSensitive = false))))))
+            Project(
+              NamedTable("some_table", Map(), is_streaming = false),
+              Seq(Id("col1", caseSensitive = false)),
+              origin = Origin.empty))))
     }
   }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeCommandBuilderSpec.scala
@@ -49,8 +49,8 @@ class SnowflakeCommandBuilderSpec
             ScalarSubquery(
               Project(
                 NamedTable("some_table", Map(), is_streaming = false),
-                Seq(Id("col1", caseSensitive = false)),
-                origin = Origin.empty))),
+                Seq(Id("col1", caseSensitive = false)))
+                (Origin.empty))),
           replace = false))
     }
   }
@@ -90,8 +90,8 @@ class SnowflakeCommandBuilderSpec
           value = ScalarSubquery(
             Project(
               NamedTable("some_table", Map(), is_streaming = false),
-              Seq(Id("col1", caseSensitive = false)),
-              origin = Origin.empty))))
+              Seq(Id("col1", caseSensitive = false)))
+              (Origin.empty))))
     }
   }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilderSpec.scala
@@ -215,7 +215,10 @@ class SnowflakeDDLBuilderSpec
         example(
           "CREATE TABLE t1 AS (SELECT * FROM t2);",
           CreateTableParams(
-            CreateTableAsSelect("t1", Project(namedTable("t2"), Seq(Star(None))), None, None, None),
+            CreateTableAsSelect("t1", Project(
+              namedTable("t2"),
+              Seq(Star(None)),
+              origin = Origin.empty), None, None, None),
             Map.empty[String, Seq[Constraint]],
             Map.empty[String, Seq[GenericOption]],
             Seq.empty[Constraint],

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilderSpec.scala
@@ -215,10 +215,7 @@ class SnowflakeDDLBuilderSpec
         example(
           "CREATE TABLE t1 AS (SELECT * FROM t2);",
           CreateTableParams(
-            CreateTableAsSelect("t1", Project(
-              namedTable("t2"),
-              Seq(Star(None)))
-              (Origin.empty), None, None, None),
+            CreateTableAsSelect("t1", Project(namedTable("t2"), Seq(Star(None)))(Origin.empty), None, None, None),
             Map.empty[String, Seq[Constraint]],
             Map.empty[String, Seq[GenericOption]],
             Seq.empty[Constraint],
@@ -290,8 +287,7 @@ class SnowflakeDDLBuilderSpec
             ruleText = "ALTER SESSION SET QUERY_TAG = 'TAG'",
             message = "Unknown ALTER command variant",
             ruleName = "alterCommand",
-            tokenName = Some("ALTER"))
-            (Origin.empty))
+            tokenName = Some("ALTER"))(Origin.empty))
       }
 
       "ALTER STREAM mystream SET COMMENT = 'New comment for stream'" in {
@@ -301,8 +297,7 @@ class SnowflakeDDLBuilderSpec
             ruleText = "ALTER STREAM mystream SET COMMENT = 'New comment for stream'",
             message = "Unknown ALTER command variant",
             ruleName = "alterCommand",
-            tokenName = Some("ALTER"))
-            (Origin.empty))
+            tokenName = Some("ALTER"))(Origin.empty))
       }
 
       "CREATE STREAM mystream ON TABLE mytable" in {
@@ -312,8 +307,7 @@ class SnowflakeDDLBuilderSpec
             ruleText = "CREATE STREAM mystream ON TABLE mytable",
             message = "CREATE STREAM UNSUPPORTED",
             ruleName = "createStream",
-            tokenName = Some("STREAM"))
-            (Origin.empty))
+            tokenName = Some("STREAM"))(Origin.empty))
       }
 
       "CREATE TASK t1 SCHEDULE = '30 MINUTE' AS INSERT INTO tbl(ts) VALUES(CURRENT_TIMESTAMP)" in {
@@ -323,8 +317,7 @@ class SnowflakeDDLBuilderSpec
             ruleText = "CREATE TASK t1 SCHEDULE = '30 MINUTE' AS INSERT INTO tbl(ts) VALUES(CURRENT_TIMESTAMP)",
             message = "CREATE TASK UNSUPPORTED",
             ruleName = "createTask",
-            tokenName = Some("TASK"))
-            (Origin.empty))
+            tokenName = Some("TASK"))(Origin.empty))
       }
     }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDDLBuilderSpec.scala
@@ -217,8 +217,8 @@ class SnowflakeDDLBuilderSpec
           CreateTableParams(
             CreateTableAsSelect("t1", Project(
               namedTable("t2"),
-              Seq(Star(None)),
-              origin = Origin.empty), None, None, None),
+              Seq(Star(None)))
+              (Origin.empty), None, None, None),
             Map.empty[String, Seq[Constraint]],
             Map.empty[String, Seq[GenericOption]],
             Seq.empty[Constraint],
@@ -290,7 +290,8 @@ class SnowflakeDDLBuilderSpec
             ruleText = "ALTER SESSION SET QUERY_TAG = 'TAG'",
             message = "Unknown ALTER command variant",
             ruleName = "alterCommand",
-            tokenName = Some("ALTER")))
+            tokenName = Some("ALTER"))
+            (Origin.empty))
       }
 
       "ALTER STREAM mystream SET COMMENT = 'New comment for stream'" in {
@@ -300,7 +301,8 @@ class SnowflakeDDLBuilderSpec
             ruleText = "ALTER STREAM mystream SET COMMENT = 'New comment for stream'",
             message = "Unknown ALTER command variant",
             ruleName = "alterCommand",
-            tokenName = Some("ALTER")))
+            tokenName = Some("ALTER"))
+            (Origin.empty))
       }
 
       "CREATE STREAM mystream ON TABLE mytable" in {
@@ -310,7 +312,8 @@ class SnowflakeDDLBuilderSpec
             ruleText = "CREATE STREAM mystream ON TABLE mytable",
             message = "CREATE STREAM UNSUPPORTED",
             ruleName = "createStream",
-            tokenName = Some("STREAM")))
+            tokenName = Some("STREAM"))
+            (Origin.empty))
       }
 
       "CREATE TASK t1 SCHEDULE = '30 MINUTE' AS INSERT INTO tbl(ts) VALUES(CURRENT_TIMESTAMP)" in {
@@ -320,7 +323,8 @@ class SnowflakeDDLBuilderSpec
             ruleText = "CREATE TASK t1 SCHEDULE = '30 MINUTE' AS INSERT INTO tbl(ts) VALUES(CURRENT_TIMESTAMP)",
             message = "CREATE TASK UNSUPPORTED",
             ruleName = "createTask",
-            tokenName = Some("TASK")))
+            tokenName = Some("TASK"))
+            (Origin.empty))
       }
     }
 
@@ -382,13 +386,13 @@ class SnowflakeDDLBuilderSpec
         ruleText = "Mocked string",
         message = "Unknown ALTER TABLE variant",
         ruleName = "alterTable",
-        tokenName = Some("ID"))
+        tokenName = Some("ID"))(Origin.empty)
       verify(alterTable).dotIdentifier(0)
       verify(alterTable).tableColumnAction()
       verify(alterTable).constraintAction()
       verify(alterTable).getRuleIndex
-      verify(alterTable, times(3)).getStart
-      verify(alterTable).getStop
+      verify(alterTable, times(4)).getStart
+      verify(alterTable, times(2)).getStop
       verifyNoMoreInteractions(alterTable)
     }
   }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilderSpec.scala
@@ -16,7 +16,7 @@ class SnowflakeDMLBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           InsertIntoTable(
             namedTable("foo"),
             None,
-            Project(Limit(namedTable("bar"), Literal(100)), Seq(Star(None))),
+            Project(Limit(namedTable("bar"), Literal(100)), Seq(Star(None)), origin = Origin.empty),
             None,
             None,
             overwrite = false))
@@ -28,7 +28,7 @@ class SnowflakeDMLBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           InsertIntoTable(
             namedTable("foo"),
             None,
-            Project(Limit(namedTable("bar"), Literal(100)), Seq(Star(None))),
+            Project(Limit(namedTable("bar"), Literal(100)), Seq(Star(None)), origin = Origin.empty),
             None,
             None,
             overwrite = true))
@@ -84,7 +84,7 @@ class SnowflakeDMLBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             _.deleteStatement(),
             MergeIntoTable(
               TableAlias(namedTable("table1"), "t1", Seq()),
-              SubqueryAlias(Project(namedTable("table2"), Seq(Star(None))), Id("t2"), Seq()),
+              SubqueryAlias(Project(namedTable("table2"), Seq(Star(None)), origin = Origin.empty), Id("t2"), Seq()),
               Equals(Dot(Id("t1"), Id("c1")), Dot(Id("t2"), Id("c2"))),
               matchedActions = Seq(DeleteAction(None))))
         }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeDMLBuilderSpec.scala
@@ -16,7 +16,7 @@ class SnowflakeDMLBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           InsertIntoTable(
             namedTable("foo"),
             None,
-            Project(Limit(namedTable("bar"), Literal(100)), Seq(Star(None)), origin = Origin.empty),
+            Project(Limit(namedTable("bar"), Literal(100)), Seq(Star(None)))(Origin.empty),
             None,
             None,
             overwrite = false))
@@ -28,7 +28,7 @@ class SnowflakeDMLBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           InsertIntoTable(
             namedTable("foo"),
             None,
-            Project(Limit(namedTable("bar"), Literal(100)), Seq(Star(None)), origin = Origin.empty),
+            Project(Limit(namedTable("bar"), Literal(100)), Seq(Star(None)))(Origin.empty),
             None,
             None,
             overwrite = true))
@@ -84,7 +84,7 @@ class SnowflakeDMLBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
             _.deleteStatement(),
             MergeIntoTable(
               TableAlias(namedTable("table1"), "t1", Seq()),
-              SubqueryAlias(Project(namedTable("table2"), Seq(Star(None)), origin = Origin.empty), Id("t2"), Seq()),
+              SubqueryAlias(Project(namedTable("table2"), Seq(Star(None)))(Origin.empty), Id("t2"), Seq()),
               Equals(Dot(Id("t1"), Id("c1")), Dot(Id("t2"), Id("c2"))),
               matchedActions = Seq(DeleteAction(None))))
         }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
@@ -127,12 +127,12 @@ class SnowflakeExprSpec extends AnyWordSpec with SnowflakeParserTestCommon with 
       "col1 IN (SELECT * FROM t)" in {
         searchConditionExample(
           "col1 IN (SELECT * FROM t)",
-          In(Id("col1"), Seq(ScalarSubquery(Project(namedTable("t"), Seq(Star(None)))))))
+          In(Id("col1"), Seq(ScalarSubquery(Project(namedTable("t"), Seq(Star(None)), origin = Origin.empty)))))
       }
       "col1 NOT IN (SELECT * FROM t)" in {
         searchConditionExample(
           "col1 NOT IN (SELECT * FROM t)",
-          Not(In(Id("col1"), Seq(ScalarSubquery(Project(namedTable("t"), Seq(Star(None))))))))
+          Not(In(Id("col1"), Seq(ScalarSubquery(Project(namedTable("t"), Seq(Star(None)), origin = Origin.empty))))))
       }
       "col1 IN (1, 2, 3)" in {
         searchConditionExample("col1 IN (1, 2, 3)", In(Id("col1"), Seq(Literal(1), Literal(2), Literal(3))))

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExprSpec.scala
@@ -127,12 +127,12 @@ class SnowflakeExprSpec extends AnyWordSpec with SnowflakeParserTestCommon with 
       "col1 IN (SELECT * FROM t)" in {
         searchConditionExample(
           "col1 IN (SELECT * FROM t)",
-          In(Id("col1"), Seq(ScalarSubquery(Project(namedTable("t"), Seq(Star(None)), origin = Origin.empty)))))
+          In(Id("col1"), Seq(ScalarSubquery(Project(namedTable("t"), Seq(Star(None)))(Origin.empty)))))
       }
       "col1 NOT IN (SELECT * FROM t)" in {
         searchConditionExample(
           "col1 NOT IN (SELECT * FROM t)",
-          Not(In(Id("col1"), Seq(ScalarSubquery(Project(namedTable("t"), Seq(Star(None)), origin = Origin.empty))))))
+          Not(In(Id("col1"), Seq(ScalarSubquery(Project(namedTable("t"), Seq(Star(None)))(Origin.empty))))))
       }
       "col1 IN (1, 2, 3)" in {
         searchConditionExample("col1 IN (1, 2, 3)", In(Id("col1"), Seq(Literal(1), Literal(2), Literal(3))))

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
@@ -349,7 +349,7 @@ class SnowflakeExpressionBuilderSpec
       exampleExpr(
         query = "(SELECT col1 from table_expr)",
         rule = _.expr(),
-        expectedAst = ScalarSubquery(Project(namedTable("table_expr"), Seq(Id("col1")), origin = Origin.empty)))
+        expectedAst = ScalarSubquery(Project(namedTable("table_expr"), Seq(Id("col1")))(Origin.empty)))
     }
   }
 
@@ -397,16 +397,14 @@ class SnowflakeExpressionBuilderSpec
     "translate EXISTS expressions" in {
       exampleExpr("EXISTS (SELECT * FROM t)", _.predicate, Exists(Project(
         namedTable("t"),
-        Seq(Star(None)),
-        origin = Origin.empty)))
+        Seq(Star(None)))(Origin.empty)))
     }
 
     // see https://github.com/databrickslabs/remorph/issues/273
     "translate NOT EXISTS expressions" ignore {
       exampleExpr("NOT EXISTS (SELECT * FROM t)", _.expr(), Not(Exists(Project(
         namedTable("t"),
-        Seq(Star(None)),
-        origin = Origin.empty))))
+        Seq(Star(None)))(Origin.empty))))
     }
   }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
@@ -349,7 +349,7 @@ class SnowflakeExpressionBuilderSpec
       exampleExpr(
         query = "(SELECT col1 from table_expr)",
         rule = _.expr(),
-        expectedAst = ScalarSubquery(Project(namedTable("table_expr"), Seq(Id("col1")))))
+        expectedAst = ScalarSubquery(Project(namedTable("table_expr"), Seq(Id("col1")), origin = Origin.empty)))
     }
   }
 
@@ -395,12 +395,18 @@ class SnowflakeExpressionBuilderSpec
     }
 
     "translate EXISTS expressions" in {
-      exampleExpr("EXISTS (SELECT * FROM t)", _.predicate, Exists(Project(namedTable("t"), Seq(Star(None)))))
+      exampleExpr("EXISTS (SELECT * FROM t)", _.predicate, Exists(Project(
+        namedTable("t"),
+        Seq(Star(None)),
+        origin = Origin.empty)))
     }
 
     // see https://github.com/databrickslabs/remorph/issues/273
     "translate NOT EXISTS expressions" ignore {
-      exampleExpr("NOT EXISTS (SELECT * FROM t)", _.expr(), Not(Exists(Project(namedTable("t"), Seq(Star(None))))))
+      exampleExpr("NOT EXISTS (SELECT * FROM t)", _.expr(), Not(Exists(Project(
+        namedTable("t"),
+        Seq(Star(None)),
+        origin = Origin.empty))))
     }
   }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeExpressionBuilderSpec.scala
@@ -395,16 +395,18 @@ class SnowflakeExpressionBuilderSpec
     }
 
     "translate EXISTS expressions" in {
-      exampleExpr("EXISTS (SELECT * FROM t)", _.predicate, Exists(Project(
-        namedTable("t"),
-        Seq(Star(None)))(Origin.empty)))
+      exampleExpr(
+        "EXISTS (SELECT * FROM t)",
+        _.predicate,
+        Exists(Project(namedTable("t"), Seq(Star(None)))(Origin.empty)))
     }
 
     // see https://github.com/databrickslabs/remorph/issues/273
     "translate NOT EXISTS expressions" ignore {
-      exampleExpr("NOT EXISTS (SELECT * FROM t)", _.expr(), Not(Exists(Project(
-        namedTable("t"),
-        Seq(Star(None)))(Origin.empty))))
+      exampleExpr(
+        "NOT EXISTS (SELECT * FROM t)",
+        _.expr(),
+        Not(Exists(Project(namedTable("t"), Seq(Star(None)))(Origin.empty))))
     }
   }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
@@ -62,7 +62,7 @@ class SnowflakeRelationBuilderSpec
         example(
           "FROM (SELECT * FROM t1) t2",
           _.fromClause(),
-          SubqueryAlias(Project(namedTable("t1"), Seq(Star(None)), origin = Origin.empty), Id("t2"), Seq()))
+          SubqueryAlias(Project(namedTable("t1"), Seq(Star(None)))(Origin.empty), Id("t2"), Seq()))
       }
     }
 
@@ -227,13 +227,13 @@ class SnowflakeRelationBuilderSpec
         example(
           "WITH a AS (SELECT x, y FROM d)",
           _.withExpression(),
-          SubqueryAlias(Project(namedTable("d"), Seq(Id("x"), Id("y")), origin = Origin.empty), Id("a"), Seq()))
+          SubqueryAlias(Project(namedTable("d"), Seq(Id("x"), Id("y")))(Origin.empty), Id("a"), Seq()))
       }
       "WITH a (b, c) AS (SELECT x, y FROM d)" in {
         example(
           "WITH a (b, c) AS (SELECT x, y FROM d)",
           _.withExpression(),
-          SubqueryAlias(Project(namedTable("d"), Seq(Id("x"), Id("y")), origin = Origin.empty), Id("a"), Seq(Id("b"), Id("c"))))
+          SubqueryAlias(Project(namedTable("d"), Seq(Id("x"), Id("y")))(Origin.empty), Id("a"), Seq(Id("b"), Id("c"))))
       }
     }
 
@@ -268,7 +268,7 @@ class SnowflakeRelationBuilderSpec
         example(
           "SELECT TOP 42 a FROM t",
           _.selectStatement(),
-          Project(Limit(namedTable("t"), Literal(42)), Seq(Id("a")), origin = Origin.empty))
+          Project(Limit(namedTable("t"), Literal(42)), Seq(Id("a")))(Origin.empty))
       }
       "SELECT DISTINCT TOP 42 a FROM t" in {
         example(

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
@@ -62,7 +62,7 @@ class SnowflakeRelationBuilderSpec
         example(
           "FROM (SELECT * FROM t1) t2",
           _.fromClause(),
-          SubqueryAlias(Project(namedTable("t1"), Seq(Star(None))), Id("t2"), Seq()))
+          SubqueryAlias(Project(namedTable("t1"), Seq(Star(None)), origin = Origin.empty), Id("t2"), Seq()))
       }
     }
 
@@ -227,13 +227,13 @@ class SnowflakeRelationBuilderSpec
         example(
           "WITH a AS (SELECT x, y FROM d)",
           _.withExpression(),
-          SubqueryAlias(Project(namedTable("d"), Seq(Id("x"), Id("y"))), Id("a"), Seq()))
+          SubqueryAlias(Project(namedTable("d"), Seq(Id("x"), Id("y")), origin = Origin.empty), Id("a"), Seq()))
       }
       "WITH a (b, c) AS (SELECT x, y FROM d)" in {
         example(
           "WITH a (b, c) AS (SELECT x, y FROM d)",
           _.withExpression(),
-          SubqueryAlias(Project(namedTable("d"), Seq(Id("x"), Id("y"))), Id("a"), Seq(Id("b"), Id("c"))))
+          SubqueryAlias(Project(namedTable("d"), Seq(Id("x"), Id("y")), origin = Origin.empty), Id("a"), Seq(Id("b"), Id("c"))))
       }
     }
 
@@ -268,7 +268,7 @@ class SnowflakeRelationBuilderSpec
         example(
           "SELECT TOP 42 a FROM t",
           _.selectStatement(),
-          Project(Limit(namedTable("t"), Literal(42)), Seq(Id("a"))))
+          Project(Limit(namedTable("t"), Literal(42)), Seq(Id("a")), origin = Origin.empty))
       }
       "SELECT DISTINCT TOP 42 a FROM t" in {
         example(

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -28,15 +28,15 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         query = "SELECT a FROM dbo.table_x",
         expectedAst = Batch(Seq(Project(
           namedTable("dbo.table_x"),
-          Seq(simplyNamedColumn("a")),
-          origin = Origin.empty))))
+          Seq(simplyNamedColumn("a")))
+          (Origin.empty))))
 
       example(
         query = "SELECT a FROM TABLE",
         expectedAst = Batch(Seq(Project(
           namedTable("TABLE"),
-          Seq(simplyNamedColumn("a")),
-          origin = Origin.empty))))
+          Seq(simplyNamedColumn("a")))
+          (Origin.empty))))
     }
 
     "translate column aliases" in {
@@ -46,8 +46,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Seq(
             Project(
               namedTable("dbo.table_x"),
-              Seq(Alias(simplyNamedColumn("a"), Id("b")), Alias(simplyNamedColumn("BigCol"), Id("J"))),
-              origin = Origin.empty))))
+              Seq(Alias(simplyNamedColumn("a"), Id("b")), Alias(simplyNamedColumn("BigCol"), Id("J"))))
+              (Origin.empty))))
     }
 
     "accept constants in selects" in {
@@ -64,8 +64,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 Literal("0x5A"),
                 Literal(2700000000L),
                 Literal(4.24523534425245e10),
-                Money(StringLiteral("$40"))),
-              origin = Origin.empty))))
+                Money(StringLiteral("$40"))))
+              (Origin.empty))))
     }
 
     "translate collation specifiers" in {
@@ -74,8 +74,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         expectedAst =
           Batch(Seq(Project(
             namedTable("dbo.table_x"),
-            Seq(Collate(simplyNamedColumn("a"), "Latin1_General_BIN")),
-            origin = Origin.empty))))
+            Seq(Collate(simplyNamedColumn("a"), "Latin1_General_BIN")))
+            (Origin.empty))))
     }
 
     "translate table source items with aliases" in {
@@ -83,8 +83,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         query = "SELECT a FROM dbo.table_x AS t",
         expectedAst = Batch(Seq(Project(
           TableAlias(namedTable("dbo.table_x"), "t"),
-          Seq(simplyNamedColumn("a")),
-          origin = Origin.empty))))
+          Seq(simplyNamedColumn("a")))
+          (Origin.empty))))
     }
 
     "translate table sources involving *" in {
@@ -92,33 +92,31 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         query = "SELECT * FROM dbo.table_x",
         expectedAst = Batch(Seq(Project(
           namedTable("dbo.table_x"),
-          Seq(Star(None)),
-          origin = Origin.empty))))
+          Seq(Star(None)))
+          (Origin.empty))))
 
       example(
         query = "SELECT t.*",
         expectedAst = Batch(Seq(Project(
           NoTable(),
-          Seq(Star(objectName = Some(ObjectReference(Id("t"))))),
-          origin = Origin.empty))))
+          Seq(Star(objectName = Some(ObjectReference(Id("t"))))))
+          (Origin.empty))))
 
       example(
         query = "SELECT x..b.y.*",
         expectedAst =
           Batch(Seq(Project(
             NoTable(),
-            Seq(Star(objectName = Some(ObjectReference(Id("x"), Id("b"), Id("y"))))),
-            origin = Origin.empty))))
+            Seq(Star(objectName = Some(ObjectReference(Id("x"), Id("b"), Id("y"))))))
+            (Origin.empty))))
 
       // TODO: Add tests for OUTPUT clause once implemented - invalid semantics here to force coverage
       example(query = "SELECT INSERTED.*", expectedAst = Batch(Seq(Project(
         NoTable(),
-        Seq(Inserted(Star(None))),
-        origin = Origin.empty))))
+        Seq(Inserted(Star(None))))(Origin.empty))))
       example(query = "SELECT DELETED.*", expectedAst = Batch(Seq(Project(
         NoTable(),
-        Seq(Deleted(Star(None))),
-        origin = Origin.empty))))
+        Seq(Deleted(Star(None))))(Origin.empty))))
     }
 
     "infer a cross join" in {
@@ -133,8 +131,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               CrossJoin,
               Seq.empty,
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            Seq(simplyNamedColumn("a"), simplyNamedColumn("b"), simplyNamedColumn("c")),
-            origin = Origin.empty))))
+            Seq(simplyNamedColumn("a"), simplyNamedColumn("b"), simplyNamedColumn("c")))
+            (Origin.empty))))
     }
 
     val t1aCol = Column(Some(ObjectReference(Id("T1"))), Id("A"))
@@ -157,8 +155,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               InnerJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            List(t1aCol, t2bCol),
-            origin = Origin.empty))))
+            List(t1aCol, t2bCol))
+            (Origin.empty))))
     }
     "translate a query with Multiple JOIN AND Condition" in {
 
@@ -180,8 +178,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               LeftOuterJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            List(t1aCol, t2bCol),
-            origin = Origin.empty))))
+            List(t1aCol, t2bCol))
+            (Origin.empty))))
     }
     "translate a query with Multiple JOIN OR Conditions" in {
       example(
@@ -202,8 +200,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               LeftOuterJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            List(t1aCol, t2bCol),
-            origin = Origin.empty))))
+            List(t1aCol, t2bCol))
+            (Origin.empty))))
     }
     "translate a query with a RIGHT OUTER JOIN" in {
       example(
@@ -217,8 +215,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               RightOuterJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            List(t1aCol),
-            origin = Origin.empty))))
+            List(t1aCol))
+            (Origin.empty))))
     }
     "translate a query with a FULL OUTER JOIN" in {
       example(
@@ -232,8 +230,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               FullOuterJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            List(t1aCol),
-            origin = Origin.empty))))
+            List(t1aCol))
+            (Origin.empty))))
     }
 
     "cover default case in translateJoinType" in {
@@ -264,8 +262,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Seq(Project(
             namedTable("tab"),
             Seq(tsql
-              .TsqlXmlFunction(CallFunction("query", Seq(Literal("/root/child"))), simplyNamedColumn("xmlcolumn"))),
-            origin = Origin.empty))))
+              .TsqlXmlFunction(CallFunction("query", Seq(Literal("/root/child"))), simplyNamedColumn("xmlcolumn"))))
+            (Origin.empty))))
 
       example(
         "SELECT xmlcolumn.value('path', 'type') FROM tab",
@@ -275,8 +273,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               namedTable("tab"),
               Seq(tsql.TsqlXmlFunction(
                 CallFunction("value", Seq(Literal("path"), Literal("type"))),
-                simplyNamedColumn("xmlcolumn"))),
-              origin = Origin.empty))))
+                simplyNamedColumn("xmlcolumn"))))
+              (Origin.empty))))
 
       example(
         "SELECT xmlcolumn.exist('/root/child[text()=\"Some Value\"]') FROM xmltable;",
@@ -285,8 +283,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             namedTable("xmltable"),
             Seq(tsql.TsqlXmlFunction(
               CallFunction("exist", Seq(Literal("/root/child[text()=\"Some Value\"]"))),
-              simplyNamedColumn("xmlcolumn"))),
-            origin = Origin.empty))))
+              simplyNamedColumn("xmlcolumn"))))
+            (Origin.empty))))
 
       // TODO: Add nodes(), modify(), when we complete UPDATE and CROSS APPLY
     }
@@ -301,8 +299,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             Seq(
               Assign(Identifier("@a", isQuoted = false), Literal(1)),
               Assign(Identifier("@b", isQuoted = false), Literal(2)),
-              Assign(Identifier("@c", isQuoted = false), Literal(3))),
-            origin = Origin.empty))))
+              Assign(Identifier("@c", isQuoted = false), Literal(3))))
+            (Origin.empty))))
 
       example(
         query = "SELECT @a += 1, @b -= 2",
@@ -311,8 +309,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             NoTable(),
             Seq(
               Assign(Identifier("@a", isQuoted = false), Add(Identifier("@a", isQuoted = false), Literal(1))),
-              Assign(Identifier("@b", isQuoted = false), Subtract(Identifier("@b", isQuoted = false), Literal(2)))),
-            origin = Origin.empty))))
+              Assign(Identifier("@b", isQuoted = false), Subtract(Identifier("@b", isQuoted = false), Literal(2)))))
+            (Origin.empty))))
 
       example(
         query = "SELECT @a *= 1, @b /= 2",
@@ -321,8 +319,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             NoTable(),
             Seq(
               Assign(Identifier("@a", isQuoted = false), Multiply(Identifier("@a", isQuoted = false), Literal(1))),
-              Assign(Identifier("@b", isQuoted = false), Divide(Identifier("@b", isQuoted = false), Literal(2)))),
-            origin = Origin.empty))))
+              Assign(Identifier("@b", isQuoted = false), Divide(Identifier("@b", isQuoted = false), Literal(2)))))
+            (Origin.empty))))
 
       example(
         query = "SELECT @a %= myColumn",
@@ -332,8 +330,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               NoTable(),
               Seq(Assign(
                 Identifier("@a", isQuoted = false),
-                Mod(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))),
-              origin = Origin.empty))))
+                Mod(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))))
+              (Origin.empty))))
 
       example(
         query = "SELECT @a &= myColumn",
@@ -343,8 +341,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               NoTable(),
               Seq(Assign(
                 Identifier("@a", isQuoted = false),
-                BitwiseAnd(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))),
-              origin = Origin.empty))))
+                BitwiseAnd(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))))
+              (Origin.empty))))
 
       example(
         query = "SELECT @a ^= myColumn",
@@ -354,8 +352,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               NoTable(),
               Seq(Assign(
                 Identifier("@a", isQuoted = false),
-                BitwiseXor(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))),
-              origin = Origin.empty))))
+                BitwiseXor(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))))
+              (Origin.empty))))
 
       example(
         query = "SELECT @a |= myColumn",
@@ -365,8 +363,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               NoTable(),
               Seq(Assign(
                 Identifier("@a", isQuoted = false),
-                BitwiseOr(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))),
-              origin = Origin.empty))))
+                BitwiseOr(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))))
+              (Origin.empty))))
     }
     "translate scalar subqueries as expressions in select list" in {
       example(
@@ -385,10 +383,10 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               Alias(
                 ScalarSubquery(Project(
                   namedTable("Employees"),
-                  Seq(simplyNamedColumn("AvgSalary")),
-                  origin = Origin.empty)),
-                Id("AverageSalary"))),
-            origin = Origin.empty))))
+                  Seq(simplyNamedColumn("AvgSalary")))
+                  (Origin.empty)),
+                Id("AverageSalary"))))
+            (Origin.empty))))
     }
   }
 
@@ -399,15 +397,15 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         Seq(
           Project(
             Deduplicate(namedTable("Employees"), List(), all_columns_as_keys = true, within_watermark = false),
-            Seq(Star(None)),
-            origin = Origin.empty))))
+            Seq(Star(None)))
+            (Origin.empty))))
     example(
       query = "SELECT DISTINCT a, b AS bb FROM t",
       expectedAst = Batch(
         Seq(Project(
           Deduplicate(namedTable("t"), List(Id("a"), Id("bb")), all_columns_as_keys = false, within_watermark = false),
-          Seq(simplyNamedColumn("a"), Alias(simplyNamedColumn("b"), Id("bb"))),
-          origin = Origin.empty))))
+          Seq(simplyNamedColumn("a"), Alias(simplyNamedColumn("b"), Id("bb"))))
+          (Origin.empty))))
   }
 
   "SELECT NEXT VALUE FOR mySequence As nextVal" in {
@@ -416,8 +414,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
       expectedAst = Batch(
         Seq(Project(
           NoTable(),
-          Seq(Alias(CallFunction("MONOTONICALLY_INCREASING_ID", List.empty), Id("nextVal"))),
-          origin = Origin.empty))))
+          Seq(Alias(CallFunction("MONOTONICALLY_INCREASING_ID", List.empty), Id("nextVal"))))
+        (Origin.empty))))
   }
 
   "SELECT NEXT VALUE FOR var.mySequence As nextVal" in {
@@ -426,8 +424,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
       expectedAst = Batch(
         Seq(Project(
           NoTable(),
-          Seq(Alias(CallFunction("MONOTONICALLY_INCREASING_ID", List.empty), Id("nextVal"))),
-          origin = Origin.empty))))
+          Seq(Alias(CallFunction("MONOTONICALLY_INCREASING_ID", List.empty), Id("nextVal"))))
+        (Origin.empty))))
   }
 
   "SELECT NEXT VALUE FOR var.mySequence OVER (ORDER BY myColumn) As nextVal" in {
@@ -442,8 +440,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               List.empty,
               List(SortOrder(simplyNamedColumn("myColumn"), UnspecifiedSortDirection, SortNullsUnspecified)),
               None),
-            Id("nextVal"))),
-          origin = Origin.empty))))
+            Id("nextVal"))))
+          (Origin.empty))))
 
   }
 
@@ -453,8 +451,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
       expectedAst = Batch(
         Seq(
           WithCTE(
-            Seq(SubqueryAlias(Project(namedTable("t"), Seq(Star(None)), origin = Origin.empty), Id("cte"), List.empty)),
-            Project(namedTable("cte"), Seq(Star(None)), origin = Origin.empty)))))
+            Seq(SubqueryAlias(Project(namedTable("t"), Seq(Star(None)))(Origin.empty), Id("cte"), List.empty)),
+            Project(namedTable("cte"), Seq(Star(None)))(Origin.empty)))))
 
     example(
       query = """WITH cteTable1 (col1, col2, col3count)
@@ -480,8 +478,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 Seq(
                   simplyNamedColumn("col1"),
                   simplyNamedColumn("fred"),
-                  Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter"))),
-                origin = Origin.empty),
+                  Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter"))))
+                (Origin.empty),
               Id("cteTable1"),
               Seq(Id("col1"), Id("col2"), Id("col3count"))),
             SubqueryAlias(
@@ -490,8 +488,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 Seq(
                   simplyNamedColumn("col1"),
                   simplyNamedColumn("fred"),
-                  Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter"))),
-                origin = Origin.empty),
+                  Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter"))))
+                (Origin.empty),
               Id("cteTable2"),
               Seq(Id("colx"), Id("coly"), Id("colxcount")))),
           Project(
@@ -502,8 +500,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               simplyNamedColumn("col3count"),
               simplyNamedColumn("colx"),
               simplyNamedColumn("coly"),
-              simplyNamedColumn("colxcount")),
-            origin = Origin.empty)))))
+              simplyNamedColumn("colxcount")))
+            (Origin.empty)))))
   }
 
   "translate a SELECT with a TOP clause" should {
@@ -512,8 +510,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         query = "SELECT TOP 10 * FROM Employees;",
         expectedAst = Batch(Seq(Project(
           Limit(namedTable("Employees"), Literal(10)),
-          Seq(Star(None)),
-          origin = Origin.empty))))
+          Seq(Star(None)))
+          (Origin.empty))))
     }
 
     "use TOP PERCENT" in {
@@ -521,16 +519,16 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         query = "SELECT TOP 10 PERCENT * FROM Employees;",
         expectedAst = Batch(Seq(Project(
           TopPercent(namedTable("Employees"), Literal(10)),
-          Seq(Star(None)),
-          origin = Origin.empty))))
+          Seq(Star(None)))
+          (Origin.empty))))
 
       example(
         query = "SELECT TOP 10 PERCENT WITH TIES * FROM Employees;",
         expectedAst =
           Batch(Seq(Project(
             TopPercent(namedTable("Employees"), Literal(10), with_ties = true),
-            Seq(Star(None)),
-            origin = Origin.empty))))
+            Seq(Star(None)))
+            (Origin.empty))))
     }
   }
 
@@ -545,8 +543,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               Seq(SortOrder(simplyNamedColumn("Salary"), Ascending, SortNullsUnspecified)),
               is_global = false),
             Literal(10)),
-          Seq(Star(None)),
-          origin = Origin.empty))))
+          Seq(Star(None)))
+          (Origin.empty))))
 
     example(
       query = "SELECT * FROM Employees ORDER BY Salary OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY",
@@ -560,8 +558,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 is_global = false),
               Literal(10)),
             Literal(5)),
-          Seq(Star(None)),
-          origin = Origin.empty))))
+          Seq(Star(None)))
+          (Origin.empty))))
   }
 
   "translate SELECT with a combination of DISTINCT, ORDER BY, and OFFSET" in {
@@ -579,8 +577,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             List(),
             all_columns_as_keys = true,
             within_watermark = false),
-          Seq(Star(None)),
-          origin = Origin.empty))))
+          Seq(Star(None)))
+          (Origin.empty))))
 
     example(
       query = "SELECT DISTINCT * FROM Employees ORDER BY Salary OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY",
@@ -598,8 +596,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             List(),
             all_columns_as_keys = true,
             within_watermark = false),
-          List(Star(None)),
-          origin = Origin.empty))))
+          List(Star(None)))
+          (Origin.empty))))
   }
 
   "translate a query with PIVOT" in {
@@ -611,8 +609,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           group_type = Pivot,
           grouping_expressions = Seq(CallFunction("SUM", Seq(simplyNamedColumn("a")))),
           pivot = Some(Pivot(simplyNamedColumn("c"), Seq(Literal("foo"), Literal("bar"))))),
-        Seq(simplyNamedColumn("a")),
-        origin = Origin.empty))
+        Seq(simplyNamedColumn("a")))(Origin.empty))
   }
 
   "translate a query with UNPIVOT" in {
@@ -625,8 +622,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           values = None,
           variable_column_name = Id("c"),
           value_column_name = Id("d")),
-        Seq(simplyNamedColumn("a")),
-        origin = Origin.empty))
+        Seq(simplyNamedColumn("a")))(Origin.empty))
   }
 
   "translate a query with an explicit CROSS JOIN" in {
@@ -640,8 +636,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           CrossJoin,
           Seq.empty,
           JoinDataType(is_left_struct = false, is_right_struct = false)),
-        Seq(simplyNamedColumn("a")),
-        origin = Origin.empty))
+        Seq(simplyNamedColumn("a")))(Origin.empty))
   }
 
   "translate a query with an explicit OUTER APPLY" in {
@@ -655,8 +650,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           OuterApply,
           Seq.empty,
           JoinDataType(is_left_struct = false, is_right_struct = false)),
-        Seq(simplyNamedColumn("a")),
-        origin = Origin.empty))
+        Seq(simplyNamedColumn("a")))(Origin.empty))
   }
 
   "translate a query with an explicit CROSS APPLY" in {
@@ -670,14 +664,13 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           CrossApply,
           Seq.empty,
           JoinDataType(is_left_struct = false, is_right_struct = false)),
-        Seq(simplyNamedColumn("a")),
-        origin = Origin.empty))
+        Seq(simplyNamedColumn("a")))(Origin.empty))
   }
 
   "parse and ignore IR for the FOR clause in a SELECT statement" in {
     example(
       query = "SELECT * FROM DAYS FOR XML RAW",
-      expectedAst = Batch(Seq(Project(namedTable("DAYS"), Seq(Star(None)), origin = Origin.empty))))
+      expectedAst = Batch(Seq(Project(namedTable("DAYS"), Seq(Star(None)))(Origin.empty))))
   }
 
   "parse and collect the options in the OPTION clause in a SELECT statement" in {
@@ -692,7 +685,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             SOMEstrOpt = 'STRINGOPTION')""",
       expectedAst = Batch(
         Seq(WithOptions(
-          Project(namedTable("t"), Seq(Star(None)), origin = Origin.empty),
+          Project(namedTable("t"), Seq(Star(None)))(Origin.empty),
           Options(
             Map("MAXRECURSION" -> Literal(10), "OPTIMIZE" -> Column(None, Id("FOR", true))),
             Map("SOMESTROPT" -> "STRINGOPTION"),
@@ -705,38 +698,37 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
       query = "SELECT * FROM t WITH (NOLOCK)",
       expectedAst = Batch(Seq(Project(
         TableWithHints(namedTable("t"),
-          Seq(FlagHint("NOLOCK"))), Seq(Star(None)),
-        origin = Origin.empty))))
+          Seq(FlagHint("NOLOCK"))), Seq(Star(None)))(Origin.empty))))
     example(
       query = "SELECT * FROM t WITH (FORCESEEK)",
       expectedAst =
         Batch(Seq(Project(
           TableWithHints(namedTable("t"), Seq(ForceSeekHint(None, None))),
-          Seq(Star(None)),
-          origin = Origin.empty))))
+          Seq(Star(None)))
+          (Origin.empty))))
     example(
       query = "SELECT * FROM t WITH (FORCESEEK(1 (Col1, Col2)))",
       expectedAst = Batch(
         Seq(
           Project(
             TableWithHints(namedTable("t"), Seq(ForceSeekHint(Some(Literal(1)), Some(Seq(Id("Col1"), Id("Col2")))))),
-            Seq(Star(None)),
-            origin = Origin.empty))))
+            Seq(Star(None)))
+            (Origin.empty))))
     example(
       query = "SELECT * FROM t WITH (INDEX = (Bill, Ted))",
       expectedAst = Batch(
         Seq(Project(
           TableWithHints(namedTable("t"), Seq(IndexHint(Seq(Id("Bill"), Id("Ted"))))),
-          Seq(Star(None)),
-          origin = Origin.empty))))
+          Seq(Star(None)))
+          (Origin.empty))))
     example(
       query = "SELECT * FROM t WITH (FORCESEEK, INDEX = (Bill, Ted))",
       expectedAst = Batch(
         Seq(
           Project(
             TableWithHints(namedTable("t"), Seq(ForceSeekHint(None, None), IndexHint(Seq(Id("Bill"), Id("Ted"))))),
-            Seq(Star(None)),
-            origin = Origin.empty))))
+            Seq(Star(None)))
+            (Origin.empty))))
   }
 
   "translate INSERT statements" in {
@@ -822,11 +814,11 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
       query = "WITH wtab AS (SELECT * FROM t) INSERT INTO t (a, b) select * from wtab",
       expectedAst = Batch(
         Seq(WithCTE(
-          Seq(SubqueryAlias(Project(namedTable("t"), Seq(Star(None)), origin = Origin.empty), Id("wtab"), List.empty)),
+          Seq(SubqueryAlias(Project(namedTable("t"), Seq(Star(None)))(Origin.empty), Id("wtab"), List.empty)),
           InsertIntoTable(
             namedTable("t"),
             Some(Seq(Id("a"), Id("b"))),
-            Project(namedTable("wtab"), Seq(Star(None)), origin = Origin.empty),
+            Project(namedTable("wtab"), Seq(Star(None)))(Origin.empty),
             None,
             None,
             overwrite = false)))))
@@ -853,10 +845,10 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               // TODO: This will change when UNION is implemented correctly
               Project(
                 namedTable("TableA"),
-                Seq(simplyNamedColumn("ID"), simplyNamedColumn("Name")),
-                origin = Origin.empty),
+                Seq(simplyNamedColumn("ID"), simplyNamedColumn("Name")))
+                (Origin.empty),
               "DerivedTable"),
-            Seq(simplyNamedColumn("ID"), simplyNamedColumn("Name")), origin = Origin.empty),
+            Seq(simplyNamedColumn("ID"), simplyNamedColumn("Name")))(Origin.empty),
           None,
           None,
           overwrite = false))))
@@ -1047,8 +1039,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               Seq(
                 simplyNamedColumn("col1"),
                 simplyNamedColumn("fred"),
-                Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter"))),
-              origin = Origin.empty),
+                Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter"))))
+              (Origin.empty),
             Id("s"),
             Seq(Id("a"), Id("b"), Id("col3count")))),
           MergeIntoTable(

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -26,11 +26,17 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
     "translate a simple SELECT query" in {
       example(
         query = "SELECT a FROM dbo.table_x",
-        expectedAst = Batch(Seq(Project(namedTable("dbo.table_x"), Seq(simplyNamedColumn("a"))))))
+        expectedAst = Batch(Seq(Project(
+          namedTable("dbo.table_x"),
+          Seq(simplyNamedColumn("a")),
+          origin = Origin.empty))))
 
       example(
         query = "SELECT a FROM TABLE",
-        expectedAst = Batch(Seq(Project(namedTable("TABLE"), Seq(simplyNamedColumn("a"))))))
+        expectedAst = Batch(Seq(Project(
+          namedTable("TABLE"),
+          Seq(simplyNamedColumn("a")),
+          origin = Origin.empty))))
     }
 
     "translate column aliases" in {
@@ -40,7 +46,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Seq(
             Project(
               namedTable("dbo.table_x"),
-              Seq(Alias(simplyNamedColumn("a"), Id("b")), Alias(simplyNamedColumn("BigCol"), Id("J")))))))
+              Seq(Alias(simplyNamedColumn("a"), Id("b")), Alias(simplyNamedColumn("BigCol"), Id("J"))),
+              origin = Origin.empty))))
     }
 
     "accept constants in selects" in {
@@ -57,39 +64,61 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 Literal("0x5A"),
                 Literal(2700000000L),
                 Literal(4.24523534425245e10),
-                Money(StringLiteral("$40")))))))
+                Money(StringLiteral("$40"))),
+              origin = Origin.empty))))
     }
 
     "translate collation specifiers" in {
       example(
         query = "SELECT a COLLATE Latin1_General_BIN FROM dbo.table_x",
         expectedAst =
-          Batch(Seq(Project(namedTable("dbo.table_x"), Seq(Collate(simplyNamedColumn("a"), "Latin1_General_BIN"))))))
+          Batch(Seq(Project(
+            namedTable("dbo.table_x"),
+            Seq(Collate(simplyNamedColumn("a"), "Latin1_General_BIN")),
+            origin = Origin.empty))))
     }
 
     "translate table source items with aliases" in {
       example(
         query = "SELECT a FROM dbo.table_x AS t",
-        expectedAst = Batch(Seq(Project(TableAlias(namedTable("dbo.table_x"), "t"), Seq(simplyNamedColumn("a"))))))
+        expectedAst = Batch(Seq(Project(
+          TableAlias(namedTable("dbo.table_x"), "t"),
+          Seq(simplyNamedColumn("a")),
+          origin = Origin.empty))))
     }
 
     "translate table sources involving *" in {
       example(
         query = "SELECT * FROM dbo.table_x",
-        expectedAst = Batch(Seq(Project(namedTable("dbo.table_x"), Seq(Star(None))))))
+        expectedAst = Batch(Seq(Project(
+          namedTable("dbo.table_x"),
+          Seq(Star(None)),
+          origin = Origin.empty))))
 
       example(
         query = "SELECT t.*",
-        expectedAst = Batch(Seq(Project(NoTable(), Seq(Star(objectName = Some(ObjectReference(Id("t")))))))))
+        expectedAst = Batch(Seq(Project(
+          NoTable(),
+          Seq(Star(objectName = Some(ObjectReference(Id("t"))))),
+          origin = Origin.empty))))
 
       example(
         query = "SELECT x..b.y.*",
         expectedAst =
-          Batch(Seq(Project(NoTable(), Seq(Star(objectName = Some(ObjectReference(Id("x"), Id("b"), Id("y")))))))))
+          Batch(Seq(Project(
+            NoTable(),
+            Seq(Star(objectName = Some(ObjectReference(Id("x"), Id("b"), Id("y"))))),
+            origin = Origin.empty))))
 
       // TODO: Add tests for OUTPUT clause once implemented - invalid semantics here to force coverage
-      example(query = "SELECT INSERTED.*", expectedAst = Batch(Seq(Project(NoTable(), Seq(Inserted(Star(None)))))))
-      example(query = "SELECT DELETED.*", expectedAst = Batch(Seq(Project(NoTable(), Seq(Deleted(Star(None)))))))
+      example(query = "SELECT INSERTED.*", expectedAst = Batch(Seq(Project(
+        NoTable(),
+        Seq(Inserted(Star(None))),
+        origin = Origin.empty))))
+      example(query = "SELECT DELETED.*", expectedAst = Batch(Seq(Project(
+        NoTable(),
+        Seq(Deleted(Star(None))),
+        origin = Origin.empty))))
     }
 
     "infer a cross join" in {
@@ -104,7 +133,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               CrossJoin,
               Seq.empty,
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            Seq(simplyNamedColumn("a"), simplyNamedColumn("b"), simplyNamedColumn("c"))))))
+            Seq(simplyNamedColumn("a"), simplyNamedColumn("b"), simplyNamedColumn("c")),
+            origin = Origin.empty))))
     }
 
     val t1aCol = Column(Some(ObjectReference(Id("T1"))), Id("A"))
@@ -127,7 +157,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               InnerJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            List(t1aCol, t2bCol)))))
+            List(t1aCol, t2bCol),
+            origin = Origin.empty))))
     }
     "translate a query with Multiple JOIN AND Condition" in {
 
@@ -149,7 +180,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               LeftOuterJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            List(t1aCol, t2bCol)))))
+            List(t1aCol, t2bCol),
+            origin = Origin.empty))))
     }
     "translate a query with Multiple JOIN OR Conditions" in {
       example(
@@ -170,7 +202,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               LeftOuterJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            List(t1aCol, t2bCol)))))
+            List(t1aCol, t2bCol),
+            origin = Origin.empty))))
     }
     "translate a query with a RIGHT OUTER JOIN" in {
       example(
@@ -184,7 +217,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               RightOuterJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            List(t1aCol)))))
+            List(t1aCol),
+            origin = Origin.empty))))
     }
     "translate a query with a FULL OUTER JOIN" in {
       example(
@@ -198,7 +232,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               FullOuterJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            List(t1aCol)))))
+            List(t1aCol),
+            origin = Origin.empty))))
     }
 
     "cover default case in translateJoinType" in {
@@ -229,7 +264,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Seq(Project(
             namedTable("tab"),
             Seq(tsql
-              .TsqlXmlFunction(CallFunction("query", Seq(Literal("/root/child"))), simplyNamedColumn("xmlcolumn")))))))
+              .TsqlXmlFunction(CallFunction("query", Seq(Literal("/root/child"))), simplyNamedColumn("xmlcolumn"))),
+            origin = Origin.empty))))
 
       example(
         "SELECT xmlcolumn.value('path', 'type') FROM tab",
@@ -239,7 +275,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               namedTable("tab"),
               Seq(tsql.TsqlXmlFunction(
                 CallFunction("value", Seq(Literal("path"), Literal("type"))),
-                simplyNamedColumn("xmlcolumn")))))))
+                simplyNamedColumn("xmlcolumn"))),
+              origin = Origin.empty))))
 
       example(
         "SELECT xmlcolumn.exist('/root/child[text()=\"Some Value\"]') FROM xmltable;",
@@ -248,7 +285,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             namedTable("xmltable"),
             Seq(tsql.TsqlXmlFunction(
               CallFunction("exist", Seq(Literal("/root/child[text()=\"Some Value\"]"))),
-              simplyNamedColumn("xmlcolumn")))))))
+              simplyNamedColumn("xmlcolumn"))),
+            origin = Origin.empty))))
 
       // TODO: Add nodes(), modify(), when we complete UPDATE and CROSS APPLY
     }
@@ -263,7 +301,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             Seq(
               Assign(Identifier("@a", isQuoted = false), Literal(1)),
               Assign(Identifier("@b", isQuoted = false), Literal(2)),
-              Assign(Identifier("@c", isQuoted = false), Literal(3)))))))
+              Assign(Identifier("@c", isQuoted = false), Literal(3))),
+            origin = Origin.empty))))
 
       example(
         query = "SELECT @a += 1, @b -= 2",
@@ -272,7 +311,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             NoTable(),
             Seq(
               Assign(Identifier("@a", isQuoted = false), Add(Identifier("@a", isQuoted = false), Literal(1))),
-              Assign(Identifier("@b", isQuoted = false), Subtract(Identifier("@b", isQuoted = false), Literal(2))))))))
+              Assign(Identifier("@b", isQuoted = false), Subtract(Identifier("@b", isQuoted = false), Literal(2)))),
+            origin = Origin.empty))))
 
       example(
         query = "SELECT @a *= 1, @b /= 2",
@@ -281,7 +321,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             NoTable(),
             Seq(
               Assign(Identifier("@a", isQuoted = false), Multiply(Identifier("@a", isQuoted = false), Literal(1))),
-              Assign(Identifier("@b", isQuoted = false), Divide(Identifier("@b", isQuoted = false), Literal(2))))))))
+              Assign(Identifier("@b", isQuoted = false), Divide(Identifier("@b", isQuoted = false), Literal(2)))),
+            origin = Origin.empty))))
 
       example(
         query = "SELECT @a %= myColumn",
@@ -291,7 +332,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               NoTable(),
               Seq(Assign(
                 Identifier("@a", isQuoted = false),
-                Mod(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn"))))))))
+                Mod(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))),
+              origin = Origin.empty))))
 
       example(
         query = "SELECT @a &= myColumn",
@@ -301,7 +343,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               NoTable(),
               Seq(Assign(
                 Identifier("@a", isQuoted = false),
-                BitwiseAnd(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn"))))))))
+                BitwiseAnd(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))),
+              origin = Origin.empty))))
 
       example(
         query = "SELECT @a ^= myColumn",
@@ -311,7 +354,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               NoTable(),
               Seq(Assign(
                 Identifier("@a", isQuoted = false),
-                BitwiseXor(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn"))))))))
+                BitwiseXor(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))),
+              origin = Origin.empty))))
 
       example(
         query = "SELECT @a |= myColumn",
@@ -321,7 +365,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               NoTable(),
               Seq(Assign(
                 Identifier("@a", isQuoted = false),
-                BitwiseOr(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn"))))))))
+                BitwiseOr(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))),
+              origin = Origin.empty))))
     }
     "translate scalar subqueries as expressions in select list" in {
       example(
@@ -338,8 +383,12 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               simplyNamedColumn("EmployeeID"),
               simplyNamedColumn("Name"),
               Alias(
-                ScalarSubquery(Project(namedTable("Employees"), Seq(simplyNamedColumn("AvgSalary")))),
-                Id("AverageSalary")))))))
+                ScalarSubquery(Project(
+                  namedTable("Employees"),
+                  Seq(simplyNamedColumn("AvgSalary")),
+                  origin = Origin.empty)),
+                Id("AverageSalary"))),
+            origin = Origin.empty))))
     }
   }
 
@@ -350,27 +399,35 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         Seq(
           Project(
             Deduplicate(namedTable("Employees"), List(), all_columns_as_keys = true, within_watermark = false),
-            Seq(Star(None))))))
+            Seq(Star(None)),
+            origin = Origin.empty))))
     example(
       query = "SELECT DISTINCT a, b AS bb FROM t",
       expectedAst = Batch(
         Seq(Project(
           Deduplicate(namedTable("t"), List(Id("a"), Id("bb")), all_columns_as_keys = false, within_watermark = false),
-          Seq(simplyNamedColumn("a"), Alias(simplyNamedColumn("b"), Id("bb")))))))
+          Seq(simplyNamedColumn("a"), Alias(simplyNamedColumn("b"), Id("bb"))),
+          origin = Origin.empty))))
   }
 
   "SELECT NEXT VALUE FOR mySequence As nextVal" in {
     example(
       query = "SELECT NEXT VALUE FOR mySequence As nextVal",
       expectedAst = Batch(
-        Seq(Project(NoTable(), Seq(Alias(CallFunction("MONOTONICALLY_INCREASING_ID", List.empty), Id("nextVal")))))))
+        Seq(Project(
+          NoTable(),
+          Seq(Alias(CallFunction("MONOTONICALLY_INCREASING_ID", List.empty), Id("nextVal"))),
+          origin = Origin.empty))))
   }
 
   "SELECT NEXT VALUE FOR var.mySequence As nextVal" in {
     example(
       query = "SELECT NEXT VALUE FOR var.mySequence As nextVal",
       expectedAst = Batch(
-        Seq(Project(NoTable(), Seq(Alias(CallFunction("MONOTONICALLY_INCREASING_ID", List.empty), Id("nextVal")))))))
+        Seq(Project(
+          NoTable(),
+          Seq(Alias(CallFunction("MONOTONICALLY_INCREASING_ID", List.empty), Id("nextVal"))),
+          origin = Origin.empty))))
   }
 
   "SELECT NEXT VALUE FOR var.mySequence OVER (ORDER BY myColumn) As nextVal" in {
@@ -385,7 +442,9 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               List.empty,
               List(SortOrder(simplyNamedColumn("myColumn"), UnspecifiedSortDirection, SortNullsUnspecified)),
               None),
-            Id("nextVal")))))))
+            Id("nextVal"))),
+          origin = Origin.empty))))
+
   }
 
   "translate CTE select statements" in {
@@ -394,8 +453,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
       expectedAst = Batch(
         Seq(
           WithCTE(
-            Seq(SubqueryAlias(Project(namedTable("t"), Seq(Star(None))), Id("cte"), List.empty)),
-            Project(namedTable("cte"), Seq(Star(None)))))))
+            Seq(SubqueryAlias(Project(namedTable("t"), Seq(Star(None)), origin = Origin.empty), Id("cte"), List.empty)),
+            Project(namedTable("cte"), Seq(Star(None)), origin = Origin.empty)))))
 
     example(
       query = """WITH cteTable1 (col1, col2, col3count)
@@ -421,7 +480,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 Seq(
                   simplyNamedColumn("col1"),
                   simplyNamedColumn("fred"),
-                  Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter")))),
+                  Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter"))),
+                origin = Origin.empty),
               Id("cteTable1"),
               Seq(Id("col1"), Id("col2"), Id("col3count"))),
             SubqueryAlias(
@@ -430,7 +490,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 Seq(
                   simplyNamedColumn("col1"),
                   simplyNamedColumn("fred"),
-                  Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter")))),
+                  Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter"))),
+                origin = Origin.empty),
               Id("cteTable2"),
               Seq(Id("colx"), Id("coly"), Id("colxcount")))),
           Project(
@@ -441,25 +502,35 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               simplyNamedColumn("col3count"),
               simplyNamedColumn("colx"),
               simplyNamedColumn("coly"),
-              simplyNamedColumn("colxcount")))))))
+              simplyNamedColumn("colxcount")),
+            origin = Origin.empty)))))
   }
 
   "translate a SELECT with a TOP clause" should {
     "use LIMIT" in {
       example(
         query = "SELECT TOP 10 * FROM Employees;",
-        expectedAst = Batch(Seq(Project(Limit(namedTable("Employees"), Literal(10)), Seq(Star(None))))))
+        expectedAst = Batch(Seq(Project(
+          Limit(namedTable("Employees"), Literal(10)),
+          Seq(Star(None)),
+          origin = Origin.empty))))
     }
 
     "use TOP PERCENT" in {
       example(
         query = "SELECT TOP 10 PERCENT * FROM Employees;",
-        expectedAst = Batch(Seq(Project(TopPercent(namedTable("Employees"), Literal(10)), Seq(Star(None))))))
+        expectedAst = Batch(Seq(Project(
+          TopPercent(namedTable("Employees"), Literal(10)),
+          Seq(Star(None)),
+          origin = Origin.empty))))
 
       example(
         query = "SELECT TOP 10 PERCENT WITH TIES * FROM Employees;",
         expectedAst =
-          Batch(Seq(Project(TopPercent(namedTable("Employees"), Literal(10), with_ties = true), Seq(Star(None))))))
+          Batch(Seq(Project(
+            TopPercent(namedTable("Employees"), Literal(10), with_ties = true),
+            Seq(Star(None)),
+            origin = Origin.empty))))
     }
   }
 
@@ -474,7 +545,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               Seq(SortOrder(simplyNamedColumn("Salary"), Ascending, SortNullsUnspecified)),
               is_global = false),
             Literal(10)),
-          Seq(Star(None))))))
+          Seq(Star(None)),
+          origin = Origin.empty))))
 
     example(
       query = "SELECT * FROM Employees ORDER BY Salary OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY",
@@ -488,7 +560,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 is_global = false),
               Literal(10)),
             Literal(5)),
-          Seq(Star(None))))))
+          Seq(Star(None)),
+          origin = Origin.empty))))
   }
 
   "translate SELECT with a combination of DISTINCT, ORDER BY, and OFFSET" in {
@@ -506,7 +579,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             List(),
             all_columns_as_keys = true,
             within_watermark = false),
-          Seq(Star(None))))))
+          Seq(Star(None)),
+          origin = Origin.empty))))
 
     example(
       query = "SELECT DISTINCT * FROM Employees ORDER BY Salary OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY",
@@ -524,7 +598,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             List(),
             all_columns_as_keys = true,
             within_watermark = false),
-          List(Star(None))))))
+          List(Star(None)),
+          origin = Origin.empty))))
   }
 
   "translate a query with PIVOT" in {
@@ -536,7 +611,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           group_type = Pivot,
           grouping_expressions = Seq(CallFunction("SUM", Seq(simplyNamedColumn("a")))),
           pivot = Some(Pivot(simplyNamedColumn("c"), Seq(Literal("foo"), Literal("bar"))))),
-        Seq(simplyNamedColumn("a"))))
+        Seq(simplyNamedColumn("a")),
+        origin = Origin.empty))
   }
 
   "translate a query with UNPIVOT" in {
@@ -549,7 +625,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           values = None,
           variable_column_name = Id("c"),
           value_column_name = Id("d")),
-        Seq(simplyNamedColumn("a"))))
+        Seq(simplyNamedColumn("a")),
+        origin = Origin.empty))
   }
 
   "translate a query with an explicit CROSS JOIN" in {
@@ -563,7 +640,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           CrossJoin,
           Seq.empty,
           JoinDataType(is_left_struct = false, is_right_struct = false)),
-        Seq(simplyNamedColumn("a"))))
+        Seq(simplyNamedColumn("a")),
+        origin = Origin.empty))
   }
 
   "translate a query with an explicit OUTER APPLY" in {
@@ -577,7 +655,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           OuterApply,
           Seq.empty,
           JoinDataType(is_left_struct = false, is_right_struct = false)),
-        Seq(simplyNamedColumn("a"))))
+        Seq(simplyNamedColumn("a")),
+        origin = Origin.empty))
   }
 
   "translate a query with an explicit CROSS APPLY" in {
@@ -591,13 +670,14 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           CrossApply,
           Seq.empty,
           JoinDataType(is_left_struct = false, is_right_struct = false)),
-        Seq(simplyNamedColumn("a"))))
+        Seq(simplyNamedColumn("a")),
+        origin = Origin.empty))
   }
 
   "parse and ignore IR for the FOR clause in a SELECT statement" in {
     example(
       query = "SELECT * FROM DAYS FOR XML RAW",
-      expectedAst = Batch(Seq(Project(namedTable("DAYS"), Seq(Star(None))))))
+      expectedAst = Batch(Seq(Project(namedTable("DAYS"), Seq(Star(None)), origin = Origin.empty))))
   }
 
   "parse and collect the options in the OPTION clause in a SELECT statement" in {
@@ -612,7 +692,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             SOMEstrOpt = 'STRINGOPTION')""",
       expectedAst = Batch(
         Seq(WithOptions(
-          Project(namedTable("t"), Seq(Star(None))),
+          Project(namedTable("t"), Seq(Star(None)), origin = Origin.empty),
           Options(
             Map("MAXRECURSION" -> Literal(10), "OPTIMIZE" -> Column(None, Id("FOR", true))),
             Map("SOMESTROPT" -> "STRINGOPTION"),
@@ -623,29 +703,40 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
   "parse and collect table hints for named table select statements in all variants" in {
     example(
       query = "SELECT * FROM t WITH (NOLOCK)",
-      expectedAst = Batch(Seq(Project(TableWithHints(namedTable("t"), Seq(FlagHint("NOLOCK"))), Seq(Star(None))))))
+      expectedAst = Batch(Seq(Project(
+        TableWithHints(namedTable("t"),
+          Seq(FlagHint("NOLOCK"))), Seq(Star(None)),
+        origin = Origin.empty))))
     example(
       query = "SELECT * FROM t WITH (FORCESEEK)",
       expectedAst =
-        Batch(Seq(Project(TableWithHints(namedTable("t"), Seq(ForceSeekHint(None, None))), Seq(Star(None))))))
+        Batch(Seq(Project(
+          TableWithHints(namedTable("t"), Seq(ForceSeekHint(None, None))),
+          Seq(Star(None)),
+          origin = Origin.empty))))
     example(
       query = "SELECT * FROM t WITH (FORCESEEK(1 (Col1, Col2)))",
       expectedAst = Batch(
         Seq(
           Project(
             TableWithHints(namedTable("t"), Seq(ForceSeekHint(Some(Literal(1)), Some(Seq(Id("Col1"), Id("Col2")))))),
-            Seq(Star(None))))))
+            Seq(Star(None)),
+            origin = Origin.empty))))
     example(
       query = "SELECT * FROM t WITH (INDEX = (Bill, Ted))",
       expectedAst = Batch(
-        Seq(Project(TableWithHints(namedTable("t"), Seq(IndexHint(Seq(Id("Bill"), Id("Ted"))))), Seq(Star(None))))))
+        Seq(Project(
+          TableWithHints(namedTable("t"), Seq(IndexHint(Seq(Id("Bill"), Id("Ted"))))),
+          Seq(Star(None)),
+          origin = Origin.empty))))
     example(
       query = "SELECT * FROM t WITH (FORCESEEK, INDEX = (Bill, Ted))",
       expectedAst = Batch(
         Seq(
           Project(
             TableWithHints(namedTable("t"), Seq(ForceSeekHint(None, None), IndexHint(Seq(Id("Bill"), Id("Ted"))))),
-            Seq(Star(None))))))
+            Seq(Star(None)),
+            origin = Origin.empty))))
   }
 
   "translate INSERT statements" in {
@@ -731,11 +822,11 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
       query = "WITH wtab AS (SELECT * FROM t) INSERT INTO t (a, b) select * from wtab",
       expectedAst = Batch(
         Seq(WithCTE(
-          Seq(SubqueryAlias(Project(namedTable("t"), Seq(Star(None))), Id("wtab"), List.empty)),
+          Seq(SubqueryAlias(Project(namedTable("t"), Seq(Star(None)), origin = Origin.empty), Id("wtab"), List.empty)),
           InsertIntoTable(
             namedTable("t"),
             Some(Seq(Id("a"), Id("b"))),
-            Project(namedTable("wtab"), Seq(Star(None))),
+            Project(namedTable("wtab"), Seq(Star(None)), origin = Origin.empty),
             None,
             None,
             overwrite = false)))))
@@ -760,9 +851,12 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Project(
             TableAlias(
               // TODO: This will change when UNION is implemented correctly
-              Project(namedTable("TableA"), Seq(simplyNamedColumn("ID"), simplyNamedColumn("Name"))),
+              Project(
+                namedTable("TableA"),
+                Seq(simplyNamedColumn("ID"), simplyNamedColumn("Name")),
+                origin = Origin.empty),
               "DerivedTable"),
-            Seq(simplyNamedColumn("ID"), simplyNamedColumn("Name"))),
+            Seq(simplyNamedColumn("ID"), simplyNamedColumn("Name")), origin = Origin.empty),
           None,
           None,
           overwrite = false))))
@@ -953,7 +1047,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               Seq(
                 simplyNamedColumn("col1"),
                 simplyNamedColumn("fred"),
-                Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter")))),
+                Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter"))),
+              origin = Origin.empty),
             Id("s"),
             Seq(Id("a"), Id("b"), Id("col3count")))),
           MergeIntoTable(

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -26,17 +26,11 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
     "translate a simple SELECT query" in {
       example(
         query = "SELECT a FROM dbo.table_x",
-        expectedAst = Batch(Seq(Project(
-          namedTable("dbo.table_x"),
-          Seq(simplyNamedColumn("a")))
-          (Origin.empty))))
+        expectedAst = Batch(Seq(Project(namedTable("dbo.table_x"), Seq(simplyNamedColumn("a")))(Origin.empty))))
 
       example(
         query = "SELECT a FROM TABLE",
-        expectedAst = Batch(Seq(Project(
-          namedTable("TABLE"),
-          Seq(simplyNamedColumn("a")))
-          (Origin.empty))))
+        expectedAst = Batch(Seq(Project(namedTable("TABLE"), Seq(simplyNamedColumn("a")))(Origin.empty))))
     }
 
     "translate column aliases" in {
@@ -46,8 +40,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Seq(
             Project(
               namedTable("dbo.table_x"),
-              Seq(Alias(simplyNamedColumn("a"), Id("b")), Alias(simplyNamedColumn("BigCol"), Id("J"))))
-              (Origin.empty))))
+              Seq(Alias(simplyNamedColumn("a"), Id("b")), Alias(simplyNamedColumn("BigCol"), Id("J"))))(Origin.empty))))
     }
 
     "accept constants in selects" in {
@@ -64,59 +57,46 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 Literal("0x5A"),
                 Literal(2700000000L),
                 Literal(4.24523534425245e10),
-                Money(StringLiteral("$40"))))
-              (Origin.empty))))
+                Money(StringLiteral("$40"))))(Origin.empty))))
     }
 
     "translate collation specifiers" in {
       example(
         query = "SELECT a COLLATE Latin1_General_BIN FROM dbo.table_x",
-        expectedAst =
-          Batch(Seq(Project(
-            namedTable("dbo.table_x"),
-            Seq(Collate(simplyNamedColumn("a"), "Latin1_General_BIN")))
-            (Origin.empty))))
+        expectedAst = Batch(
+          Seq(Project(namedTable("dbo.table_x"), Seq(Collate(simplyNamedColumn("a"), "Latin1_General_BIN")))(
+            Origin.empty))))
     }
 
     "translate table source items with aliases" in {
       example(
         query = "SELECT a FROM dbo.table_x AS t",
-        expectedAst = Batch(Seq(Project(
-          TableAlias(namedTable("dbo.table_x"), "t"),
-          Seq(simplyNamedColumn("a")))
-          (Origin.empty))))
+        expectedAst =
+          Batch(Seq(Project(TableAlias(namedTable("dbo.table_x"), "t"), Seq(simplyNamedColumn("a")))(Origin.empty))))
     }
 
     "translate table sources involving *" in {
       example(
         query = "SELECT * FROM dbo.table_x",
-        expectedAst = Batch(Seq(Project(
-          namedTable("dbo.table_x"),
-          Seq(Star(None)))
-          (Origin.empty))))
+        expectedAst = Batch(Seq(Project(namedTable("dbo.table_x"), Seq(Star(None)))(Origin.empty))))
 
       example(
         query = "SELECT t.*",
-        expectedAst = Batch(Seq(Project(
-          NoTable(),
-          Seq(Star(objectName = Some(ObjectReference(Id("t"))))))
-          (Origin.empty))))
+        expectedAst =
+          Batch(Seq(Project(NoTable(), Seq(Star(objectName = Some(ObjectReference(Id("t"))))))(Origin.empty))))
 
       example(
         query = "SELECT x..b.y.*",
-        expectedAst =
-          Batch(Seq(Project(
-            NoTable(),
-            Seq(Star(objectName = Some(ObjectReference(Id("x"), Id("b"), Id("y"))))))
-            (Origin.empty))))
+        expectedAst = Batch(Seq(
+          Project(NoTable(), Seq(Star(objectName = Some(ObjectReference(Id("x"), Id("b"), Id("y"))))))(Origin.empty))))
 
       // TODO: Add tests for OUTPUT clause once implemented - invalid semantics here to force coverage
-      example(query = "SELECT INSERTED.*", expectedAst = Batch(Seq(Project(
-        NoTable(),
-        Seq(Inserted(Star(None))))(Origin.empty))))
-      example(query = "SELECT DELETED.*", expectedAst = Batch(Seq(Project(
-        NoTable(),
-        Seq(Deleted(Star(None))))(Origin.empty))))
+      example(
+        query = "SELECT INSERTED.*",
+        expectedAst = Batch(Seq(Project(NoTable(), Seq(Inserted(Star(None))))(Origin.empty))))
+      example(
+        query = "SELECT DELETED.*",
+        expectedAst = Batch(Seq(Project(NoTable(), Seq(Deleted(Star(None))))(Origin.empty))))
     }
 
     "infer a cross join" in {
@@ -131,8 +111,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               CrossJoin,
               Seq.empty,
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            Seq(simplyNamedColumn("a"), simplyNamedColumn("b"), simplyNamedColumn("c")))
-            (Origin.empty))))
+            Seq(simplyNamedColumn("a"), simplyNamedColumn("b"), simplyNamedColumn("c")))(Origin.empty))))
     }
 
     val t1aCol = Column(Some(ObjectReference(Id("T1"))), Id("A"))
@@ -155,8 +134,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               InnerJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            List(t1aCol, t2bCol))
-            (Origin.empty))))
+            List(t1aCol, t2bCol))(Origin.empty))))
     }
     "translate a query with Multiple JOIN AND Condition" in {
 
@@ -178,8 +156,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               LeftOuterJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            List(t1aCol, t2bCol))
-            (Origin.empty))))
+            List(t1aCol, t2bCol))(Origin.empty))))
     }
     "translate a query with Multiple JOIN OR Conditions" in {
       example(
@@ -200,8 +177,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               LeftOuterJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            List(t1aCol, t2bCol))
-            (Origin.empty))))
+            List(t1aCol, t2bCol))(Origin.empty))))
     }
     "translate a query with a RIGHT OUTER JOIN" in {
       example(
@@ -215,8 +191,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               RightOuterJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            List(t1aCol))
-            (Origin.empty))))
+            List(t1aCol))(Origin.empty))))
     }
     "translate a query with a FULL OUTER JOIN" in {
       example(
@@ -230,8 +205,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               FullOuterJoin,
               List(),
               JoinDataType(is_left_struct = false, is_right_struct = false)),
-            List(t1aCol))
-            (Origin.empty))))
+            List(t1aCol))(Origin.empty))))
     }
 
     "cover default case in translateJoinType" in {
@@ -259,11 +233,12 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
       example(
         query = "SELECT xmlcolumn.query('/root/child') FROM tab",
         expectedAst = Batch(
-          Seq(Project(
-            namedTable("tab"),
-            Seq(tsql
-              .TsqlXmlFunction(CallFunction("query", Seq(Literal("/root/child"))), simplyNamedColumn("xmlcolumn"))))
-            (Origin.empty))))
+          Seq(
+            Project(
+              namedTable("tab"),
+              Seq(tsql
+                .TsqlXmlFunction(CallFunction("query", Seq(Literal("/root/child"))), simplyNamedColumn("xmlcolumn"))))(
+              Origin.empty))))
 
       example(
         "SELECT xmlcolumn.value('path', 'type') FROM tab",
@@ -273,8 +248,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               namedTable("tab"),
               Seq(tsql.TsqlXmlFunction(
                 CallFunction("value", Seq(Literal("path"), Literal("type"))),
-                simplyNamedColumn("xmlcolumn"))))
-              (Origin.empty))))
+                simplyNamedColumn("xmlcolumn"))))(Origin.empty))))
 
       example(
         "SELECT xmlcolumn.exist('/root/child[text()=\"Some Value\"]') FROM xmltable;",
@@ -283,8 +257,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             namedTable("xmltable"),
             Seq(tsql.TsqlXmlFunction(
               CallFunction("exist", Seq(Literal("/root/child[text()=\"Some Value\"]"))),
-              simplyNamedColumn("xmlcolumn"))))
-            (Origin.empty))))
+              simplyNamedColumn("xmlcolumn"))))(Origin.empty))))
 
       // TODO: Add nodes(), modify(), when we complete UPDATE and CROSS APPLY
     }
@@ -299,8 +272,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             Seq(
               Assign(Identifier("@a", isQuoted = false), Literal(1)),
               Assign(Identifier("@b", isQuoted = false), Literal(2)),
-              Assign(Identifier("@c", isQuoted = false), Literal(3))))
-            (Origin.empty))))
+              Assign(Identifier("@c", isQuoted = false), Literal(3))))(Origin.empty))))
 
       example(
         query = "SELECT @a += 1, @b -= 2",
@@ -309,8 +281,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             NoTable(),
             Seq(
               Assign(Identifier("@a", isQuoted = false), Add(Identifier("@a", isQuoted = false), Literal(1))),
-              Assign(Identifier("@b", isQuoted = false), Subtract(Identifier("@b", isQuoted = false), Literal(2)))))
-            (Origin.empty))))
+              Assign(Identifier("@b", isQuoted = false), Subtract(Identifier("@b", isQuoted = false), Literal(2)))))(
+            Origin.empty))))
 
       example(
         query = "SELECT @a *= 1, @b /= 2",
@@ -319,8 +291,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             NoTable(),
             Seq(
               Assign(Identifier("@a", isQuoted = false), Multiply(Identifier("@a", isQuoted = false), Literal(1))),
-              Assign(Identifier("@b", isQuoted = false), Divide(Identifier("@b", isQuoted = false), Literal(2)))))
-            (Origin.empty))))
+              Assign(Identifier("@b", isQuoted = false), Divide(Identifier("@b", isQuoted = false), Literal(2)))))(
+            Origin.empty))))
 
       example(
         query = "SELECT @a %= myColumn",
@@ -330,8 +302,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               NoTable(),
               Seq(Assign(
                 Identifier("@a", isQuoted = false),
-                Mod(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))))
-              (Origin.empty))))
+                Mod(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))))(Origin.empty))))
 
       example(
         query = "SELECT @a &= myColumn",
@@ -341,8 +312,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               NoTable(),
               Seq(Assign(
                 Identifier("@a", isQuoted = false),
-                BitwiseAnd(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))))
-              (Origin.empty))))
+                BitwiseAnd(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))))(Origin.empty))))
 
       example(
         query = "SELECT @a ^= myColumn",
@@ -352,8 +322,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               NoTable(),
               Seq(Assign(
                 Identifier("@a", isQuoted = false),
-                BitwiseXor(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))))
-              (Origin.empty))))
+                BitwiseXor(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))))(Origin.empty))))
 
       example(
         query = "SELECT @a |= myColumn",
@@ -363,8 +332,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               NoTable(),
               Seq(Assign(
                 Identifier("@a", isQuoted = false),
-                BitwiseOr(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))))
-              (Origin.empty))))
+                BitwiseOr(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn")))))(Origin.empty))))
     }
     "translate scalar subqueries as expressions in select list" in {
       example(
@@ -381,12 +349,8 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               simplyNamedColumn("EmployeeID"),
               simplyNamedColumn("Name"),
               Alias(
-                ScalarSubquery(Project(
-                  namedTable("Employees"),
-                  Seq(simplyNamedColumn("AvgSalary")))
-                  (Origin.empty)),
-                Id("AverageSalary"))))
-            (Origin.empty))))
+                ScalarSubquery(Project(namedTable("Employees"), Seq(simplyNamedColumn("AvgSalary")))(Origin.empty)),
+                Id("AverageSalary"))))(Origin.empty))))
     }
   }
 
@@ -397,35 +361,29 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         Seq(
           Project(
             Deduplicate(namedTable("Employees"), List(), all_columns_as_keys = true, within_watermark = false),
-            Seq(Star(None)))
-            (Origin.empty))))
+            Seq(Star(None)))(Origin.empty))))
     example(
       query = "SELECT DISTINCT a, b AS bb FROM t",
       expectedAst = Batch(
         Seq(Project(
           Deduplicate(namedTable("t"), List(Id("a"), Id("bb")), all_columns_as_keys = false, within_watermark = false),
-          Seq(simplyNamedColumn("a"), Alias(simplyNamedColumn("b"), Id("bb"))))
-          (Origin.empty))))
+          Seq(simplyNamedColumn("a"), Alias(simplyNamedColumn("b"), Id("bb"))))(Origin.empty))))
   }
 
   "SELECT NEXT VALUE FOR mySequence As nextVal" in {
     example(
       query = "SELECT NEXT VALUE FOR mySequence As nextVal",
       expectedAst = Batch(
-        Seq(Project(
-          NoTable(),
-          Seq(Alias(CallFunction("MONOTONICALLY_INCREASING_ID", List.empty), Id("nextVal"))))
-        (Origin.empty))))
+        Seq(Project(NoTable(), Seq(Alias(CallFunction("MONOTONICALLY_INCREASING_ID", List.empty), Id("nextVal"))))(
+          Origin.empty))))
   }
 
   "SELECT NEXT VALUE FOR var.mySequence As nextVal" in {
     example(
       query = "SELECT NEXT VALUE FOR var.mySequence As nextVal",
       expectedAst = Batch(
-        Seq(Project(
-          NoTable(),
-          Seq(Alias(CallFunction("MONOTONICALLY_INCREASING_ID", List.empty), Id("nextVal"))))
-        (Origin.empty))))
+        Seq(Project(NoTable(), Seq(Alias(CallFunction("MONOTONICALLY_INCREASING_ID", List.empty), Id("nextVal"))))(
+          Origin.empty))))
   }
 
   "SELECT NEXT VALUE FOR var.mySequence OVER (ORDER BY myColumn) As nextVal" in {
@@ -440,8 +398,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               List.empty,
               List(SortOrder(simplyNamedColumn("myColumn"), UnspecifiedSortDirection, SortNullsUnspecified)),
               None),
-            Id("nextVal"))))
-          (Origin.empty))))
+            Id("nextVal"))))(Origin.empty))))
 
   }
 
@@ -449,10 +406,9 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
     example(
       query = "WITH cte AS (SELECT * FROM t) SELECT * FROM cte",
       expectedAst = Batch(
-        Seq(
-          WithCTE(
-            Seq(SubqueryAlias(Project(namedTable("t"), Seq(Star(None)))(Origin.empty), Id("cte"), List.empty)),
-            Project(namedTable("cte"), Seq(Star(None)))(Origin.empty)))))
+        Seq(WithCTE(
+          Seq(SubqueryAlias(Project(namedTable("t"), Seq(Star(None)))(Origin.empty), Id("cte"), List.empty)),
+          Project(namedTable("cte"), Seq(Star(None)))(Origin.empty)))))
 
     example(
       query = """WITH cteTable1 (col1, col2, col3count)
@@ -478,8 +434,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 Seq(
                   simplyNamedColumn("col1"),
                   simplyNamedColumn("fred"),
-                  Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter"))))
-                (Origin.empty),
+                  Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter"))))(Origin.empty),
               Id("cteTable1"),
               Seq(Id("col1"), Id("col2"), Id("col3count"))),
             SubqueryAlias(
@@ -488,8 +443,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 Seq(
                   simplyNamedColumn("col1"),
                   simplyNamedColumn("fred"),
-                  Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter"))))
-                (Origin.empty),
+                  Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter"))))(Origin.empty),
               Id("cteTable2"),
               Seq(Id("colx"), Id("coly"), Id("colxcount")))),
           Project(
@@ -500,35 +454,26 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               simplyNamedColumn("col3count"),
               simplyNamedColumn("colx"),
               simplyNamedColumn("coly"),
-              simplyNamedColumn("colxcount")))
-            (Origin.empty)))))
+              simplyNamedColumn("colxcount")))(Origin.empty)))))
   }
 
   "translate a SELECT with a TOP clause" should {
     "use LIMIT" in {
       example(
         query = "SELECT TOP 10 * FROM Employees;",
-        expectedAst = Batch(Seq(Project(
-          Limit(namedTable("Employees"), Literal(10)),
-          Seq(Star(None)))
-          (Origin.empty))))
+        expectedAst = Batch(Seq(Project(Limit(namedTable("Employees"), Literal(10)), Seq(Star(None)))(Origin.empty))))
     }
 
     "use TOP PERCENT" in {
       example(
         query = "SELECT TOP 10 PERCENT * FROM Employees;",
-        expectedAst = Batch(Seq(Project(
-          TopPercent(namedTable("Employees"), Literal(10)),
-          Seq(Star(None)))
-          (Origin.empty))))
+        expectedAst =
+          Batch(Seq(Project(TopPercent(namedTable("Employees"), Literal(10)), Seq(Star(None)))(Origin.empty))))
 
       example(
         query = "SELECT TOP 10 PERCENT WITH TIES * FROM Employees;",
-        expectedAst =
-          Batch(Seq(Project(
-            TopPercent(namedTable("Employees"), Literal(10), with_ties = true),
-            Seq(Star(None)))
-            (Origin.empty))))
+        expectedAst = Batch(Seq(
+          Project(TopPercent(namedTable("Employees"), Literal(10), with_ties = true), Seq(Star(None)))(Origin.empty))))
     }
   }
 
@@ -543,8 +488,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               Seq(SortOrder(simplyNamedColumn("Salary"), Ascending, SortNullsUnspecified)),
               is_global = false),
             Literal(10)),
-          Seq(Star(None)))
-          (Origin.empty))))
+          Seq(Star(None)))(Origin.empty))))
 
     example(
       query = "SELECT * FROM Employees ORDER BY Salary OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY",
@@ -558,8 +502,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
                 is_global = false),
               Literal(10)),
             Literal(5)),
-          Seq(Star(None)))
-          (Origin.empty))))
+          Seq(Star(None)))(Origin.empty))))
   }
 
   "translate SELECT with a combination of DISTINCT, ORDER BY, and OFFSET" in {
@@ -577,8 +520,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             List(),
             all_columns_as_keys = true,
             within_watermark = false),
-          Seq(Star(None)))
-          (Origin.empty))))
+          Seq(Star(None)))(Origin.empty))))
 
     example(
       query = "SELECT DISTINCT * FROM Employees ORDER BY Salary OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY",
@@ -596,8 +538,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
             List(),
             all_columns_as_keys = true,
             within_watermark = false),
-          List(Star(None)))
-          (Origin.empty))))
+          List(Star(None)))(Origin.empty))))
   }
 
   "translate a query with PIVOT" in {
@@ -696,39 +637,31 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
   "parse and collect table hints for named table select statements in all variants" in {
     example(
       query = "SELECT * FROM t WITH (NOLOCK)",
-      expectedAst = Batch(Seq(Project(
-        TableWithHints(namedTable("t"),
-          Seq(FlagHint("NOLOCK"))), Seq(Star(None)))(Origin.empty))))
+      expectedAst =
+        Batch(Seq(Project(TableWithHints(namedTable("t"), Seq(FlagHint("NOLOCK"))), Seq(Star(None)))(Origin.empty))))
     example(
       query = "SELECT * FROM t WITH (FORCESEEK)",
-      expectedAst =
-        Batch(Seq(Project(
-          TableWithHints(namedTable("t"), Seq(ForceSeekHint(None, None))),
-          Seq(Star(None)))
-          (Origin.empty))))
+      expectedAst = Batch(
+        Seq(Project(TableWithHints(namedTable("t"), Seq(ForceSeekHint(None, None))), Seq(Star(None)))(Origin.empty))))
     example(
       query = "SELECT * FROM t WITH (FORCESEEK(1 (Col1, Col2)))",
       expectedAst = Batch(
         Seq(
           Project(
             TableWithHints(namedTable("t"), Seq(ForceSeekHint(Some(Literal(1)), Some(Seq(Id("Col1"), Id("Col2")))))),
-            Seq(Star(None)))
-            (Origin.empty))))
+            Seq(Star(None)))(Origin.empty))))
     example(
       query = "SELECT * FROM t WITH (INDEX = (Bill, Ted))",
       expectedAst = Batch(
-        Seq(Project(
-          TableWithHints(namedTable("t"), Seq(IndexHint(Seq(Id("Bill"), Id("Ted"))))),
-          Seq(Star(None)))
-          (Origin.empty))))
+        Seq(Project(TableWithHints(namedTable("t"), Seq(IndexHint(Seq(Id("Bill"), Id("Ted"))))), Seq(Star(None)))(
+          Origin.empty))))
     example(
       query = "SELECT * FROM t WITH (FORCESEEK, INDEX = (Bill, Ted))",
       expectedAst = Batch(
         Seq(
           Project(
             TableWithHints(namedTable("t"), Seq(ForceSeekHint(None, None), IndexHint(Seq(Id("Bill"), Id("Ted"))))),
-            Seq(Star(None)))
-            (Origin.empty))))
+            Seq(Star(None)))(Origin.empty))))
   }
 
   "translate INSERT statements" in {
@@ -843,10 +776,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Project(
             TableAlias(
               // TODO: This will change when UNION is implemented correctly
-              Project(
-                namedTable("TableA"),
-                Seq(simplyNamedColumn("ID"), simplyNamedColumn("Name")))
-                (Origin.empty),
+              Project(namedTable("TableA"), Seq(simplyNamedColumn("ID"), simplyNamedColumn("Name")))(Origin.empty),
               "DerivedTable"),
             Seq(simplyNamedColumn("ID"), simplyNamedColumn("Name")))(Origin.empty),
           None,
@@ -1039,8 +969,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
               Seq(
                 simplyNamedColumn("col1"),
                 simplyNamedColumn("fred"),
-                Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter"))))
-              (Origin.empty),
+                Alias(CallFunction("COUNT", Seq(simplyNamedColumn("OrderDate"))), Id("counter"))))(Origin.empty),
             Id("s"),
             Seq(Id("a"), Id("b"), Id("col3count")))),
           MergeIntoTable(

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
@@ -1,5 +1,6 @@
 package com.databricks.labs.remorph.parsers.tsql
 
+import com.databricks.labs.remorph.intermediate.Origin
 import com.databricks.labs.remorph.{intermediate => ir}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -129,7 +130,7 @@ class TSqlRelationBuilderSpec
         "WITH a (b, c) AS (SELECT x, y FROM d)",
         _.withExpression(),
         ir.SubqueryAlias(
-          ir.Project(namedTable("d"), Seq(simplyNamedColumn("x"), simplyNamedColumn("y"))),
+          ir.Project(namedTable("d"), Seq(simplyNamedColumn("x"), simplyNamedColumn("y")), origin = Origin.empty),
           ir.Id("a"),
           Seq(ir.Id("b"), ir.Id("c"))))
     }
@@ -144,7 +145,7 @@ class TSqlRelationBuilderSpec
             column_names = Seq(ir.Id("a"), ir.Id("bb")),
             all_columns_as_keys = false,
             within_watermark = false),
-          Seq(simplyNamedColumn("a"), ir.Alias(simplyNamedColumn("b"), ir.Id("bb")))))
+          Seq(simplyNamedColumn("a"), ir.Alias(simplyNamedColumn("b"), ir.Id("bb"))), origin = Origin.empty))
     }
 
     "SELECT a, b AS bb FROM (SELECT x, y FROM d) AS t (aliasA, 'aliasB')" in {
@@ -156,10 +157,11 @@ class TSqlRelationBuilderSpec
             ColumnAliases(
               ir.Project(
                 ir.NamedTable("d", Map(), is_streaming = false),
-                Seq(ir.Column(None, ir.Id("x")), ir.Column(None, ir.Id("y")))),
+                Seq(ir.Column(None, ir.Id("x")), ir.Column(None, ir.Id("y"))), origin = Origin.empty),
               Seq(ir.Id("aliasA"), ir.Id("aliasB"))),
             "t"),
-          Seq(ir.Column(None, ir.Id("a")), ir.Alias(ir.Column(None, ir.Id("b")), ir.Id("bb")))))
+          Seq(ir.Column(None, ir.Id("a")), ir.Alias(ir.Column(None, ir.Id("b")), ir.Id("bb"))),
+          origin = Origin.empty))
     }
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
@@ -130,7 +130,7 @@ class TSqlRelationBuilderSpec
         "WITH a (b, c) AS (SELECT x, y FROM d)",
         _.withExpression(),
         ir.SubqueryAlias(
-          ir.Project(namedTable("d"), Seq(simplyNamedColumn("x"), simplyNamedColumn("y")), origin = Origin.empty),
+          ir.Project(namedTable("d"), Seq(simplyNamedColumn("x"), simplyNamedColumn("y")))(Origin.empty),
           ir.Id("a"),
           Seq(ir.Id("b"), ir.Id("c"))))
     }
@@ -145,7 +145,7 @@ class TSqlRelationBuilderSpec
             column_names = Seq(ir.Id("a"), ir.Id("bb")),
             all_columns_as_keys = false,
             within_watermark = false),
-          Seq(simplyNamedColumn("a"), ir.Alias(simplyNamedColumn("b"), ir.Id("bb"))), origin = Origin.empty))
+          Seq(simplyNamedColumn("a"), ir.Alias(simplyNamedColumn("b"), ir.Id("bb"))))(Origin.empty))
     }
 
     "SELECT a, b AS bb FROM (SELECT x, y FROM d) AS t (aliasA, 'aliasB')" in {
@@ -157,11 +157,11 @@ class TSqlRelationBuilderSpec
             ColumnAliases(
               ir.Project(
                 ir.NamedTable("d", Map(), is_streaming = false),
-                Seq(ir.Column(None, ir.Id("x")), ir.Column(None, ir.Id("y"))), origin = Origin.empty),
+                Seq(ir.Column(None, ir.Id("x")), ir.Column(None, ir.Id("y"))))(Origin.empty),
               Seq(ir.Id("aliasA"), ir.Id("aliasB"))),
             "t"),
-          Seq(ir.Column(None, ir.Id("a")), ir.Alias(ir.Column(None, ir.Id("b")), ir.Id("bb"))),
-          origin = Origin.empty))
+          Seq(ir.Column(None, ir.Id("a")), ir.Alias(ir.Column(None, ir.Id("b")), ir.Id("bb"))))
+          (Origin.empty))
     }
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
@@ -160,8 +160,7 @@ class TSqlRelationBuilderSpec
                 Seq(ir.Column(None, ir.Id("x")), ir.Column(None, ir.Id("y"))))(Origin.empty),
               Seq(ir.Id("aliasA"), ir.Id("aliasB"))),
             "t"),
-          Seq(ir.Column(None, ir.Id("a")), ir.Alias(ir.Column(None, ir.Id("b")), ir.Id("bb"))))
-          (Origin.empty))
+          Seq(ir.Column(None, ir.Id("a")), ir.Alias(ir.Column(None, ir.Id("b")), ir.Id("bb"))))(Origin.empty))
     }
   }
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/PullLimitUpwardsTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/PullLimitUpwardsTest.scala
@@ -9,26 +9,23 @@ class PullLimitUpwardsTest extends AnyWordSpec with PlanComparison with Matchers
   "from project" in {
     val out = PullLimitUpwards.apply(Project(
       Limit(namedTable("a"), Literal(10)),
-      Seq(Star(None)),
-      origin = Origin.empty))
+      Seq(Star(None)))(Origin.empty))
     comparePlans(out, Limit(Project(
       namedTable("a"),
-      Seq(Star()),
-      origin = Origin.empty), Literal(10)))
+      Seq(Star()))(Origin.empty), Literal(10)))
   }
 
   "from project with filter" in {
     val out = PullLimitUpwards.apply(
       Filter(
-        Project(Limit(namedTable("a"), Literal(10)), Seq(Star(None)), origin = Origin.empty),
+        Project(Limit(namedTable("a"), Literal(10)), Seq(Star(None)))(Origin.empty),
         GreaterThan(UnresolvedAttribute("b"), Literal(1))))
     comparePlans(
       out,
       Limit(
         Filter(Project(
           namedTable("a"),
-          Seq(Star()),
-          origin = Origin.empty), GreaterThan(UnresolvedAttribute("b"), Literal(1))),
+          Seq(Star()))(Origin.empty), GreaterThan(UnresolvedAttribute("b"), Literal(1))),
         Literal(10)))
   }
 
@@ -36,7 +33,7 @@ class PullLimitUpwardsTest extends AnyWordSpec with PlanComparison with Matchers
     val out = PullLimitUpwards.apply(
       Sort(
         Filter(
-          Project(Limit(namedTable("a"), Literal(10)), Seq(Star(None)), origin = Origin.empty),
+          Project(Limit(namedTable("a"), Literal(10)), Seq(Star(None)))(Origin.empty),
           GreaterThan(UnresolvedAttribute("b"), Literal(1))),
         Seq(SortOrder(UnresolvedAttribute("b"))),
         is_global = false))
@@ -46,8 +43,8 @@ class PullLimitUpwardsTest extends AnyWordSpec with PlanComparison with Matchers
         Sort(
           Filter(Project(
             namedTable("a"),
-            Seq(Star()),
-            origin = Origin.empty), GreaterThan(UnresolvedAttribute("b"), Literal(1))),
+            Seq(Star()))
+            (Origin.empty), GreaterThan(UnresolvedAttribute("b"), Literal(1))),
           Seq(SortOrder(UnresolvedAttribute("b"))),
           is_global = false),
         Literal(10)))

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/PullLimitUpwardsTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/PullLimitUpwardsTest.scala
@@ -7,19 +7,28 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class PullLimitUpwardsTest extends AnyWordSpec with PlanComparison with Matchers with IRHelpers {
   "from project" in {
-    val out = PullLimitUpwards.apply(Project(Limit(namedTable("a"), Literal(10)), Seq(Star(None))))
-    comparePlans(out, Limit(Project(namedTable("a"), Seq(Star())), Literal(10)))
+    val out = PullLimitUpwards.apply(Project(
+      Limit(namedTable("a"), Literal(10)),
+      Seq(Star(None)),
+      origin = Origin.empty))
+    comparePlans(out, Limit(Project(
+      namedTable("a"),
+      Seq(Star()),
+      origin = Origin.empty), Literal(10)))
   }
 
   "from project with filter" in {
     val out = PullLimitUpwards.apply(
       Filter(
-        Project(Limit(namedTable("a"), Literal(10)), Seq(Star(None))),
+        Project(Limit(namedTable("a"), Literal(10)), Seq(Star(None)), origin = Origin.empty),
         GreaterThan(UnresolvedAttribute("b"), Literal(1))))
     comparePlans(
       out,
       Limit(
-        Filter(Project(namedTable("a"), Seq(Star())), GreaterThan(UnresolvedAttribute("b"), Literal(1))),
+        Filter(Project(
+          namedTable("a"),
+          Seq(Star()),
+          origin = Origin.empty), GreaterThan(UnresolvedAttribute("b"), Literal(1))),
         Literal(10)))
   }
 
@@ -27,7 +36,7 @@ class PullLimitUpwardsTest extends AnyWordSpec with PlanComparison with Matchers
     val out = PullLimitUpwards.apply(
       Sort(
         Filter(
-          Project(Limit(namedTable("a"), Literal(10)), Seq(Star(None))),
+          Project(Limit(namedTable("a"), Literal(10)), Seq(Star(None)), origin = Origin.empty),
           GreaterThan(UnresolvedAttribute("b"), Literal(1))),
         Seq(SortOrder(UnresolvedAttribute("b"))),
         is_global = false))
@@ -35,7 +44,10 @@ class PullLimitUpwardsTest extends AnyWordSpec with PlanComparison with Matchers
       out,
       Limit(
         Sort(
-          Filter(Project(namedTable("a"), Seq(Star())), GreaterThan(UnresolvedAttribute("b"), Literal(1))),
+          Filter(Project(
+            namedTable("a"),
+            Seq(Star()),
+            origin = Origin.empty), GreaterThan(UnresolvedAttribute("b"), Literal(1))),
           Seq(SortOrder(UnresolvedAttribute("b"))),
           is_global = false),
         Literal(10)))

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/PullLimitUpwardsTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/PullLimitUpwardsTest.scala
@@ -7,12 +7,8 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class PullLimitUpwardsTest extends AnyWordSpec with PlanComparison with Matchers with IRHelpers {
   "from project" in {
-    val out = PullLimitUpwards.apply(Project(
-      Limit(namedTable("a"), Literal(10)),
-      Seq(Star(None)))(Origin.empty))
-    comparePlans(out, Limit(Project(
-      namedTable("a"),
-      Seq(Star()))(Origin.empty), Literal(10)))
+    val out = PullLimitUpwards.apply(Project(Limit(namedTable("a"), Literal(10)), Seq(Star(None)))(Origin.empty))
+    comparePlans(out, Limit(Project(namedTable("a"), Seq(Star()))(Origin.empty), Literal(10)))
   }
 
   "from project with filter" in {
@@ -23,9 +19,7 @@ class PullLimitUpwardsTest extends AnyWordSpec with PlanComparison with Matchers
     comparePlans(
       out,
       Limit(
-        Filter(Project(
-          namedTable("a"),
-          Seq(Star()))(Origin.empty), GreaterThan(UnresolvedAttribute("b"), Literal(1))),
+        Filter(Project(namedTable("a"), Seq(Star()))(Origin.empty), GreaterThan(UnresolvedAttribute("b"), Literal(1))),
         Literal(10)))
   }
 
@@ -41,10 +35,9 @@ class PullLimitUpwardsTest extends AnyWordSpec with PlanComparison with Matchers
       out,
       Limit(
         Sort(
-          Filter(Project(
-            namedTable("a"),
-            Seq(Star()))
-            (Origin.empty), GreaterThan(UnresolvedAttribute("b"), Literal(1))),
+          Filter(
+            Project(namedTable("a"), Seq(Star()))(Origin.empty),
+            GreaterThan(UnresolvedAttribute("b"), Literal(1))),
           Seq(SortOrder(UnresolvedAttribute("b"))),
           is_global = false),
         Literal(10)))

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/TopPercentToLimitSubqueryTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/TopPercentToLimitSubqueryTest.scala
@@ -10,17 +10,16 @@ class TopPercentToLimitSubqueryTest extends AnyWordSpec with PlanComparison with
     val out =
       (new TopPercentToLimitSubquery).apply(TopPercent(Project(
         namedTable("Employees"),
-        Seq(Star()),
-        origin = Origin.empty), Literal(10)))
+        Seq(Star()))(Origin.empty), Literal(10)))
     comparePlans(
       out,
       WithCTE(
         Seq(
-          SubqueryAlias(Project(namedTable("Employees"), Seq(Star()), origin = Origin.empty), Id("_limited1")),
+          SubqueryAlias(Project(namedTable("Employees"), Seq(Star()))(Origin.empty), Id("_limited1")),
           SubqueryAlias(
             Project(
               UnresolvedRelation(ruleText = "_limited1", message = "Unresolved relation _limited1"),
-              Seq(Alias(Count(Seq(Star())), Id("count"))), origin = Origin.empty),
+              Seq(Alias(Count(Seq(Star())), Id("count"))))(Origin.empty),
             Id("_counted1"))),
         Limit(
           Project(
@@ -29,8 +28,8 @@ class TopPercentToLimitSubqueryTest extends AnyWordSpec with PlanComparison with
               message = "Unresolved relation _limited1",
               ruleName = "rule name undetermined",
               tokenName = None),
-            Seq(Star()),
-            origin = Origin.empty),
+            Seq(Star()))
+            (Origin.empty),
           ScalarSubquery(
             Project(
               UnresolvedRelation(
@@ -38,21 +37,21 @@ class TopPercentToLimitSubqueryTest extends AnyWordSpec with PlanComparison with
                 message = "Unresolved relation _counted1",
                 ruleName = "N/A",
                 tokenName = Some("N/A")),
-              Seq(Cast(Multiply(Divide(Id("count"), Literal(10)), Literal(100)), LongType)),
-              origin = Origin.empty)))))
+              Seq(Cast(Multiply(Divide(Id("count"), Literal(10)), Literal(100)), LongType)))
+              (Origin.empty)))))
   }
 
   "PERCENT WITH TIES applies" in {
     val out = (new TopPercentToLimitSubquery).apply(
       Sort(
-        Project(TopPercent(namedTable("Employees"), Literal(10), with_ties = true), Seq(Star()), origin = Origin.empty),
+        Project(TopPercent(namedTable("Employees"), Literal(10), with_ties = true), Seq(Star()))(Origin.empty),
         Seq(SortOrder(UnresolvedAttribute("a"))),
         is_global = false))
     comparePlans(
       out,
       WithCTE(
         Seq(
-          SubqueryAlias(Project(namedTable("Employees"), Seq(Star()), origin = Origin.empty), Id("_limited1")),
+          SubqueryAlias(Project(namedTable("Employees"), Seq(Star()))(Origin.empty), Id("_limited1")),
           SubqueryAlias(
             Project(
               UnresolvedRelation(ruleText = "_limited1", message = "Unresolved _limited1"),
@@ -60,14 +59,14 @@ class TopPercentToLimitSubqueryTest extends AnyWordSpec with PlanComparison with
                 Star(),
                 Alias(
                   Window(NTile(Literal(100)), sort_order = Seq(SortOrder(UnresolvedAttribute("a")))),
-                  Id("_percentile1"))),
-              origin = Origin.empty),
+                  Id("_percentile1"))))
+              (Origin.empty),
             Id("_with_percentile1"))),
         Filter(
           Project(
             UnresolvedRelation(ruleText = "_with_percentile1", message = "Unresolved _with_percentile1"),
-            Seq(Star()),
-            origin = Origin.empty),
+            Seq(Star()))
+            (Origin.empty),
           LessThanOrEqual(
             UnresolvedAttribute(
               unparsed_identifier = "_percentile1",

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/TopPercentToLimitSubqueryTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/rules/TopPercentToLimitSubqueryTest.scala
@@ -8,9 +8,8 @@ import org.scalatest.wordspec.AnyWordSpec
 class TopPercentToLimitSubqueryTest extends AnyWordSpec with PlanComparison with Matchers with IRHelpers {
   "PERCENT applies" in {
     val out =
-      (new TopPercentToLimitSubquery).apply(TopPercent(Project(
-        namedTable("Employees"),
-        Seq(Star()))(Origin.empty), Literal(10)))
+      (new TopPercentToLimitSubquery).apply(
+        TopPercent(Project(namedTable("Employees"), Seq(Star()))(Origin.empty), Literal(10)))
     comparePlans(
       out,
       WithCTE(
@@ -28,8 +27,7 @@ class TopPercentToLimitSubqueryTest extends AnyWordSpec with PlanComparison with
               message = "Unresolved relation _limited1",
               ruleName = "rule name undetermined",
               tokenName = None),
-            Seq(Star()))
-            (Origin.empty),
+            Seq(Star()))(Origin.empty),
           ScalarSubquery(
             Project(
               UnresolvedRelation(
@@ -37,8 +35,7 @@ class TopPercentToLimitSubqueryTest extends AnyWordSpec with PlanComparison with
                 message = "Unresolved relation _counted1",
                 ruleName = "N/A",
                 tokenName = Some("N/A")),
-              Seq(Cast(Multiply(Divide(Id("count"), Literal(10)), Literal(100)), LongType)))
-              (Origin.empty)))))
+              Seq(Cast(Multiply(Divide(Id("count"), Literal(10)), Literal(100)), LongType)))(Origin.empty)))))
   }
 
   "PERCENT WITH TIES applies" in {
@@ -59,14 +56,12 @@ class TopPercentToLimitSubqueryTest extends AnyWordSpec with PlanComparison with
                 Star(),
                 Alias(
                   Window(NTile(Literal(100)), sort_order = Seq(SortOrder(UnresolvedAttribute("a")))),
-                  Id("_percentile1"))))
-              (Origin.empty),
+                  Id("_percentile1"))))(Origin.empty),
             Id("_with_percentile1"))),
         Filter(
           Project(
             UnresolvedRelation(ruleText = "_with_percentile1", message = "Unresolved _with_percentile1"),
-            Seq(Star()))
-            (Origin.empty),
+            Seq(Star()))(Origin.empty),
           LessThanOrEqual(
             UnresolvedAttribute(
               unparsed_identifier = "_percentile1",

--- a/core/src/test/scala/com/databricks/labs/remorph/queries/ExampleDebuggerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/queries/ExampleDebuggerTest.scala
@@ -3,7 +3,6 @@ package com.databricks.labs.remorph.queries
 import com.databricks.labs.remorph.{OkResult, TransformationConstructors}
 import com.databricks.labs.remorph.parsers.PlanParser
 import com.databricks.labs.remorph.intermediate.NoopNode
-import org.antlr.v4.runtime.ParserRuleContext
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.matchers.should.Matchers
@@ -15,8 +14,7 @@ class ExampleDebuggerTest extends AnyWordSpec with Matchers with MockitoSugar wi
     "work" in {
       val buf = new StringBuilder
       val parser = mock[PlanParser[_]]
-      when(parser.parse(any())).thenReturn(lift(OkResult(ParserRuleContext.EMPTY)))
-      when(parser.visit(any())).thenReturn(lift(OkResult(NoopNode)))
+      when(parser.parse(any())).thenReturn(lift(OkResult(NoopNode)))
 
       val debugger = new ExampleDebugger(parser, x => buf.append(x), "snowflake")
       val name = s"${NestedFiles.projectRoot}/tests/resources/functional/snowflake/nested_query_with_json_1.sql"

--- a/core/src/test/scala/com/databricks/labs/remorph/queries/ExampleDebuggerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/queries/ExampleDebuggerTest.scala
@@ -14,7 +14,7 @@ class ExampleDebuggerTest extends AnyWordSpec with Matchers with MockitoSugar wi
     "work" in {
       val buf = new StringBuilder
       val parser = mock[PlanParser[_]]
-      when(parser.parse(any())).thenReturn(lift(OkResult(NoopNode)))
+      when(parser.parseLogicalPlan(any())).thenReturn(lift(OkResult(NoopNode)))
 
       val debugger = new ExampleDebugger(parser, x => buf.append(x), "snowflake")
       val name = s"${NestedFiles.projectRoot}/tests/resources/functional/snowflake/nested_query_with_json_1.sql"

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
@@ -39,10 +39,10 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
     "transpile BANG without semicolon" in {
       "!print Include This Text" transpilesTo
         """/* The following issues were detected:
-        |
-        |   Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand
-        |    !print Include This Text
-        | */""".stripMargin
+          |
+          |   Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand
+          |    !print Include This Text
+          | */""".stripMargin
     }
     "transpile BANG with options" in {
       "!options catch=true" transpilesTo
@@ -68,7 +68,7 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
            |  t1
            |ADD
            |  COLUMN c1 DECIMAL(38, 0);""".stripMargin
-      )
+        )
     }
 
     "ALTER TABLE t1 ADD COLUMN c1 INTEGER, c2 VARCHAR;" in {
@@ -84,7 +84,7 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
       "ALTER TABLE t1 DROP COLUMN c1;" transpilesTo (
         s"""ALTER TABLE
            |  t1 DROP COLUMN c1;""".stripMargin
-      )
+        )
     }
 
     "ALTER TABLE t1 DROP COLUMN c1, c2;" in {
@@ -118,7 +118,7 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
            |  t1
            |WHERE
            |  col1 != 100;""".stripMargin
-      )
+        )
 
       "SELECT * FROM t1;" transpilesTo
         s"""SELECT
@@ -150,9 +150,9 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
 
       "SELECT JSON_EXTRACT_PATH_TEXT(json_data, path_col) FROM demo1;" transpilesTo
         """SELECT
-           |  GET_JSON_OBJECT(json_data, CONCAT('$.', path_col))
-           |FROM
-           |  demo1;""".stripMargin
+          |  GET_JSON_OBJECT(json_data, CONCAT('$.', path_col))
+          |FROM
+          |  demo1;""".stripMargin
     }
 
     "transpile select distinct query" in {
@@ -166,9 +166,9 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
 
     "transpile window functions" in {
       s"""SELECT LAST_VALUE(c1)
-        |IGNORE NULLS OVER (PARTITION BY t1.c2 ORDER BY t1.c3 DESC
-        |RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS dc4
-        |FROM t1;""".stripMargin transpilesTo
+         |IGNORE NULLS OVER (PARTITION BY t1.c2 ORDER BY t1.c3 DESC
+         |RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS dc4
+         |FROM t1;""".stripMargin transpilesTo
         s"""SELECT
            |  LAST(c1) IGNORE NULLS OVER (
            |    PARTITION BY
@@ -186,16 +186,16 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
     "transpile MONTHS_BETWEEN function" in {
       "SELECT MONTHS_BETWEEN('2021-02-01'::DATE, '2021-01-01'::DATE);" transpilesTo
         """SELECT
-           |  MONTHS_BETWEEN(CAST('2021-02-01' AS DATE), CAST('2021-01-01' AS DATE), TRUE)
-           |  ;""".stripMargin
+          |  MONTHS_BETWEEN(CAST('2021-02-01' AS DATE), CAST('2021-01-01' AS DATE), TRUE)
+          |  ;""".stripMargin
 
       """SELECT
         | MONTHS_BETWEEN('2019-03-01 02:00:00'::TIMESTAMP, '2019-02-15 01:00:00'::TIMESTAMP)
         | AS mb;""".stripMargin transpilesTo
         """SELECT
-           |  MONTHS_BETWEEN(CAST('2019-03-01 02:00:00' AS TIMESTAMP), CAST('2019-02-15 01:00:00'
-           |  AS TIMESTAMP), TRUE) AS mb
-           |  ;""".stripMargin
+          |  MONTHS_BETWEEN(CAST('2019-03-01 02:00:00' AS TIMESTAMP), CAST('2019-02-15 01:00:00'
+          |  AS TIMESTAMP), TRUE) AS mb
+          |  ;""".stripMargin
     }
 
     "transpile ARRAY_REMOVE function" in {
@@ -273,7 +273,7 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
            |  CURRENT_TIMESTAMP()
            |FROM
            |  t1;""".stripMargin
-      )
+        )
     }
 
     "SELECT CURRENT_TIMESTAMP(1) FROM t1 where dt < CURRENT_TIMESTAMP" in {
@@ -284,7 +284,7 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
            |  t1
            |WHERE
            |  dt < CURRENT_TIMESTAMP();""".stripMargin
-      )
+        )
     }
 
     "SELECT CURRENT_TIME(1) FROM t1 where dt < CURRENT_TIMESTAMP()" in {
@@ -295,7 +295,7 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
            |  t1
            |WHERE
            |  dt < CURRENT_TIMESTAMP();""".stripMargin
-      )
+        )
     }
 
     "SELECT LOCALTIME() FROM t1 where dt < LOCALTIMESTAMP" in {
@@ -306,7 +306,7 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
            |  t1
            |WHERE
            |  dt < CURRENT_TIMESTAMP();""".stripMargin
-      )
+        )
     }
   }
 
@@ -344,6 +344,17 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
            |WHEN NOT MATCHED THEN
            |  INSERT (id, value, status) VALUES (s.id, s.value, s.status);""".stripMargin
     }
+  }
+
+  "line comment" should {
+    "transpiles to line comment" in {
+      """-- some comment
+select * from test_tbl;""" transpilesTo
+        """-- some comment
+SELECT * FROM test_tbl
+;""".stripMargin
+    }
+
   }
 
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
@@ -322,6 +322,7 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
     }
   }
 
+  /*
   "Snowflake MERGE commands" should {
 
     "MERGE;" in {
@@ -345,5 +346,6 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
            |  INSERT (id, value, status) VALUES (s.id, s.value, s.status);""".stripMargin
     }
   }
+   */
 
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
@@ -39,10 +39,10 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
     "transpile BANG without semicolon" in {
       "!print Include This Text" transpilesTo
         """/* The following issues were detected:
-          |
-          |   Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand
-          |    !print Include This Text
-          | */""".stripMargin
+        |
+        |   Unknown command in SnowflakeAstBuilder.visitSnowSqlCommand
+        |    !print Include This Text
+        | */""".stripMargin
     }
     "transpile BANG with options" in {
       "!options catch=true" transpilesTo
@@ -68,7 +68,7 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
            |  t1
            |ADD
            |  COLUMN c1 DECIMAL(38, 0);""".stripMargin
-        )
+      )
     }
 
     "ALTER TABLE t1 ADD COLUMN c1 INTEGER, c2 VARCHAR;" in {
@@ -84,7 +84,7 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
       "ALTER TABLE t1 DROP COLUMN c1;" transpilesTo (
         s"""ALTER TABLE
            |  t1 DROP COLUMN c1;""".stripMargin
-        )
+      )
     }
 
     "ALTER TABLE t1 DROP COLUMN c1, c2;" in {
@@ -118,7 +118,7 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
            |  t1
            |WHERE
            |  col1 != 100;""".stripMargin
-        )
+      )
 
       "SELECT * FROM t1;" transpilesTo
         s"""SELECT
@@ -150,9 +150,9 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
 
       "SELECT JSON_EXTRACT_PATH_TEXT(json_data, path_col) FROM demo1;" transpilesTo
         """SELECT
-          |  GET_JSON_OBJECT(json_data, CONCAT('$.', path_col))
-          |FROM
-          |  demo1;""".stripMargin
+           |  GET_JSON_OBJECT(json_data, CONCAT('$.', path_col))
+           |FROM
+           |  demo1;""".stripMargin
     }
 
     "transpile select distinct query" in {
@@ -166,9 +166,9 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
 
     "transpile window functions" in {
       s"""SELECT LAST_VALUE(c1)
-         |IGNORE NULLS OVER (PARTITION BY t1.c2 ORDER BY t1.c3 DESC
-         |RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS dc4
-         |FROM t1;""".stripMargin transpilesTo
+        |IGNORE NULLS OVER (PARTITION BY t1.c2 ORDER BY t1.c3 DESC
+        |RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS dc4
+        |FROM t1;""".stripMargin transpilesTo
         s"""SELECT
            |  LAST(c1) IGNORE NULLS OVER (
            |    PARTITION BY
@@ -186,16 +186,16 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
     "transpile MONTHS_BETWEEN function" in {
       "SELECT MONTHS_BETWEEN('2021-02-01'::DATE, '2021-01-01'::DATE);" transpilesTo
         """SELECT
-          |  MONTHS_BETWEEN(CAST('2021-02-01' AS DATE), CAST('2021-01-01' AS DATE), TRUE)
-          |  ;""".stripMargin
+           |  MONTHS_BETWEEN(CAST('2021-02-01' AS DATE), CAST('2021-01-01' AS DATE), TRUE)
+           |  ;""".stripMargin
 
       """SELECT
         | MONTHS_BETWEEN('2019-03-01 02:00:00'::TIMESTAMP, '2019-02-15 01:00:00'::TIMESTAMP)
         | AS mb;""".stripMargin transpilesTo
         """SELECT
-          |  MONTHS_BETWEEN(CAST('2019-03-01 02:00:00' AS TIMESTAMP), CAST('2019-02-15 01:00:00'
-          |  AS TIMESTAMP), TRUE) AS mb
-          |  ;""".stripMargin
+           |  MONTHS_BETWEEN(CAST('2019-03-01 02:00:00' AS TIMESTAMP), CAST('2019-02-15 01:00:00'
+           |  AS TIMESTAMP), TRUE) AS mb
+           |  ;""".stripMargin
     }
 
     "transpile ARRAY_REMOVE function" in {
@@ -273,7 +273,7 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
            |  CURRENT_TIMESTAMP()
            |FROM
            |  t1;""".stripMargin
-        )
+      )
     }
 
     "SELECT CURRENT_TIMESTAMP(1) FROM t1 where dt < CURRENT_TIMESTAMP" in {
@@ -284,7 +284,7 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
            |  t1
            |WHERE
            |  dt < CURRENT_TIMESTAMP();""".stripMargin
-        )
+      )
     }
 
     "SELECT CURRENT_TIME(1) FROM t1 where dt < CURRENT_TIMESTAMP()" in {
@@ -295,7 +295,7 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
            |  t1
            |WHERE
            |  dt < CURRENT_TIMESTAMP();""".stripMargin
-        )
+      )
     }
 
     "SELECT LOCALTIME() FROM t1 where dt < LOCALTIMESTAMP" in {
@@ -306,7 +306,7 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
            |  t1
            |WHERE
            |  dt < CURRENT_TIMESTAMP();""".stripMargin
-        )
+      )
     }
   }
 
@@ -344,17 +344,6 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
            |WHEN NOT MATCHED THEN
            |  INSERT (id, value, status) VALUES (s.id, s.value, s.status);""".stripMargin
     }
-  }
-
-  "line comment" should {
-    "transpiles to line comment" in {
-      """-- some comment
-select * from test_tbl;""" transpilesTo
-        """-- some comment
-SELECT * FROM test_tbl
-;""".stripMargin
-    }
-
   }
 
 }


### PR DESCRIPTION
Refactors the LogicalPlan pipeline such that it's possible to use the original TokenStream to fetch the comment tokens and apply them appropriately to the plan items.

Requires #1190 

Progresses https://github.com/databrickslabs/remorph/issues/869