### PR TITLE
Adjust Dependabot's maven update policies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
     schedule:
       interval: "daily"
     ignore:
+      # Ignore "preview" releases: in general we only want final releases.
+      # Example: com.microsoft.sqlserver:mssql-jdbc:12.9.0.jre8-preview
+      - dependency-name: "*"
+        versions:
+          - "*-preview"
       # Ignore updates for Databricks Connect: the version in use needs to match the testing infrastructure.
       - dependency-name: "com.databricks:databricks-connect"
       # Ignore updates for Scala: we manage this dependency manually.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,5 +20,9 @@ updates:
           - "*-preview"
       # Ignore updates for Databricks Connect: the version in use needs to match the testing infrastructure.
       - dependency-name: "com.databricks:databricks-connect"
-      # Ignore updates for Scala: we manage this dependency manually.
+      # Ignore non-patch updates for Scala: we manually manage the Scala version.
       - dependency-name: "org.scala-lang:scala-library"
+        update-types:
+          # (Scala 2 patch releases are binary compatible, so they're the only type allowed.)
+          - "version-update:semver-minor"
+          - "version-update:semver-major"


### PR DESCRIPTION
This PR adjusts the update policy for Dependabot:

 - We try to configure Dependabot to ignore `-preview` releases.
 - For Scala patch-release updates are allowed: it's the major/minor changes that are breaking that we wish to manage ourselves.