### PR TITLE
Fix incorrect script for no-pylint-disable

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -112,10 +112,12 @@ jobs:
 
       - name: Verify no lint disabled in the new code
         run: |
-          NEW_CODE=$(git diff origin/main..$(git branch --show-current) | grep -e '^+')
-          CHEAT=$(echo "${NEW_CODE}" | grep '# pylint: disable' | grep -v "CHEAT" | wc -c)
-          if [ "${CHEAT}" -ne 0 ]; then
-            echo "Do not cheat the linter: ${CHEAT}"
+          git fetch origin $GITHUB_BASE_REF:$GITHUB_BASE_REF
+          git diff $GITHUB_BASE_REF...$(git branch --show-current) >> diff_data.txt
+          python tests/unit/no_cheat.py diff_data.txt >> cheats.txt
+          COUNT=$(cat cheats.txt | wc -c)
+          if [ ${COUNT} -gt 1 ]; then
+            cat cheats.txt
             exit 1
           fi
 

--- a/tests/unit/no_cheat.py
+++ b/tests/unit/no_cheat.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+DISABLE_TAG = '# pylint: disable='
+
+
+def no_cheat(diff_text: str) -> str:
+    lines = diff_text.split('\n')
+    removed: dict[str, int] = {}
+    added: dict[str, int] = {}
+    for line in lines:
+        if not (line.startswith("-") or line.startswith("+")):
+            continue
+        idx = line.find(DISABLE_TAG)
+        if idx < 0:
+            continue
+        codes = line[idx + len(DISABLE_TAG) :].split(',')
+        for code in codes:
+            code = code.strip().strip('\n').strip('"').strip("'")
+            if line.startswith("-"):
+                removed[code] = removed.get(code, 0) + 1
+                continue
+            added[code] = added.get(code, 0) + 1
+    results: list[str] = []
+    for code, count in added.items():
+        count -= removed.get(code, 0)
+        if count > 0:
+            results.append(f"Do not cheat the linter: found {count} additional {DISABLE_TAG}{code}")
+    return '\n'.join(results)
+
+
+if __name__ == "__main__":
+    diff_data = sys.argv[1]
+    path = Path(diff_data)
+    if path.exists():
+        diff_data = path.read_text("utf-8")
+    print(no_cheat(diff_data))


### PR DESCRIPTION
Our current script returns false positives for stacked PRs.
Upgrading it to the latest one from ucx