### PR TITLE
Enclose subqueries in parenthesis

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
@@ -17,8 +17,14 @@ class LogicalPlanGenerator(
       case w: ir.WithCTE => cte(w)
       case p: ir.Project => project(p)
       case ir.NamedTable(id, _, _) => lift(OkResult(id))
-      case ir.Filter(input, condition) =>
-        code"${generate(input)} WHERE ${expr.generate(condition)}"
+      case ir.Filter(input, condition) => {
+        val source = input match {
+          // enclose subquery in parenthesis
+          case project: ir.Project => code"(${generate(project)})"
+          case _ => code"${generate(input)}"
+        }
+        code"${source} WHERE ${expr.generate(condition)}"
+      }
       case ir.Limit(input, limit) =>
         code"${generate(input)} LIMIT ${expr.generate(limit)}"
       case ir.Offset(child, offset) =>

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGeneratorTest.scala
@@ -58,7 +58,7 @@ class LogicalPlanGeneratorTest extends AnyWordSpec with GeneratorTestCommon[ir.L
     "transpile to WHERE" in {
       ir.Filter(
         ir.Project(namedTable("t1"), Seq(ir.Id("c1"))),
-        ir.CallFunction("IS_DATE", Seq(ir.Id("c2")))) generates "SELECT c1 FROM t1 WHERE IS_DATE(c2)"
+        ir.CallFunction("IS_DATE", Seq(ir.Id("c2")))) generates "(SELECT c1 FROM t1) WHERE IS_DATE(c2)"
     }
   }
 


### PR DESCRIPTION
Generator does not currently enclose subqueries in parenthesis, thus generating incorrect code such as the following:

`SELECT * FROM SELECT * FROM t WHERE a > 'a'  WHERE a > 'b' `

This PR fixes the issue such that the generated code is now:

`SELECT * FROM (SELECT * FROM t WHERE a > 'a')  WHERE a > 'b' `

It takes special care of the `.. IN(SELECT...)` pattern, by avoiding doubling enlosing parenthesis

Test cases are included #1233 but not added here because they require changes unrelated to this PR