### PR TITLE
Fixing presto strpos and array_average functions

### DIFF
--- a/src/databricks/labs/remorph/snow/local_expression.py
+++ b/src/databricks/labs/remorph/snow/local_expression.py
@@ -180,3 +180,11 @@ class MapKeys(Func):
 
 class ArrayExists(Func):
     arg_types = {"this": True, "expression": True}
+
+
+class Locate(Func):
+    arg_types = {"substring": True, "this": True, "position": False}
+
+
+class NamedStruct(Func):
+    arg_types = {"expressions": True}

--- a/src/databricks/labs/remorph/snow/presto.py
+++ b/src/databricks/labs/remorph/snow/presto.py
@@ -2,7 +2,6 @@ from sqlglot.dialects.presto import Presto as presto
 from sqlglot import exp
 from sqlglot.helper import seq_get
 from sqlglot.errors import ParseError
-from sqlglot.dialects.dialect import locate_to_strposition
 from sqlglot.tokens import TokenType
 
 from databricks.labs.remorph.snow import local_expression
@@ -41,6 +40,74 @@ def _build_any_keys_match(args: list) -> local_expression.ArrayExists:
     )
 
 
+def _build_str_position(args: list) -> local_expression.Locate:
+    # TODO the 3rd param in presto strpos and databricks locate has different implementation.
+    # For now we haven't implemented the logic same as presto for 3rd param.
+    # Users should be vigilant when using 3 param function in presto strpos.
+    if len(args) == 3:
+        return local_expression.Locate(substring=seq_get(args, 1), this=seq_get(args, 0), position=seq_get(args, 2))
+    return local_expression.Locate(substring=seq_get(args, 1), this=seq_get(args, 0))
+
+
+def _build_array_average(args: list) -> exp.Reduce:
+    return exp.Reduce(
+        this=exp.ArrayFilter(
+            this=seq_get(args, 0),
+            expression=exp.Lambda(
+                this=exp.Not(this=exp.Is(this=exp.Identifier(this="x", quoted=False), expression=exp.Null())),
+                expressions=[exp.Identifier(this="x", quoted=False)],
+            ),
+        ),
+        initial=local_expression.NamedStruct(
+            expressions=[
+                exp.Literal(this="sum", is_string=True),
+                exp.Cast(this=exp.Literal(this="0", is_string=False), to=exp.DataType(this="DOUBLE")),
+                exp.Literal(this="cnt", is_string=True),
+                exp.Literal(this="0", is_string=False),
+            ],
+        ),
+        merge=exp.Lambda(
+            this=local_expression.NamedStruct(
+                expressions=[
+                    exp.Literal(this="sum", is_string=True),
+                    exp.Add(
+                        this=exp.Dot(
+                            this=exp.Identifier(this="acc", quoted=False),
+                            expression=exp.Identifier(this="sum", quoted=False),
+                        ),
+                        expression=exp.Identifier(this="x", quoted=False),
+                    ),
+                    exp.Literal(this="cnt", is_string=True),
+                    exp.Add(
+                        this=exp.Dot(
+                            this=exp.Identifier(this="acc", quoted=False),
+                            expression=exp.Identifier(this="cnt", quoted=False),
+                        ),
+                        expression=exp.Literal(this="1", is_string=False),
+                    ),
+                ],
+            ),
+            expressions=[exp.Identifier(this="acc", quoted=False), exp.Identifier(this="x", quoted=False)],
+        ),
+        finish=exp.Lambda(
+            this=exp.Anonymous(
+                this="try_divide",
+                expressions=[
+                    exp.Dot(
+                        this=exp.Identifier(this="acc", quoted=False),
+                        expression=exp.Identifier(this="sum", quoted=False),
+                    ),
+                    exp.Dot(
+                        this=exp.Identifier(this="acc", quoted=False),
+                        expression=exp.Identifier(this="cnt", quoted=False),
+                    ),
+                ],
+            ),
+            expressions=[exp.Identifier(this="acc", quoted=False)],
+        ),
+    )
+
+
 class Presto(presto):
 
     class Parser(presto.Parser):
@@ -49,8 +116,9 @@ class Presto(presto):
         FUNCTIONS = {
             **presto.Parser.FUNCTIONS,
             "APPROX_PERCENTILE": _build_approx_percentile,
-            "STRPOS": locate_to_strposition,
+            "STRPOS": _build_str_position,
             "ANY_KEYS_MATCH": _build_any_keys_match,
+            "ARRAY_AVERAGE": _build_array_average,
         }
 
     class Tokenizer(presto.Tokenizer):

--- a/src/databricks/labs/remorph/snow/presto.py
+++ b/src/databricks/labs/remorph/snow/presto.py
@@ -1,3 +1,4 @@
+import logging
 from sqlglot.dialects.presto import Presto as presto
 from sqlglot import exp
 from sqlglot.helper import seq_get
