### PR TITLE
Rename lineage related classes and methods

### DIFF
--- a/src/databricks/labs/remorph/intermediate/engine_adapter.py
+++ b/src/databricks/labs/remorph/intermediate/engine_adapter.py
@@ -18,9 +18,9 @@ class EngineAdapter:
             raise ValueError(msg)
         return SqlglotEngine()
 
-    def parse_sql_content(self, dag, sql_content: str, file_path: str | Path, engine: str):
+    def analyse_table_lineage(self, dag, sql_content: str, file_path: str | Path, engine: str):
         # Not added type hints for dag as it is a cyclic import
         parser = self.select_engine(engine)
-        for root_table, child in parser.parse_sql_content(self.dialect, sql_content, file_path):
+        for root_table, child in parser.analyse_table_lineage(self.dialect, sql_content, file_path):
             dag.add_node(child)
             dag.add_edge(root_table, child)

--- a/src/databricks/labs/remorph/intermediate/root_tables.py
+++ b/src/databricks/labs/remorph/intermediate/root_tables.py
@@ -12,7 +12,7 @@ from databricks.labs.remorph.intermediate.engine_adapter import EngineAdapter
 logger = logging.getLogger(__name__)
 
 
-class RootTableExtractor:
+class RootTableAnalyzer:
     def __init__(self, source_dialect: str, input_path: str | Path):
         self.source_dialect = source_dialect
         self.input_path = input_path

--- a/src/databricks/labs/remorph/intermediate/root_tables.py
+++ b/src/databricks/labs/remorph/intermediate/root_tables.py
@@ -12,13 +12,13 @@ from databricks.labs.remorph.intermediate.engine_adapter import EngineAdapter
 logger = logging.getLogger(__name__)
 
 
-class RootTableIdentifier:
+class RootTableExtractor:
     def __init__(self, source_dialect: str, input_path: str | Path):
         self.source_dialect = source_dialect
         self.input_path = input_path
         self.engine_adapter = EngineAdapter(source_dialect)
 
-    def generate_lineage(self, engine="sqlglot") -> DAG:
+    def generate_lineage_dag(self, engine="sqlglot") -> DAG:
         dag = DAG()
 
         # when input is sql file then parse the file
@@ -26,13 +26,13 @@ class RootTableIdentifier:
             filename = self.input_path
             logger.debug(f"Generating Lineage file: {filename}")
             sql_content = read_file(filename)
-            self.engine_adapter.parse_sql_content(dag, sql_content, filename, engine)
+            self.engine_adapter.analyse_table_lineage(dag, sql_content, filename, engine)
             return dag  # return after processing the file
 
         # when the input is a directory
         for filename in get_sql_file(self.input_path):
             logger.debug(f"Generating Lineage file: {filename}")
             sql_content = read_file(filename)
-            self.engine_adapter.parse_sql_content(dag, sql_content, filename, engine)
+            self.engine_adapter.analyse_table_lineage(dag, sql_content, filename, engine)
 
         return dag

--- a/src/databricks/labs/remorph/lineage.py
+++ b/src/databricks/labs/remorph/lineage.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 
 from databricks.labs.remorph.intermediate.dag import DAG
-from databricks.labs.remorph.intermediate.root_tables import RootTableIdentifier
+from databricks.labs.remorph.intermediate.root_tables import RootTableExtractor
 
 logger = logging.getLogger(__name__)
 
@@ -26,8 +26,8 @@ def lineage_generator(source: str, input_sql: str, output_folder: str):
 
     msg = f"Processing for SQLs at this location: {input_sql_path}"
     logger.info(msg)
-    root_table_identifier = RootTableIdentifier(source, input_sql_path)
-    generated_dag = root_table_identifier.generate_lineage()
+    root_table_extractor = RootTableExtractor(source, input_sql_path)
+    generated_dag = root_table_extractor.generate_lineage_dag()
     lineage_file_content = _generate_dot_file_contents(generated_dag)
 
     date_str = datetime.datetime.now().strftime("%d%m%y")

--- a/src/databricks/labs/remorph/lineage.py
+++ b/src/databricks/labs/remorph/lineage.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 
 from databricks.labs.remorph.intermediate.dag import DAG
-from databricks.labs.remorph.intermediate.root_tables import RootTableExtractor
+from databricks.labs.remorph.intermediate.root_tables import RootTableAnalyzer
 
 logger = logging.getLogger(__name__)
 
@@ -26,8 +26,8 @@ def lineage_generator(source: str, input_sql: str, output_folder: str):
 
     msg = f"Processing for SQLs at this location: {input_sql_path}"
     logger.info(msg)
