### PR TITLE
Prevent Dependabot from upgrading Databricks Connect.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # Ignore updates for Databricks Connect: the version in use needs to match the testing infrastructure.
+      - dependency-name: "com.databricks:databricks-connect"

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,6 +23,7 @@
     <sql-formatter.version>2.0.5</sql-formatter.version>
     <scala-logging.version>3.9.5</scala-logging.version>
     <databricks-sdk-java.version>0.27.1</databricks-sdk-java.version>
+    <!-- Note: DB-connect must match the version in our testing infrastructure. -->
     <databricks-connect.version>15.1.0</databricks-connect.version>
     <circe.version>0.14.2</circe.version>
     <mssql-jdbc.version>12.8.0.jre8</mssql-jdbc.version>


### PR DESCRIPTION
This PR configures Dependabot so that it won't try to upgrade Databricks Connect.

Relates #1317.