### PR TITLE
Fix TSQL precedence of `INTERSECT` with respect to `UNION`/`EXCEPT`

### DIFF
--- a/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
+++ b/core/src/main/antlr4/com/databricks/labs/remorph/parsers/tsql/TSqlParser.g4
@@ -2796,8 +2796,8 @@ queryExpression
     // INTERSECT has higher precedence than EXCEPT and UNION ALL.
     // Reference: https://learn.microsoft.com/en-us/sql/t-sql/language-elements/set-operators-except-and-intersect-transact-sql?view=sql-server-ver16#:~:text=following%20precedence
     : LPAREN queryExpression RPAREN                         # queryInParenthesis
-    | queryExpression (UNION ALL? | EXCEPT) queryExpression # queryUnion
     | queryExpression INTERSECT queryExpression             # queryIntersect
+    | queryExpression (UNION ALL? | EXCEPT) queryExpression # queryUnion
     | querySpecification                                    # querySimple
     ;
 

--- a/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/parsers/tsql/TSqlRelationBuilderSpec.scala
@@ -211,25 +211,25 @@ class TSqlRelationBuilderSpec
           ir.SetOperation(
             ir.SetOperation(
               ir.SetOperation(
-                ir.SetOperation(
-                  ir.Project(ir.NoTable, Seq(ir.Literal(1, ir.IntegerType))),
-                  ir.Project(ir.NoTable, Seq(ir.Literal(2, ir.IntegerType))),
-                  ir.UnionSetOp,
-                  is_all = false,
-                  by_name = false,
-                  allow_missing_columns = false),
-                ir.Project(ir.NoTable, Seq(ir.Literal(3, ir.IntegerType))),
+                ir.Project(ir.NoTable, Seq(ir.Literal(1, ir.IntegerType))),
+                ir.Project(ir.NoTable, Seq(ir.Literal(2, ir.IntegerType))),
                 ir.UnionSetOp,
-                is_all = true,
+                is_all = false,
                 by_name = false,
                 allow_missing_columns = false),
+              ir.Project(ir.NoTable, Seq(ir.Literal(3, ir.IntegerType))),
+              ir.UnionSetOp,
+              is_all = true,
+              by_name = false,
+              allow_missing_columns = false),
+            ir.SetOperation(
               ir.Project(ir.NoTable, Seq(ir.Literal(4, ir.IntegerType))),
-              ir.ExceptSetOp,
+              ir.Project(ir.NoTable, Seq(ir.Literal(5, ir.IntegerType))),
+              ir.IntersectSetOp,
               is_all = false,
               by_name = false,
               allow_missing_columns = false),
-            ir.Project(ir.NoTable, Seq(ir.Literal(5, ir.IntegerType))),
-            ir.IntersectSetOp,
+            ir.ExceptSetOp,
             is_all = false,
             by_name = false,
             allow_missing_columns = false))
@@ -272,10 +272,34 @@ class TSqlRelationBuilderSpec
             by_name = false,
             allow_missing_columns = false))
       }
-      "SELECT 1 INTERSECT SELECT 2 EXCEPT SELECT 3 UNION SELECT 4" in {
+      "SELECT 1 UNION SELECT 2 EXCEPT SELECT 3 INTERSECT SELECT 4" in {
         // INTERSECT has higher precedence than both UNION and EXCEPT
         example(
-          "SELECT 1 INTERSECT SELECT 2 EXCEPT SELECT 3 UNION SELECT 4",
+          "SELECT 1 UNION SELECT 2 EXCEPT SELECT 3 INTERSECT SELECT 4",
+          _.queryExpression(),
+          ir.SetOperation(
+            ir.SetOperation(
+              ir.Project(ir.NoTable, Seq(ir.Literal(1, ir.IntegerType))),
+              ir.Project(ir.NoTable, Seq(ir.Literal(2, ir.IntegerType))),
+              ir.UnionSetOp,
+              is_all = false,
+              by_name = false,
+              allow_missing_columns = false),
+            ir.SetOperation(
+              ir.Project(ir.NoTable, Seq(ir.Literal(3, ir.IntegerType))),
+              ir.Project(ir.NoTable, Seq(ir.Literal(4, ir.IntegerType))),
+              ir.IntersectSetOp,
+              is_all = false,
+              by_name = false,
+              allow_missing_columns = false),
+            ir.ExceptSetOp,
+            is_all = false,
+            by_name = false,
+            allow_missing_columns = false))
+      }
+      "SELECT 1 UNION (SELECT 2 UNION ALL SELECT 3) INTERSECT (SELECT 4 EXCEPT SELECT 5)" in {
+        example(
+          "SELECT 1 UNION (SELECT 2 UNION ALL SELECT 3) INTERSECT (SELECT 4 EXCEPT SELECT 5)",
           _.queryExpression(),
           ir.SetOperation(
             ir.Project(ir.NoTable, Seq(ir.Literal(1, ir.IntegerType))),
@@ -283,46 +307,22 @@ class TSqlRelationBuilderSpec
               ir.SetOperation(
                 ir.Project(ir.NoTable, Seq(ir.Literal(2, ir.IntegerType))),
                 ir.Project(ir.NoTable, Seq(ir.Literal(3, ir.IntegerType))),
-                ir.ExceptSetOp,
-                is_all = false,
-                by_name = false,
-                allow_missing_columns = false),
-              ir.Project(ir.NoTable, Seq(ir.Literal(4, ir.IntegerType))),
-              ir.UnionSetOp,
-              is_all = false,
-              by_name = false,
-              allow_missing_columns = false),
-            ir.IntersectSetOp,
-            is_all = false,
-            by_name = false,
-            allow_missing_columns = false))
-      }
-      "SELECT 1 UNION (SELECT 2 UNION ALL SELECT 3) EXCEPT (SELECT 4 INTERSECT SELECT 5)" in {
-        example(
-          "SELECT 1 UNION (SELECT 2 UNION ALL SELECT 3) EXCEPT (SELECT 4 INTERSECT SELECT 5)",
-          _.queryExpression(),
-          ir.SetOperation(
-            ir.SetOperation(
-              ir.Project(ir.NoTable, Seq(ir.Literal(1, ir.IntegerType))),
-              ir.SetOperation(
-                ir.Project(ir.NoTable, Seq(ir.Literal(2, ir.IntegerType))),
-                ir.Project(ir.NoTable, Seq(ir.Literal(3, ir.IntegerType))),
                 ir.UnionSetOp,
                 is_all = true,
                 by_name = false,
                 allow_missing_columns = false),
-              ir.UnionSetOp,
-              is_all = false,
-              by_name = false,
-              allow_missing_columns = false),
-            ir.SetOperation(
-              ir.Project(ir.NoTable, Seq(ir.Literal(4, ir.IntegerType))),
-              ir.Project(ir.NoTable, Seq(ir.Literal(5, ir.IntegerType))),
+              ir.SetOperation(
+                ir.Project(ir.NoTable, Seq(ir.Literal(4, ir.IntegerType))),
+                ir.Project(ir.NoTable, Seq(ir.Literal(5, ir.IntegerType))),
+                ir.ExceptSetOp,
+                is_all = false,
+                by_name = false,
+                allow_missing_columns = false),
               ir.IntersectSetOp,
               is_all = false,
               by_name = false,
               allow_missing_columns = false),
-            ir.ExceptSetOp,
+            ir.UnionSetOp,
             is_all = false,
             by_name = false,
             allow_missing_columns = false))

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/TsqlToDatabricksTranspilerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/TsqlToDatabricksTranspilerTest.scala
@@ -37,11 +37,11 @@ class TsqlToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTestComm
             |  UNION
             |  (SELECT d, e FROM f))
             | UNION ALL
