### PR TITLE
 Added support for format_datetime function in presto to Databricks

### DIFF
--- a/src/databricks/labs/remorph/snow/presto.py
+++ b/src/databricks/labs/remorph/snow/presto.py
@@ -192,6 +192,7 @@ class Presto(presto):
             "ANY_KEYS_MATCH": _build_any_keys_match,
             "ARRAY_AVERAGE": _build_array_average,
             "JSON_SIZE": _build_json_size,
+            "FORMAT_DATETIME": local_expression.DateFormat.from_arg_list,
         }
 
     class Tokenizer(presto.Tokenizer):

--- a/tests/resources/functional/presto/test_format_datetime/test_format_datetime_1.sql
+++ b/tests/resources/functional/presto/test_format_datetime/test_format_datetime_1.sql
@@ -1,0 +1,13 @@
+-- presto sql:
+select
+  format_datetime(current_timestamp,'EEEE') as col1
+, format_datetime(current_date,'EEEE') as col2
+, format_datetime(from_unixtime(1732723200), 'hh:mm:ss a') as col3
+, format_datetime(from_unixtime(1732723200), 'yyyy-MM-dd HH:mm:ss EEEE') as col4;
+
+-- databricks sql:
+SELECT
+  DATE_FORMAT(CURRENT_TIMESTAMP(), 'EEEE') AS col1,
+  DATE_FORMAT(CURRENT_DATE(), 'EEEE') AS col2,
+  DATE_FORMAT(CAST(FROM_UNIXTIME(1732723200) AS TIMESTAMP), 'hh:mm:ss a') AS col3,
+  DATE_FORMAT(CAST(FROM_UNIXTIME(1732723200) AS TIMESTAMP), 'yyyy-MM-dd HH:mm:ss EEEE') AS col4


### PR DESCRIPTION
 Added support for format_datetime function in presto to Databricks
<img width="838" alt="Screenshot 2024-11-27 at 5 09 44 PM" src="https://github.com/user-attachments/assets/5eef2df5-757c-4107-a2a7-28b3f57f970d">
<img width="972" alt="Screenshot 2024-11-27 at 5 09 38 PM" src="https://github.com/user-attachments/assets/70499579-09a8-4f34-b6fb-062b5bbb4424">
