### PR TITLE
Constrain the Databricks SDK: version 0.37.0 introduced breaking changes which affect our tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "databricks-sdk~=0.29.0",
+  "databricks-sdk~=0.29.0,<0.37.0",  # TODO: Temporary; fix compatibility with SDK 0.37.0 and later.
   "sqlglot==25.30.0",
   "databricks-labs-blueprint[yaml]>=0.2.3",
   "databricks-labs-lsql>=0.7.5",


### PR DESCRIPTION
This PR updates the project dependencies to not use version 0.37.0 (or later) of the Databricks SDK: it introduced some breaking changes that affect our unit tests.

This is intended to be a temporary fix to unblock CI and new installations; these install the latest version.