-            | (SELECT g, h FROM i))
-            |INTERSECT
-            | ((SELECT j, k FROM l)
-            |  EXCEPT
-            |  (SELECT m, n FROM o));""".stripMargin)
+            | ((SELECT g, h FROM i)
+            |  INTERSECT
+            |  (SELECT j, k FROM l)))
+            |EXCEPT
+            |(SELECT m, n FROM o);""".stripMargin)
       expectedTranslations.foreach(correctlyTranspile)
     }
     "mixing CTEs with set operations" should {

--- a/tests/resources/functional/tsql/set-operations/precedence.sql
+++ b/tests/resources/functional/tsql/set-operations/precedence.sql
@@ -8,53 +8,71 @@
 -- tsql sql:
 
 -- Verifies UNION/EXCEPT as left-to-right, with brackets.
-SELECT 1
-UNION
-SELECT 2
-EXCEPT
-(SELECT 3
- UNION ALL
- SELECT 4)
+(SELECT 1
+ UNION
+ SELECT 2
+ EXCEPT
+ (SELECT 3
+  UNION
+  SELECT 4))
 
-INTERSECT
+UNION ALL
 
 -- Verifies UNION/EXCEPT as left-to-right when the order is reversed.
-SELECT 5
-EXCEPT
-SELECT 6
-UNION
-SELECT 7
+(SELECT 5
+ EXCEPT
+ SELECT 6
+ UNION
+ SELECT 7)
 
-INTERSECT
+UNION ALL
 
--- Verifies brackets have precedence over INTERSECT.
+-- Verifies that INTERSECT has precedence over UNION/EXCEPT.
 (SELECT 8
+ UNION
+ SELECT 9
+ EXCEPT
+ SELECT 10
  INTERSECT
- SELECT 9)
+ SELECT 11)
 
-INTERSECT
+UNION ALL
 
--- Not needed: just confirms helps us confirm that INTERSECT is also left-to-right.
-SELECT 10;
-
+-- Verifies that INTERSECT is left-to-right, although brackets have precedence.
+(SELECT 12
+ INTERSECT
+ SELECT 13
+ INTERSECT
+ (SELECT 14
+  INTERSECT
+  SELECT 15));
 
 -- databricks sql:
+
     (
         (
             (
                 ((SELECT 1) UNION (SELECT 2))
             EXCEPT
-                ((SELECT 3) UNION ALL (SELECT 4))
+                ((SELECT 3) UNION (SELECT 4))
             )
-        INTERSECT
+        UNION ALL
             (
                 ((SELECT 5) EXCEPT (SELECT 6))
             UNION
                 (SELECT 7)
             )
         )
-    INTERSECT
-        ((SELECT 8) INTERSECT (SELECT 9))
+    UNION ALL
+        (
+            ((SELECT 8) UNION (SELECT 9))
+        EXCEPT
+            ((SELECT 10) INTERSECT (SELECT 11))
+        )
     )
-INTERSECT
-    (SELECT 10);
+UNION ALL
+    (
+        ((SELECT 12) INTERSECT (SELECT 13))
+    INTERSECT
+        ((SELECT 14) INTERSECT (SELECT 15))
+    );


### PR DESCRIPTION
This is an incredibly embarrassing PR, because it turns out that in #1126 and #1259 I totally misunderstood higher vs. lower precedence and implemented `INTERSECT` with the wrong precedence with respect to `UNION` and `EXCEPT`. This PR fixes this, and updates the associated tests.