@@ -5,6 +6,9 @@ from sqlglot.errors import ParseError
 from sqlglot.tokens import TokenType
 
 from databricks.labs.remorph.snow import local_expression
+
+
+logger = logging.getLogger(__name__)
 
 
 def _build_approx_percentile(args: list) -> exp.Expression:
@@ -45,6 +49,12 @@ def _build_str_position(args: list) -> local_expression.Locate:
     # For now we haven't implemented the logic same as presto for 3rd param.
     # Users should be vigilant when using 3 param function in presto strpos.
     if len(args) == 3:
+        msg = (
+            "*Warning:: The third parameter in Presto's `strpos` function and Databricks' `locate` function "
+            "have different implementations. Please exercise caution when using the three-parameter version "
+            "of the `strpos` function in Presto."
+        )
+        logger.warning(msg)
         return local_expression.Locate(substring=seq_get(args, 1), this=seq_get(args, 0), position=seq_get(args, 2))
     return local_expression.Locate(substring=seq_get(args, 1), this=seq_get(args, 0))
 

--- a/tests/resources/functional/presto/test_array_average/test_array_average_1.sql
+++ b/tests/resources/functional/presto/test_array_average/test_array_average_1.sql
@@ -1,0 +1,40 @@
+-- presto sql:
+select
+  id,
+  sum(array_average(arr)) as sum_arr
+FROM
+  (
+    SELECT
+      1 as id,
+      ARRAY [1,2,3] AS arr
+    UNION
+    SELECT
+      2 as id,
+      ARRAY [10.20,20.108,30.4,40.0] as arr
+  ) AS t
+group by
+  id;
+
+-- databricks sql:
+SELECT
+  id,
+  SUM(
+    AGGREGATE(
+      FILTER(arr, x -> x IS NOT NULL),
+      NAMED_STRUCT('sum', CAST(0 AS DOUBLE), 'cnt', 0),
+      (acc, x) -> NAMED_STRUCT('sum', acc.sum + x, 'cnt', acc.cnt + 1),
+      acc -> TRY_DIVIDE(acc.sum, acc.cnt)
+    )
+  ) AS sum_arr
+FROM
+  (
+    SELECT
+      1 AS id,
+      ARRAY(1, 2, 3) AS arr
+    UNION
+    SELECT
+      2 AS id,
+      ARRAY(10.20, 20.108, 30.4, 40.0) AS arr
+  ) AS t
+GROUP BY
+  id;

--- a/tests/resources/functional/presto/test_strpos/test_strpos_1.sql
+++ b/tests/resources/functional/presto/test_strpos/test_strpos_1.sql
@@ -3,4 +3,4 @@
 SELECT strpos('Hello world', 'l', 2);
 
 -- databricks sql:
-SELECT LOCATE('Hello world', 'l', 2);
+SELECT LOCATE('l', 'Hello world', 2);

--- a/tests/resources/functional/presto/test_strpos/test_strpos_2.sql
+++ b/tests/resources/functional/presto/test_strpos/test_strpos_2.sql
@@ -1,6 +1,6 @@
 
 -- presto sql:
-SELECT CASE WHEN strpos(greeting_message, 'hello') > 0 THEN 'Contains hello' ELSE 'Does not contain hello' END FROM greetings_table;;
+SELECT CASE WHEN strpos(greeting_message, 'hello') > 0 THEN 'Contains hello' ELSE 'Does not contain hello' END FROM greetings_table;
 
 -- databricks sql:
-SELECT CASE WHEN LOCATE(greeting_message, 'hello') > 0 THEN 'Contains hello' ELSE 'Does not contain hello' END FROM greetings_table;
+SELECT CASE WHEN LOCATE('hello', greeting_message) > 0 THEN 'Contains hello' ELSE 'Does not contain hello' END FROM greetings_table;


### PR DESCRIPTION
In this PR we are handling both STRPOS and ARRAY_AVERAGE functions.

`STRPOS:`
--presto SQL:
SELECT strpos('Hello world', 'l', 2);

--databricks sql:
SELECT LOCATE('l', 'Hello world', 2);

`ARRAY_AVERAGE:`
Databricks doesn't have any built-in function to calculate the average of an array, so we are handling it using nested functions available in Databricks. It handles nulls, Integer and Double.

--presto SQL:
rray_average(arr)

--databricks SQL:
AGGREGATE(
      FILTER(arr, x -> x IS NOT NULL),
      NAMED_STRUCT('sum', CAST(0 AS DOUBLE), 'cnt', 0),
      (acc, x) -> NAMED_STRUCT('sum', acc.sum + x, 'cnt', acc.cnt + 1),
      acc -> TRY_DIVIDE(acc.sum, acc.cnt)
    )

