### PR TITLE
Implement remaining TSQL set operations.

### DIFF
--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -759,8 +759,13 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
           Some(Seq(Id("ID"), Id("Name"))),
           Project(
             TableAlias(
-              // TODO: This will change when UNION is implemented correctly
-              Project(namedTable("TableA"), Seq(simplyNamedColumn("ID"), simplyNamedColumn("Name"))),
+              SetOperation(
+                Project(namedTable("TableA"), Seq(simplyNamedColumn("ID"), simplyNamedColumn("Name"))),
+                Project(namedTable("TableB"), Seq(simplyNamedColumn("ID"), simplyNamedColumn("Name"))),
+                UnionSetOp,
+                is_all = false,
+                by_name = false,
+                allow_missing_columns = false),
               "DerivedTable"),
             Seq(simplyNamedColumn("ID"), simplyNamedColumn("Name"))),
           None,


### PR DESCRIPTION
## Changes

This PR implements support for parsing set operations with TSql: `UNION [ALL]`, `EXCEPT` and `INTERSECT`.

The grammar previously supported these but they were not being converted to the IR.

### Linked issues

Resolves #1126.
Resolves #1102.

### Tests

- [ ] added unit tests
- [ ] added transpiler tests
- [ ] added functional tests
