### PR TITLE
Refactor `x.tail.foldleft(x.head)` chains as `x.reduceLeft`

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/generators/py/StatementGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/py/StatementGenerator.scala
@@ -67,15 +67,9 @@ class StatementGenerator(private val exprs: ExpressionGenerator) extends BasePyt
   private def e(expr: Expression): Python = exprs.generate(expr)
 
   private def lines(statements: Seq[Statement], finish: String = "\n"): Python = {
-    if (statements.isEmpty) {
-      code""
-    } else {
-      val body = statements.map(generate(_))
-      val separatedItems = body.reduceLeft[Python] { case (agg, item) =>
-        code"$agg\n$item"
-      }
-      code"$separatedItems$finish"
-    }
+    val body = statements.map(generate)
+    val separatedItems = body.reduceLeftOption[Python] { case (agg, item) => code"$agg\n$item" }
+    separatedItems.map(items => code"$items$finish").getOrElse(code"")
   }
 
   // decorators need their leading whitespace trimmed and get followed by a trailing whitespace

--- a/core/src/main/scala/com/databricks/labs/remorph/generators/py/StatementGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/py/StatementGenerator.scala
@@ -71,7 +71,7 @@ class StatementGenerator(private val exprs: ExpressionGenerator) extends BasePyt
       code""
     } else {
       val body = statements.map(generate(_))
-      val separatedItems = body.tail.foldLeft[Python](body.head) { case (agg, item) =>
+      val separatedItems = body.reduceLeft[Python] { case (agg, item) =>
         code"$agg\n$item"
       }
       code"$separatedItems$finish"

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
@@ -49,6 +49,7 @@ class TSqlDMLBuilder(override val vc: TSqlVisitorCoordinator)
 
       val mergeCondition = ctx.searchCondition().accept(vc.expressionBuilder)
       val tableSourcesPlan = ctx.tableSources().tableSource().asScala.map(_.accept(vc.relationBuilder))
+      // Reduce is safe: Grammar rule for tableSources ensures that there is always at least one tableSource.
       val sourcePlan = tableSourcesPlan.reduceLeft(
         ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlDMLBuilder.scala
@@ -49,7 +49,7 @@ class TSqlDMLBuilder(override val vc: TSqlVisitorCoordinator)
 
       val mergeCondition = ctx.searchCondition().accept(vc.expressionBuilder)
       val tableSourcesPlan = ctx.tableSources().tableSource().asScala.map(_.accept(vc.relationBuilder))
-      val sourcePlan = tableSourcesPlan.tail.foldLeft(tableSourcesPlan.head)(
+      val sourcePlan = tableSourcesPlan.reduceLeft(
         ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
 
       // We may have a number of when clauses, each with a condition and an action. We keep the ANTLR syntax compact
@@ -140,10 +140,9 @@ class TSqlDMLBuilder(override val vc: TSqlVisitorCoordinator)
       val setElements = ctx.updateElem().asScala.map(_.accept(vc.expressionBuilder))
 
       val tableSourcesOption = Option(ctx.tableSources()).map(_.tableSource().asScala.map(_.accept(vc.relationBuilder)))
-      val sourceRelation = tableSourcesOption.map { tableSources =>
-        tableSources.tail.foldLeft(tableSources.head)(
-          ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
-      }
+      val sourceRelation = tableSourcesOption.map(
+        _.reduceLeft(
+          ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false))))
 
       val where = Option(ctx.updateWhereClause()) map (_.accept(vc.expressionBuilder))
       val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
@@ -163,10 +162,9 @@ class TSqlDMLBuilder(override val vc: TSqlVisitorCoordinator)
 
       val output = Option(ctx.outputClause()).map(buildOutputClause)
       val tableSourcesOption = Option(ctx.tableSources()).map(_.tableSource().asScala.map(_.accept(vc.relationBuilder)))
-      val sourceRelation = tableSourcesOption.map { tableSources =>
-        tableSources.tail.foldLeft(tableSources.head)(
-          ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
-      }
+      val sourceRelation = tableSourcesOption.map(
+        _.reduceLeft(
+          ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false))))
 
       val where = Option(ctx.updateWhereClause()) map (_.accept(vc.expressionBuilder))
       val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -313,6 +313,7 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
 
       val mergeCondition = ctx.searchCondition().accept(vc.expressionBuilder)
       val tableSourcesPlan = ctx.tableSources().tableSource().asScala.map(_.accept(this))
+      // Reduce is safe: Grammar rule for tableSources ensures that there is always at least one tableSource.
       val sourcePlan = tableSourcesPlan.reduceLeft(
         ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
 

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilder.scala
@@ -313,7 +313,7 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
 
       val mergeCondition = ctx.searchCondition().accept(vc.expressionBuilder)
       val tableSourcesPlan = ctx.tableSources().tableSource().asScala.map(_.accept(this))
-      val sourcePlan = tableSourcesPlan.tail.foldLeft(tableSourcesPlan.head)(
+      val sourcePlan = tableSourcesPlan.reduceLeft(
         ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
 
       // We may have a number of when clauses, each with a condition and an action. We keep the ANTLR syntax compact
@@ -404,10 +404,9 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
       val setElements = ctx.updateElem().asScala.map(_.accept(vc.expressionBuilder))
 
       val tableSourcesOption = Option(ctx.tableSources()).map(_.tableSource().asScala.map(_.accept(this)))
-      val sourceRelation = tableSourcesOption.map { tableSources =>
-        tableSources.tail.foldLeft(tableSources.head)(
-          ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
-      }
+      val sourceRelation = tableSourcesOption.map(
+        _.reduceLeft(
+          ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false))))
 
       val where = Option(ctx.updateWhereClause()) map (_.accept(vc.expressionBuilder))
       val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))
@@ -427,10 +426,9 @@ class TSqlRelationBuilder(override val vc: TSqlVisitorCoordinator)
 
       val output = Option(ctx.outputClause()).map(_.accept(this))
       val tableSourcesOption = Option(ctx.tableSources()).map(_.tableSource().asScala.map(_.accept(this)))
-      val sourceRelation = tableSourcesOption.map { tableSources =>
-        tableSources.tail.foldLeft(tableSources.head)(
-          ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false)))
-      }
+      val sourceRelation = tableSourcesOption.map(
+        _.reduceLeft(
+          ir.Join(_, _, None, ir.CrossJoin, Seq(), ir.JoinDataType(is_left_struct = false, is_right_struct = false))))
 
       val where = Option(ctx.updateWhereClause()) map (_.accept(vc.expressionBuilder))
       val optionClause = Option(ctx.optionClause).map(_.accept(vc.expressionBuilder))


### PR DESCRIPTION
This PR refactors the situations where we use this:

```scala
x.tail.foldLeft(x.head)
```

to use the equivalent operation that does this:
```scala
x.reduceLeft
```

Following a review comment discussing the safety of reduce in these situations[^1], some further changes have been made to the surrounding code such that the behaviour remains the same but the safety can be determined via trivial inspection without needing to refer to the grammar.

[^1]: Not a new concern; the previous code had the same safety issue due to the use of `.head`.
