### PR TITLE
Mark scala as a dependency for Dependabot to ignore.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,5 @@ updates:
     ignore:
       # Ignore updates for Databricks Connect: the version in use needs to match the testing infrastructure.
       - dependency-name: "com.databricks:databricks-connect"
+      # Ignore updates for Scala: we manage this dependency manually.
+      - dependency-name: "org.scala-lang:scala-library"

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <scala.binary.version>2.12</scala.binary.version>
+    <!-- Don't upgrade this automatically: it's a breaking change. -->
     <scala.version>2.12.19</scala.version>
     <scoverage.plugin.version>2.0.6</scoverage.plugin.version>
     <spark.version>3.3.0</spark.version>


### PR DESCRIPTION
This PR configures Dependabot to ignore Scala version updates.

Relates #1327.