### PR TITLE
Limit LSQL to releases before 0.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "databricks-sdk~=0.29.0",
   "sqlglot==25.30.0",
   "databricks-labs-blueprint[yaml]>=0.2.3",
-  "databricks-labs-lsql>=0.7.5",
+  "databricks-labs-lsql>=0.7.5,<0.14.0",  # TODO: Limit the LSQL version until dependencies are correct.
   "cryptography>=41.0.3",
 ]
 


### PR DESCRIPTION
The 0.14.0 release depends on Databricks SDK 0.37.0, but doesn't declare this. As such it can't be installed due to our dependency on Databricks SDK 0.29.0.

Reference: databrickslabs/lsql#330