### PR TITLE
TSQL parser support for `(LHS) UNION RHS` queries

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -66,12 +66,11 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
       ctx match {
         case qs if qs.querySpecification() != null => qs.querySpecification().accept(this) // TODO: Implement set ops
         case qe if qe.queryExpression() != null =>
-          val lhs = qe.queryExpression(0).accept(this)
-          Option(qe.queryExpression(1)).map(_.accept(this)) match {
-            case Some(rhs) =>
+          qe.queryExpression().asScala.map(_.accept(this)) match {
+            case Seq(lhs) => lhs
+            case Seq(lhs, rhs) =>
               val isAll = qe.ALL() != null
               ir.SetOperation(lhs, rhs, ir.UnionSetOp, is_all = isAll, by_name = false, allow_missing_columns = false)
-            case None => lhs
           }
       }
   }

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -67,9 +67,12 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
         case qs if qs.querySpecification() != null => qs.querySpecification().accept(this) // TODO: Implement set ops
         case qe if qe.queryExpression() != null =>
           val lhs = qe.queryExpression(0).accept(this)
-          val rhs = qe.queryExpression(1).accept(this)
-          val isAll = qe.ALL() != null
-          ir.SetOperation(lhs, rhs, ir.UnionSetOp, is_all = isAll, by_name = false, allow_missing_columns = false)
+          Option(qe.queryExpression(1)).map(_.accept(this)) match {
+            case Some(rhs) =>
+              val isAll = qe.ALL() != null
+              ir.SetOperation(lhs, rhs, ir.UnionSetOp, is_all = isAll, by_name = false, allow_missing_columns = false)
+            case None => lhs
+          }
       }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -65,13 +65,11 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
     case None =>
       ctx match {
         case qs if qs.querySpecification() != null => qs.querySpecification().accept(this) // TODO: Implement set ops
-        case _ =>
-          // TODO: Implement this style of UNION
-          ir.UnresolvedRelation(
-            ruleText = contextText(ctx),
-            message = s"This style of UNION specification is as yet supported",
-            ruleName = vc.ruleName(ctx),
-            tokenName = Some(tokenName(ctx.getStart)))
+        case qe if qe.queryExpression() != null =>
+          val lhs = qe.queryExpression(0).accept(this)
+          val rhs = qe.queryExpression(1).accept(this)
+          val isAll = qe.ALL() != null
+          ir.SetOperation(lhs, rhs, ir.UnionSetOp, is_all = isAll, by_name = false, allow_missing_columns = false)
       }
   }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -3,7 +3,6 @@ package com.databricks.labs.remorph.parsers.tsql
 import com.databricks.labs.remorph.parsers.ParserCommon
 import com.databricks.labs.remorph.parsers.tsql.TSqlParser.{StringContext => _, _}
 import com.databricks.labs.remorph.parsers.tsql.rules.{InsertDefaultsAction, TopPercent}
-import com.databricks.labs.remorph.parsers.tsql.TSqlParser.{StringContext => _, _}
 import com.databricks.labs.remorph.{intermediate => ir}
 import org.antlr.v4.runtime.ParserRuleContext
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
@@ -147,6 +147,34 @@ class TSqlRelationBuilderSpec
           Seq(simplyNamedColumn("a"), ir.Alias(simplyNamedColumn("b"), ir.Id("bb")))))
     }
 
