### PR TITLE
Fix logical plan for `LIMIT` when combined with `OFFSET`

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
@@ -25,6 +25,8 @@ class LogicalPlanGenerator(
         }
         code"${source} WHERE ${expr.generate(condition)}"
       }
+      case ir.Limit(ir.Offset(input, offset), limit) =>
+        code"${generate(input)} LIMIT ${expr.generate(limit)} OFFSET ${expr.generate(offset)}"
       case ir.Limit(input, limit) =>
         code"${generate(input)} LIMIT ${expr.generate(limit)}"
       case ir.Offset(child, offset) =>

--- a/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/parsers/snowflake/SnowflakeRelationBuilder.scala
@@ -51,6 +51,8 @@ class SnowflakeRelationBuilder(override val vc: SnowflakeVisitorCoordinator)
   }
 
   private def buildLimitOffset(ctx: LimitClauseContext, input: ir.LogicalPlan): ir.LogicalPlan = {
+    // TODO: This is backwards: the IR should be LIMIT(OFFSET(input, offset), limit)
+    // TODO: Snowflake supports the OFFSET/FETCH syntax but currently the IR is emitted with reversed arguments.
     Option(ctx).fold(input) { c =>
       if (c.LIMIT() != null) {
         val limit = ir.Limit(input, ctx.expr(0).accept(vc.expressionBuilder))

--- a/core/src/test/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGeneratorTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGeneratorTest.scala
@@ -301,6 +301,10 @@ class LogicalPlanGeneratorTest extends AnyWordSpec with GeneratorTestCommon[ir.L
     ir.Offset(namedTable("a"), ir.Literal(10)) generates "a OFFSET 10"
   }
 
+  "transpile to LIMIT and OFFSET" in {
+    ir.Limit(ir.Offset(namedTable("a"), ir.Literal(10)), ir.Literal(20)) generates "a LIMIT 20 OFFSET 10"
+  }
+
   "transpile to ORDER BY" in {
     ir.Sort(
       namedTable("a"),


### PR DESCRIPTION
This PR updates code emitted by the logical planner for IR of the form: $\mathop{\mathit{limit}}(\mathop{\mathit{offset}}(input, x), y)$

This is the form that should be used for the following SQL:
```sql
LIMIT x OFFSET y
```
or
```sql
OFFSET x ROWS FETCH FIRST y ROWS ONLY
```

Prior to this PR we emit the following code which is invalid:
```sql
OFFSET y LIMIT x
```

Further to fixing the logical planner, this PR marks the Snowflake builder where this isn't being handled correctly. 