### PR TITLE
Tech debt: replace empty case classes with case objects

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/generators/py/rules/PySparkStatements.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/py/rules/PySparkStatements.scala
@@ -28,7 +28,7 @@ class PySparkStatements(val expr: ir.Rule[ir.Expression]) extends ir.Rule[py.Sta
   private def plan(logical: ir.LogicalPlan): ir.Expression = logical match {
     case ir.PlanComment(input, text) => py.Comment(plan(input), text)
     case ir.NamedTable(name, _, _) => methodOf(ir.Name("spark"), "table", Seq(ir.StringLiteral(name)))
-    case ir.NoTable() => methodOf(ir.Name("spark"), "emptyDataFrame", Seq())
+    case ir.NoTable => methodOf(ir.Name("spark"), "emptyDataFrame", Seq())
     case ir.Filter(input, condition) => methodOf(plan(input), "filter", Seq(condition))
     case ir.Project(input, projectList) => methodOf(plan(input), "select", projectList)
     case ir.Limit(input, limit) => methodOf(plan(input), "limit", Seq(limit))

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
@@ -278,7 +278,7 @@ class LogicalPlanGenerator(
   }
 
   private def project(proj: ir.Project): SQL = {
-    val fromClause = if (proj.input != ir.NoTable()) {
+    val fromClause = if (proj.input != ir.NoTable) {
       code" FROM ${generate(proj.input)}"
     } else {
       code""

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/extensions.scala
@@ -26,7 +26,7 @@ case class Column(tableNameOrAlias: Option[ObjectReference], columnName: NameOrP
     with AstExtension {}
 
 case class Identifier(name: String, isQuoted: Boolean) extends ToRefactor with AstExtension {}
-case class DollarAction() extends ToRefactor with AstExtension {}
+case object DollarAction extends ToRefactor with AstExtension {}
 case class Distinct(expression: Expression) extends ToRefactor
 
 case object Noop extends LeafExpression {
@@ -61,7 +61,7 @@ case class Assign(left: Expression, right: Expression) extends Binary(left, righ
 }
 
 // Some statements, such as SELECT, do not require a table specification
-case class NoTable() extends LeafNode {
+case object NoTable extends LeafNode {
   override def output: Seq[Attribute] = Seq.empty
 }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/relations.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/relations.scala
@@ -354,7 +354,7 @@ case class AsOfJoin(
   override def output: Seq[Attribute] = left.output ++ right.output
 }
 
-case class Unknown() extends LeafNode {
+case object Unknown extends LeafNode {
   override def output: Seq[Attribute] = Seq.empty
 }
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
@@ -24,7 +24,7 @@ class SnowflakeRelationBuilder(override val vc: SnowflakeVisitorCoordinator)
     case None =>
       // Note that the optional select clauses may be null on very simple statements
       // such as SELECT 1;
-      val select = Option(ctx.selectOptionalClauses()).map(_.accept(this)).getOrElse(ir.NoTable())
+      val select = Option(ctx.selectOptionalClauses()).map(_.accept(this)).getOrElse(ir.NoTable)
       val relation = buildLimitOffset(ctx.limitClause(), select)
       val (top, allOrDistinct, selectListElements) = ctx match {
         case c if ctx.selectClause() != null =>
@@ -82,7 +82,7 @@ class SnowflakeRelationBuilder(override val vc: SnowflakeVisitorCoordinator)
   override def visitSelectOptionalClauses(ctx: SelectOptionalClausesContext): ir.LogicalPlan = errorCheck(ctx) match {
     case Some(errorResult) => errorResult
     case None =>
-      val from = Option(ctx.fromClause()).map(_.accept(this)).getOrElse(ir.NoTable())
+      val from = Option(ctx.fromClause()).map(_.accept(this)).getOrElse(ir.NoTable)
       buildOrderBy(
         ctx.orderByClause(),
         buildQualify(

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilder.scala
@@ -279,7 +279,7 @@ class TSqlExpressionBuilder(override val vc: TSqlVisitorCoordinator)
   override def visitExprDollar(ctx: ExprDollarContext): ir.Expression = errorCheck(ctx) match {
     case Some(errorResult) => errorResult
     case None =>
-      ir.DollarAction()
+      ir.DollarAction
   }
 
   override def visitExprStar(ctx: ExprStarContext): ir.Expression = errorCheck(ctx) match {

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -107,7 +107,7 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
   override def visitSelectOptionalClauses(ctx: SelectOptionalClausesContext): ir.LogicalPlan = errorCheck(ctx) match {
     case Some(errorResult) => errorResult
     case None =>
-      val from = Option(ctx.fromClause()).map(_.accept(this)).getOrElse(ir.NoTable())
+      val from = Option(ctx.fromClause()).map(_.accept(this)).getOrElse(ir.NoTable)
       buildOrderBy(
         ctx.selectOrderByClause(),
         buildHaving(ctx.havingClause(), buildGroupBy(ctx.groupByClause(), buildWhere(ctx.whereClause(), from))))

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGeneratorTest.scala
@@ -16,7 +16,7 @@ class LogicalPlanGeneratorTest extends AnyWordSpec with GeneratorTestCommon[ir.L
     "transpile to SELECT" in {
       ir.Project(namedTable("t1"), Seq(ir.Id("c1"))) generates "SELECT c1 FROM t1"
       ir.Project(namedTable("t1"), Seq(ir.Star(None))) generates "SELECT * FROM t1"
-      ir.Project(ir.NoTable(), Seq(ir.Literal(1))) generates "SELECT 1"
+      ir.Project(ir.NoTable, Seq(ir.Literal(1))) generates "SELECT 1"
     }
 
     "transpile to SELECT with COMMENTS" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilderSpec.scala
@@ -33,7 +33,7 @@ class SnowflakeRelationBuilderSpec
   "SnowflakeRelationBuilder" should {
 
     "translate query with no FROM clause" in {
-      example("", _.selectOptionalClauses(), NoTable())
+      example("", _.selectOptionalClauses(), NoTable)
     }
 
     "translate FROM clauses" should {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlAstBuilderSpec.scala
@@ -49,7 +49,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         expectedAst = Batch(
           Seq(
             Project(
-              NoTable(),
+              NoTable,
               Seq(
                 Literal(42),
                 Literal(65535),
@@ -80,16 +80,16 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
 
       example(
         query = "SELECT t.*",
-        expectedAst = Batch(Seq(Project(NoTable(), Seq(Star(objectName = Some(ObjectReference(Id("t")))))))))
+        expectedAst = Batch(Seq(Project(NoTable, Seq(Star(objectName = Some(ObjectReference(Id("t")))))))))
 
       example(
         query = "SELECT x..b.y.*",
         expectedAst =
-          Batch(Seq(Project(NoTable(), Seq(Star(objectName = Some(ObjectReference(Id("x"), Id("b"), Id("y")))))))))
+          Batch(Seq(Project(NoTable, Seq(Star(objectName = Some(ObjectReference(Id("x"), Id("b"), Id("y")))))))))
 
       // TODO: Add tests for OUTPUT clause once implemented - invalid semantics here to force coverage
-      example(query = "SELECT INSERTED.*", expectedAst = Batch(Seq(Project(NoTable(), Seq(Inserted(Star(None)))))))
-      example(query = "SELECT DELETED.*", expectedAst = Batch(Seq(Project(NoTable(), Seq(Deleted(Star(None)))))))
+      example(query = "SELECT INSERTED.*", expectedAst = Batch(Seq(Project(NoTable, Seq(Inserted(Star(None)))))))
+      example(query = "SELECT DELETED.*", expectedAst = Batch(Seq(Project(NoTable, Seq(Deleted(Star(None)))))))
     }
 
     "infer a cross join" in {
@@ -259,7 +259,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         query = "SELECT @a = 1, @b = 2, @c = 3",
         expectedAst = Batch(
           Seq(Project(
-            NoTable(),
+            NoTable,
             Seq(
               Assign(Identifier("@a", isQuoted = false), Literal(1)),
               Assign(Identifier("@b", isQuoted = false), Literal(2)),
@@ -269,7 +269,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         query = "SELECT @a += 1, @b -= 2",
         expectedAst = Batch(
           Seq(Project(
-            NoTable(),
+            NoTable,
             Seq(
               Assign(Identifier("@a", isQuoted = false), Add(Identifier("@a", isQuoted = false), Literal(1))),
               Assign(Identifier("@b", isQuoted = false), Subtract(Identifier("@b", isQuoted = false), Literal(2))))))))
@@ -278,7 +278,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         query = "SELECT @a *= 1, @b /= 2",
         expectedAst = Batch(
           Seq(Project(
-            NoTable(),
+            NoTable,
             Seq(
               Assign(Identifier("@a", isQuoted = false), Multiply(Identifier("@a", isQuoted = false), Literal(1))),
               Assign(Identifier("@b", isQuoted = false), Divide(Identifier("@b", isQuoted = false), Literal(2))))))))
@@ -288,7 +288,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         expectedAst = Batch(
           Seq(
             Project(
-              NoTable(),
+              NoTable,
               Seq(Assign(
                 Identifier("@a", isQuoted = false),
                 Mod(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn"))))))))
@@ -298,7 +298,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         expectedAst = Batch(
           Seq(
             Project(
-              NoTable(),
+              NoTable,
               Seq(Assign(
                 Identifier("@a", isQuoted = false),
                 BitwiseAnd(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn"))))))))
@@ -308,7 +308,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         expectedAst = Batch(
           Seq(
             Project(
-              NoTable(),
+              NoTable,
               Seq(Assign(
                 Identifier("@a", isQuoted = false),
                 BitwiseXor(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn"))))))))
@@ -318,7 +318,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
         expectedAst = Batch(
           Seq(
             Project(
-              NoTable(),
+              NoTable,
               Seq(Assign(
                 Identifier("@a", isQuoted = false),
                 BitwiseOr(Identifier("@a", isQuoted = false), simplyNamedColumn("myColumn"))))))))
@@ -363,14 +363,14 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
     example(
       query = "SELECT NEXT VALUE FOR mySequence As nextVal",
       expectedAst = Batch(
-        Seq(Project(NoTable(), Seq(Alias(CallFunction("MONOTONICALLY_INCREASING_ID", List.empty), Id("nextVal")))))))
+        Seq(Project(NoTable, Seq(Alias(CallFunction("MONOTONICALLY_INCREASING_ID", List.empty), Id("nextVal")))))))
   }
 
   "SELECT NEXT VALUE FOR var.mySequence As nextVal" in {
     example(
       query = "SELECT NEXT VALUE FOR var.mySequence As nextVal",
       expectedAst = Batch(
-        Seq(Project(NoTable(), Seq(Alias(CallFunction("MONOTONICALLY_INCREASING_ID", List.empty), Id("nextVal")))))))
+        Seq(Project(NoTable, Seq(Alias(CallFunction("MONOTONICALLY_INCREASING_ID", List.empty), Id("nextVal")))))))
   }
 
   "SELECT NEXT VALUE FOR var.mySequence OVER (ORDER BY myColumn) As nextVal" in {
@@ -378,7 +378,7 @@ class TSqlAstBuilderSpec extends AnyWordSpec with TSqlParserTestCommon with Matc
       query = "SELECT NEXT VALUE FOR var.mySequence OVER (ORDER BY myColumn) As nextVal ",
       expectedAst = Batch(
         Seq(Project(
-          NoTable(),
+          NoTable,
           Seq(Alias(
             Window(
               CallFunction("ROW_NUMBER", List.empty),

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlExpressionBuilderSpec.scala
@@ -419,7 +419,7 @@ class TSqlExpressionBuilderSpec extends AnyWordSpec with TSqlParserTestCommon wi
     }
 
     "translate the $ACTION special column reference" in {
-      exampleExpr("$ACTION", _.expression(), ir.DollarAction())
+      exampleExpr("$ACTION", _.expression(), ir.DollarAction)
     }
 
     "translate a timezone reference" in {

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
@@ -17,7 +17,7 @@ class TSqlRelationBuilderSpec
   "TSqlRelationBuilder" should {
 
     "translate query with no FROM clause" in {
-      example("", _.selectOptionalClauses(), ir.NoTable())
+      example("", _.selectOptionalClauses(), ir.NoTable)
     }
 
     "translate FROM clauses" should {


### PR DESCRIPTION
This PR trivially refactors the situations where we are using cases classes without parameters to be case objects (as is idiomatic in Scala).