-    root_table_extractor = RootTableExtractor(source, input_sql_path)
-    generated_dag = root_table_extractor.generate_lineage_dag()
+    root_table_analyzer = RootTableAnalyzer(source, input_sql_path)
+    generated_dag = root_table_analyzer.generate_lineage_dag()
     lineage_file_content = _generate_dot_file_contents(generated_dag)
 
     date_str = datetime.datetime.now().strftime("%d%m%y")

--- a/src/databricks/labs/remorph/transpiler/sqlglot/sqlglot_engine.py
+++ b/src/databricks/labs/remorph/transpiler/sqlglot/sqlglot_engine.py
@@ -148,7 +148,7 @@ class SqlglotEngine(TranspileEngine):
 
     @staticmethod
     def _find_root_table(expression) -> str | None:
-        table = expression.find_all(exp.Table, bfs=False)
+        table = expression.find(exp.Table, bfs=False)
         return table.name if table else None
 
     @staticmethod

--- a/src/databricks/labs/remorph/transpiler/sqlglot/sqlglot_engine.py
+++ b/src/databricks/labs/remorph/transpiler/sqlglot/sqlglot_engine.py
@@ -45,16 +45,15 @@ class SqlglotEngine(TranspileEngine):
                 child: str | None = str(file_path)
                 if expr is not None:
                     for create in expr.find_all(exp.Create, exp.Insert, exp.Merge, bfs=False):
-                        child = self._find_root_tables(create)
+                        child = self._find_root_table(create)
 
                     for select in expr.find_all(exp.Select, exp.Join, exp.With, bfs=False):
-                        yield self._find_root_tables(select), child
+                        yield self._find_root_table(select), child
 
     @staticmethod
-    def _find_root_tables(expression) -> str | None:
-        for table in expression.find_all(exp.Table, bfs=False):
-            return table.name
-        return None
+    def _find_root_table(expression) -> str | None:
+        table = expression.find_all(exp.Table, bfs=False)
+        return table.name if table else None
 
     def check_for_unsupported_lca(self, source_dialect, source_code, file_path) -> ValidationError | None:
         return lca_utils.check_for_unsupported_lca(source_dialect, source_code, file_path)

--- a/src/databricks/labs/remorph/transpiler/sqlglot/sqlglot_engine.py
+++ b/src/databricks/labs/remorph/transpiler/sqlglot/sqlglot_engine.py
@@ -44,6 +44,7 @@ class SqlglotEngine(TranspileEngine):
             for expr in parsed_expression:
                 child: str | None = str(file_path)
                 if expr is not None:
+                    # TODO: fix possible issue where the file reference is lost (if we have a 'create')
                     for create in expr.find_all(exp.Create, exp.Insert, exp.Merge, bfs=False):
                         child = self._find_root_table(create)
 

--- a/src/databricks/labs/remorph/transpiler/sqlglot/sqlglot_engine.py
+++ b/src/databricks/labs/remorph/transpiler/sqlglot/sqlglot_engine.py
@@ -38,7 +38,7 @@ class SqlglotEngine(TranspileEngine):
 
         return expression, error
 
-    def parse_sql_content(self, source_dialect: str, source_code: str, file_path: Path):
+    def analyse_table_lineage(self, source_dialect: str, source_code: str, file_path: Path):
         parsed_expression, _ = self.parse(source_dialect, source_code, file_path)
         if parsed_expression is not None:
             for expr in parsed_expression:

--- a/tests/unit/intermediate/test_root_tables.py
+++ b/tests/unit/intermediate/test_root_tables.py
@@ -1,6 +1,6 @@
 import pytest
 
-from databricks.labs.remorph.intermediate.root_tables import RootTableExtractor
+from databricks.labs.remorph.intermediate.root_tables import RootTableAnalyzer
 
 
 @pytest.fixture(autouse=True)
@@ -17,8 +17,8 @@ def setup_file(tmpdir):
 
 
 def test_generate_lineage(tmpdir):
-    root_table_extractor = RootTableExtractor("snowflake", str(tmpdir))
-    dag = root_table_extractor.generate_lineage_dag()
+    root_table_analyzer = RootTableAnalyzer("snowflake", str(tmpdir))
+    dag = root_table_analyzer.generate_lineage_dag()
     roots = ["table2", "table3", "table4"]
 
     assert len(dag.nodes["table4"].parents) == 0
@@ -30,8 +30,8 @@ def test_generate_lineage(tmpdir):
 
 
 def test_generate_lineage_sql_file(setup_file):
