### PR TITLE
Allow easier debugging of test failures

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/intermediate/extensions.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/intermediate/extensions.scala
@@ -91,7 +91,7 @@ case class TableWithHints(child: LogicalPlan, hints: Seq[TableHint]) extends Una
 }
 
 case class Batch(children: Seq[LogicalPlan]) extends LogicalPlan {
-  override def output: Seq[Attribute] = children.lastOption.map(_.output).getOrElse(Seq()).toSeq
+  override def output: Seq[Attribute] = children.lastOption.map(_.output).getOrElse(Seq())
 }
 
 case class FunctionParameter(name: String, dataType: DataType, defaultValue: Option[Expression])
@@ -249,4 +249,3 @@ case class KnownInterval(value: Expression, iType: KnownIntervalType) extends Ex
   override def children: Seq[Expression] = Seq(value)
   override def dataType: DataType = UnresolvedType
 }
-

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/TranspilerTestCommon.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/TranspilerTestCommon.scala
@@ -13,13 +13,17 @@ trait TranspilerTestCommon extends Matchers with Formatter with ErrorEncoders {
   implicit class TranspilerTestOps(input: String) {
 
     def transpilesTo(expectedOutput: String, failOnError: Boolean = true): Assertion = {
+      val formattedExpectedOutput = format(expectedOutput)
       transpiler.transpile(Parsing(input)).runAndDiscardState(Init) match {
-        case OkResult(output) => format(output) shouldBe format(expectedOutput)
+        case OkResult(output) =>
+          val formattedOutput = format(output)
+          formattedOutput shouldBe formattedExpectedOutput
         case PartialResult(output, err) =>
           if (failOnError) {
             fail(err.asJson.noSpaces)
           } else {
-            format(output) shouldBe format(expectedOutput)
+            val formattedOutput = format(output)
+            formattedOutput shouldBe formattedExpectedOutput
           }
         case KoResult(_, err) => fail(err.asJson.noSpaces)
       }


### PR DESCRIPTION
This PR adjusts the way transpilation results are checked during tests so that the formatted values can be easily checked in a debugger. (IntelliJ/PyCharm have better ways of comparing output than the side-by-side view we display.)