### PR TITLE
Add tests for partially successful parsing

### DIFF
--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/ParserTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/ParserTestCommon.scala
@@ -30,7 +30,11 @@ trait ParserTestCommon[P <: Parser] extends PlanComparison { self: Assertions =>
     tree
   }
 
-  protected def example[R <: RuleContext](query: String, rule: P => R, expectedAst: ir.LogicalPlan, failOnErrors: Boolean = true): Unit = {
+  protected def example[R <: RuleContext](
+      query: String,
+      rule: P => R,
+      expectedAst: ir.LogicalPlan,
+      failOnErrors: Boolean = true): Unit = {
     val sfTree = parseString(query, rule)
     if (errListener != null && errListener.errorCount != 0) {
       errListener.logErrors()

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/ParserTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/ParserTestCommon.scala
@@ -30,11 +30,13 @@ trait ParserTestCommon[P <: Parser] extends PlanComparison { self: Assertions =>
     tree
   }
 
-  protected def example[R <: RuleContext](query: String, rule: P => R, expectedAst: ir.LogicalPlan): Unit = {
+  protected def example[R <: RuleContext](query: String, rule: P => R, expectedAst: ir.LogicalPlan, failOnErrors: Boolean = true): Unit = {
     val sfTree = parseString(query, rule)
     if (errListener != null && errListener.errorCount != 0) {
       errListener.logErrors()
-      fail(s"${errListener.errorCount} errors found in the child string")
+      if (failOnErrors) {
+        fail(s"${errListener.errorCount} errors found in the child string")
+      }
     }
 
     val result = astBuilder.visit(sfTree)

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
@@ -457,13 +457,13 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
           Seq(
             CreateTableCommand("t1", Seq(ColumnDeclaration("x", StringType))),
             UnresolvedRelation("Unparsable text: SELECTxyz", message = "Unparsed input - ErrorNode encountered"),
-            UnresolvedRelation("Unparsable text: SELECT\nUnparsable text: x\nUnparsable text: y\nUnparsable text: z\nUnparsable text: parser recovered by ignoring: SELECTxyz;", message = "Unparsed input - ErrorNode encountered"),
+            UnresolvedRelation(
+              "Unparsable text: SELECT\nUnparsable text: x\nUnparsable text: y\nUnparsable text: z\nUnparsable text: parser recovered by ignoring: SELECTxyz;",
+              message = "Unparsed input - ErrorNode encountered"),
             Project(namedTable("t3"), Seq(Literal(3))))),
         failOnErrors = false)
 
     }
-
-
 
     "translate BANG to Unresolved Expression" in {
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeAstBuilderSpec.scala
@@ -445,6 +445,26 @@ class SnowflakeAstBuilderSpec extends AnyWordSpec with SnowflakeParserTestCommon
         UpdateTable(namedTable("t1"), None, Seq(Assign(Column(None, Id("c1")), Literal(42))), None, None, None))
     }
 
+    "survive an invalid command" in {
+      example(
+        """
+          |CREATE TABLE t1 (x VARCHAR);
+          |SELECT x y z;
+          |SELECT 3 FROM t3;
+          |""".stripMargin,
+        _.snowflakeFile(),
+        Batch(
+          Seq(
+            CreateTableCommand("t1", Seq(ColumnDeclaration("x", StringType))),
+            UnresolvedRelation("Unparsable text: SELECTxyz", message = "Unparsed input - ErrorNode encountered"),
+            UnresolvedRelation("Unparsable text: SELECT\nUnparsable text: x\nUnparsable text: y\nUnparsable text: z\nUnparsable text: parser recovered by ignoring: SELECTxyz;", message = "Unparsed input - ErrorNode encountered"),
+            Project(namedTable("t3"), Seq(Literal(3))))),
+        failOnErrors = false)
+
+    }
+
+
+
     "translate BANG to Unresolved Expression" in {
 
       example(

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
@@ -378,8 +378,7 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
         |CREATE TABLE t1 (x VARCHAR);
         |SELECT x y z;
         |SELECT 3 FROM t3;
-        |""".stripMargin transpilesTo(
-      """
+        |""".stripMargin transpilesTo ("""
         |CREATE TABLE t1 (x STRING);
         |/* The following issues were detected:
         |

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
@@ -372,4 +372,35 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
         |    t;""".stripMargin
   }
 
+  "Batch statements" should {
+    "survive invalid SQL" in {
+      """
+        |CREATE TABLE t1 (x VARCHAR);
+        |SELECT x y z;
+        |SELECT 3 FROM t3;
+        |""".stripMargin transpilesTo(
+      """
+        |CREATE TABLE t1 (x STRING);
+        |/* The following issues were detected:
+        |
+        |   Unparsed input - ErrorNode encountered
+        |    Unparsable text: SELECTxyz
+        | */
+        |/* The following issues were detected:
+        |
+        |   Unparsed input - ErrorNode encountered
+        |    Unparsable text: SELECT
+        |    Unparsable text: x
+        |    Unparsable text: y
+        |    Unparsable text: z
+        |    Unparsable text: parser recovered by ignoring: SELECTxyz;
+        | */
+        | SELECT
+        |  3
+        |FROM
+        |  t3;""".stripMargin, false)
+
+    }
+  }
+
 }

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/TranspilerTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/TranspilerTestCommon.scala
@@ -11,10 +11,15 @@ trait TranspilerTestCommon extends Matchers with Formatter with ErrorEncoders {
   protected def transpiler: Transpiler
 
   implicit class TranspilerTestOps(input: String) {
-    def transpilesTo(expectedOutput: String): Assertion = {
+
+    def transpilesTo(expectedOutput: String, failOnError: Boolean = true): Assertion = {
       transpiler.transpile(Parsing(input)).runAndDiscardState(Init) match {
         case OkResult(output) => format(output) shouldBe format(expectedOutput)
-        case PartialResult(_, err) => fail(err.asJson.noSpaces)
+        case PartialResult(output, err) => if (failOnError) {
+          fail(err.asJson.noSpaces)
+        } else {
+          format(output) shouldBe format(expectedOutput)
+        }
         case KoResult(_, err) => fail(err.asJson.noSpaces)
       }
     }

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/TranspilerTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/TranspilerTestCommon.scala
@@ -15,11 +15,12 @@ trait TranspilerTestCommon extends Matchers with Formatter with ErrorEncoders {
     def transpilesTo(expectedOutput: String, failOnError: Boolean = true): Assertion = {
       transpiler.transpile(Parsing(input)).runAndDiscardState(Init) match {
         case OkResult(output) => format(output) shouldBe format(expectedOutput)
-        case PartialResult(output, err) => if (failOnError) {
-          fail(err.asJson.noSpaces)
-        } else {
-          format(output) shouldBe format(expectedOutput)
-        }
+        case PartialResult(output, err) =>
+          if (failOnError) {
+            fail(err.asJson.noSpaces)
+          } else {
+            format(output) shouldBe format(expectedOutput)
+          }
         case KoResult(_, err) => fail(err.asJson.noSpaces)
       }
     }


### PR DESCRIPTION
Doesn't actually fix anything, rather adds tests that show that a fix might not be required
Progresses https://github.com/databrickslabs/remorph/issues/976

Supersedes #1223 which was lacking gpg signature