-    root_table_extractor = RootTableExtractor("snowflake", str(setup_file))
-    dag = root_table_extractor.generate_lineage_dag(engine="sqlglot")
+    root_table_analyzer = RootTableAnalyzer("snowflake", str(setup_file))
+    dag = root_table_analyzer.generate_lineage_dag(engine="sqlglot")
     roots = ["table2", "table3", "table4"]
 
     assert len(dag.nodes["table4"].parents) == 0
@@ -43,6 +43,6 @@ def test_generate_lineage_sql_file(setup_file):
 
 
 def test_non_sqlglot_engine_raises_error(tmpdir):
-    root_table_extractor = RootTableExtractor("snowflake", str(tmpdir))
+    root_table_analyzer = RootTableAnalyzer("snowflake", str(tmpdir))
     with pytest.raises(ValueError):
-        root_table_extractor.generate_lineage_dag(engine="antlr")
+        root_table_analyzer.generate_lineage_dag(engine="antlr")

--- a/tests/unit/intermediate/test_root_tables.py
+++ b/tests/unit/intermediate/test_root_tables.py
@@ -1,6 +1,6 @@
 import pytest
 
-from databricks.labs.remorph.intermediate.root_tables import RootTableIdentifier
+from databricks.labs.remorph.intermediate.root_tables import RootTableExtractor
 
 
 @pytest.fixture(autouse=True)
@@ -17,8 +17,8 @@ def setup_file(tmpdir):
 
 
 def test_generate_lineage(tmpdir):
-    root_table_identifier = RootTableIdentifier("snowflake", str(tmpdir))
-    dag = root_table_identifier.generate_lineage()
+    root_table_extractor = RootTableExtractor("snowflake", str(tmpdir))
+    dag = root_table_extractor.generate_lineage_dag()
     roots = ["table2", "table3", "table4"]
 
     assert len(dag.nodes["table4"].parents) == 0
@@ -30,8 +30,8 @@ def test_generate_lineage(tmpdir):
 
 
 def test_generate_lineage_sql_file(setup_file):
-    root_table_identifier = RootTableIdentifier("snowflake", str(setup_file))
-    dag = root_table_identifier.generate_lineage(engine="sqlglot")
+    root_table_extractor = RootTableExtractor("snowflake", str(setup_file))
+    dag = root_table_extractor.generate_lineage_dag(engine="sqlglot")
     roots = ["table2", "table3", "table4"]
 
     assert len(dag.nodes["table4"].parents) == 0
@@ -43,6 +43,6 @@ def test_generate_lineage_sql_file(setup_file):
 
 
 def test_non_sqlglot_engine_raises_error(tmpdir):
-    root_table_identifier = RootTableIdentifier("snowflake", str(tmpdir))
+    root_table_extractor = RootTableExtractor("snowflake", str(tmpdir))
     with pytest.raises(ValueError):
-        root_table_identifier.generate_lineage(engine="antlr")
+        root_table_extractor.generate_lineage_dag(engine="antlr")

--- a/tests/unit/transpiler/test_sqlglot_engine.py
+++ b/tests/unit/transpiler/test_sqlglot_engine.py
@@ -87,10 +87,10 @@ def test_procedure_conversion(transpiler, transpile_config):
     )
 
 
-def test_find_root_tables(transpiler):
+def test_find_root_table(transpiler):
     expression, _ = transpiler.parse("snowflake", "SELECT * FROM table_name", Path("test.sql"))
     # pylint: disable=protected-access
-    assert transpiler._find_root_tables(expression[0]) == "table_name"
+    assert transpiler._find_root_table(expression[0]) == "table_name"
 
 
 def test_parse_sql_content(transpiler):

--- a/tests/unit/transpiler/test_sqlglot_engine.py
+++ b/tests/unit/transpiler/test_sqlglot_engine.py
@@ -94,6 +94,6 @@ def test_find_root_tables(transpiler):
 
 
 def test_parse_sql_content(transpiler):
-    result = list(transpiler.parse_sql_content("databricks", "SELECT * FROM table_name", Path("test.sql")))
+    result = list(transpiler.analyse_table_lineage("databricks", "SELECT * FROM table_name", Path("test.sql")))
     assert result[0][0] == "table_name"
     assert result[0][1] == "test.sql"


### PR DESCRIPTION
This PR:
 - renames `RootTableIdentifier` (which sounds like a parsed entity) to `RootTableAnalyzer` (which is what it does)
 - renames related methods accordingly, such as `parse_sql_content` to `analyse_table_lineage`

Requires #1328 

Progresses #1298 