### PR TITLE
Configure Dependabot to ignore Mockito from 5.x onwards.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,7 @@ updates:
           # (Scala 2 patch releases are binary compatible, so they're the only type allowed.)
           - "version-update:semver-minor"
           - "version-update:semver-major"
+      # Mockito from 5.x requires JDK 11, but we are using JDK 8.
+      - dependency-name: "org.mockito:mockito-core"
+        versions:
+          - ">=5.0.0"


### PR DESCRIPTION
Mockito 5 requires JDK 11 or later but we need to support JDK 8. This is unlikely to change.

References:

 - https://github.com/mockito/mockito/releases/tag/v5.0.0
 - https://github.com/mockito/mockito/issues/2997

Relates: #1341 