+    "translate right-associative UNION clauses" should {
+      // These are of the form: (queryExpression) UNION [ALL] query expression
+      "(SELECT a, b FROM bb) UNION select x, y FROM zz" in {
+        example(
+          "(SELECT a, b FROM bb) UNION select x, y FROM zz",
+          _.queryExpression(),
+          ir.SetOperation(
+            ir.Project(namedTable("bb"), Seq(ir.Column(None, ir.Id("a")), ir.Column(None, ir.Id("b")))),
+            ir.Project(namedTable("zz"), Seq(ir.Column(None, ir.Id("x")), ir.Column(None, ir.Id("y")))),
+            ir.UnionSetOp,
+            is_all = false,
+            by_name = false,
+            allow_missing_columns = false))
+      }
+      "(SELECT a, b FROM bb) UNION ALL select x, y FROM zz" in {
+        example(
+          "(SELECT a, b FROM bb) UNION ALL select x, y FROM zz",
+          _.queryExpression(),
+          ir.SetOperation(
+            ir.Project(namedTable("bb"), Seq(ir.Column(None, ir.Id("a")), ir.Column(None, ir.Id("b")))),
+            ir.Project(namedTable("zz"), Seq(ir.Column(None, ir.Id("x")), ir.Column(None, ir.Id("y")))),
+            ir.UnionSetOp,
+            is_all = true,
+            by_name = false,
+            allow_missing_columns = false))
+      }
+    }
+
     "SELECT a, b AS bb FROM (SELECT x, y FROM d) AS t (aliasA, 'aliasB')" in {
       example(
         "SELECT a, b AS bb FROM (SELECT x, y FROM d) AS t (aliasA, 'aliasB')",

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
@@ -148,7 +148,7 @@ class TSqlRelationBuilderSpec
     }
 
     "translate right-associative UNION clauses" should {
-      // These are of the form: (queryExpression) UNION [ALL] query expression
+      // These are of the form: (queryExpression) [UNION [ALL] query expression]
       "(SELECT a, b FROM bb) UNION select x, y FROM zz" in {
         example(
           "(SELECT a, b FROM bb) UNION select x, y FROM zz",
@@ -172,6 +172,12 @@ class TSqlRelationBuilderSpec
             is_all = true,
             by_name = false,
             allow_missing_columns = false))
+      }
+      "(SELECT a, b FROM bb)" in {
+        example(
+          "(SELECT a, b FROM bb)",
+          _.queryExpression(),
+          ir.Project(namedTable("bb"), Seq(ir.Column(None, ir.Id("a")), ir.Column(None, ir.Id("b")))))
       }
     }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/TsqlToDatabricksTranspilerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/TsqlToDatabricksTranspilerTest.scala
@@ -1,0 +1,22 @@
+package com.databricks.labs.remorph.transpilers
+
+import org.scalatest.wordspec.AnyWordSpec
+
+class TsqlToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTestCommon {
+
+  protected final val transpiler = new TSqlToDatabricksTranspiler
+
+  "The TSQL-to-Databricks transpiler" when {
+    "transpiling set operations" should {
+      val expectedTranslations = Map(
+        "(SELECT a, b from c) UNION SELECT x, y FROM z" -> "(SELECT a, b from c) UNION (SELECT x, y from z);",
+        "(SELECT a, b from c) UNION ALL SELECT x, y FROM z" -> "(SELECT a, b from c) UNION ALL (SELECT x, y from z);",
+        "(SELECT a, b FROM c)" -> "SELECT a, b FROM c;")
+      expectedTranslations.foreach { case (originalTSql, expectedDatabricksSql) =>
+        s"correctly transpile: $originalTSql" in {
+          originalTSql transpilesTo expectedDatabricksSql
+        }
+      }
+    }
+  }
+}

--- a/tests/resources/functional/tsql/set-operations/union_all_left_grouped.sql
+++ b/tests/resources/functional/tsql/set-operations/union_all_left_grouped.sql
@@ -1,0 +1,10 @@
+-- ## (SELECT …) UNION ALL SELECT …
+--
+-- Verify UNION handling when the LHS of the union is explicitly wrapped in parentheses.
+--
+-- tsql sql:
+
+(SELECT a, b from c) UNION ALL SELECT x, y from z;
+
+-- databricks sql:
+(SELECT a, b FROM c) UNION ALL (SELECT x, y  FROM z);

--- a/tests/resources/functional/tsql/set-operations/union_left_grouped.sql
+++ b/tests/resources/functional/tsql/set-operations/union_left_grouped.sql
@@ -1,0 +1,10 @@
+-- ## (SELECT …) UNION SELECT …
+--
+-- Verify UNION handling when the LHS of the union is explicitly wrapped in parentheses.
+--
+-- tsql sql:
+
+(SELECT a, b from c) UNION SELECT x, y from z;
+
+-- databricks sql:
+(SELECT a, b FROM c) UNION (SELECT x, y  FROM z);


### PR DESCRIPTION
This PR updates the TSQL parsing so that the following form of UNION is supported:
```sql
(SELECT a from b)
UNION [ALL]
SELECT x from y
```

Resolves #1127.