### PR TITLE
Allow python local imports if they solve a cyclic import problem

### DIFF
--- a/tests/unit/no_cheat.py
+++ b/tests/unit/no_cheat.py
@@ -20,7 +20,7 @@ def no_cheat(diff_text: str) -> str:
             continue
         codes = {_strip_code(code) for code in line[idx + len(DISABLE_TAG) :].split(',')}
         allowed_local_cyclic_imports = {'cyclic-import', 'import-outside-toplevel'}
-        if len(codes.intersection(allowed_local_cyclic_imports)) == 2:
+        if len(codes.intersection(allowed_local_cyclic_imports)) == len(allowed_local_cyclic_imports):
             codes = codes.difference(allowed_local_cyclic_imports)
         for code in codes:
             if line.startswith("-"):

--- a/tests/unit/no_cheat.py
+++ b/tests/unit/no_cheat.py
@@ -18,7 +18,7 @@ def no_cheat(diff_text: str) -> str:
         idx = line.find(DISABLE_TAG)
         if idx < 0:
             continue
-        codes = set([_strip_code(code) for code in line[idx + len(DISABLE_TAG) :].split(',')])
+        codes = {_strip_code(code) for code in line[idx + len(DISABLE_TAG) :].split(',')}
         allowed_local_cyclic_imports = {'cyclic-import', 'import-outside-toplevel'}
         if len(codes.intersection(allowed_local_cyclic_imports)) == 2:
             codes = codes.difference(allowed_local_cyclic_imports)

--- a/tests/unit/no_cheat.py
+++ b/tests/unit/no_cheat.py
@@ -3,8 +3,10 @@ from pathlib import Path
 
 DISABLE_TAG = '# pylint: disable='
 
+
 def _strip_code(code: str) -> str:
     return code.strip().strip('\n').strip('"').strip("'")
+
 
 def no_cheat(diff_text: str) -> str:
     lines = diff_text.split('\n')

--- a/tests/unit/test_no_cheat.py
+++ b/tests/unit/test_no_cheat.py
@@ -62,7 +62,7 @@ def test_no_cheat_returns_message_for_multiple_cheats_in_different_lines():
     result = no_cheat(diff_data)
     assert set(result.split('\n')) == {
         "Do not cheat the linter: found 1 additional # pylint: disable=some-rule",
-        "Do not cheat the linter: found 1 additional # pylint: disable=some-other-rule"
+        "Do not cheat the linter: found 1 additional # pylint: disable=some-other-rule",
     }
 
 
@@ -74,8 +74,9 @@ def test_no_cheat_returns_message_for_multiple_cheats_in_same_lines():
     result = no_cheat(diff_data)
     assert set(result.split('\n')) == {
         "Do not cheat the linter: found 1 additional # pylint: disable=some-rule",
-        "Do not cheat the linter: found 1 additional # pylint: disable=some-other-rule"
+        "Do not cheat the linter: found 1 additional # pylint: disable=some-other-rule",
     }
+
 
 def test_no_cheat_returns_message_for_standalone_cyclic_import():
     diff_data = """
@@ -83,9 +84,8 @@ def test_no_cheat_returns_message_for_standalone_cyclic_import():
 -some other code
 """
     result = no_cheat(diff_data)
-    assert result == (
-        "Do not cheat the linter: found 1 additional # pylint: disable=cyclic-import"
-    )
+    assert result == ("Do not cheat the linter: found 1 additional # pylint: disable=cyclic-import")
+
 
 def test_no_cheat_returns_message_for_standalone_import_outside_toplevel():
     diff_data = """
@@ -93,9 +93,8 @@ def test_no_cheat_returns_message_for_standalone_import_outside_toplevel():
 -some other code
 """
     result = no_cheat(diff_data)
-    assert result == (
-        "Do not cheat the linter: found 1 additional # pylint: disable=import-outside-toplevel"
-    )
+    assert result == ("Do not cheat the linter: found 1 additional # pylint: disable=import-outside-toplevel")
+
 
 def test_no_cheat_returns_empty_string_for_combined_cyclic_import_standalone_cyclic_import():
     diff_data = """
@@ -106,6 +105,7 @@ def test_no_cheat_returns_empty_string_for_combined_cyclic_import_standalone_cyc
     result = no_cheat(diff_data)
     assert not result
 
+
 def test_no_cheat_returns_message_for_code_within_combined_cyclic_import_standalone_cyclic_import():
     diff_data = """
 +some code # pylint: disable=some-rule, cyclic-import, import-outside-toplevel
@@ -113,6 +113,4 @@ def test_no_cheat_returns_message_for_code_within_combined_cyclic_import_standal
 -some other code
 """
     result = no_cheat(diff_data)
-    assert result == (
-        "Do not cheat the linter: found 1 additional # pylint: disable=some-rule"
-    )
+    assert result == ("Do not cheat the linter: found 1 additional # pylint: disable=some-rule")

--- a/tests/unit/test_no_cheat.py
+++ b/tests/unit/test_no_cheat.py
@@ -1,0 +1,118 @@
+from tests.unit.no_cheat import no_cheat
+
+
+def test_no_cheat_returns_empty_string_for_empty_diff():
+    diff_data = ""
+    result = no_cheat(diff_data)
+    assert not result
+
+
+def test_no_cheat_returns_empty_string_for_no_cheat_diff():
+    diff_data = """
++some code
+-some other code
+"""
+    result = no_cheat(diff_data)
+    assert not result
+
+
+def test_no_cheat_returns_empty_string_for_removed_cheat():
+    diff_data = """
++some code
+-some other code # pylint: disable=some-rule
+"""
+    result = no_cheat(diff_data)
+    assert not result
+
+
+def test_no_cheat_returns_empty_string_for_replaced_cheat():
+    diff_data = """
++some code # pylint: disable=some-rule
+-some other code # pylint: disable=some-rule
+"""
+    result = no_cheat(diff_data)
+    assert not result
+
+
+def test_no_cheat_returns_message_for_single_cheat():
+    diff_data = """
++some code # pylint: disable=some-rule
+-some other code
+"""
+    result = no_cheat(diff_data)
+    assert result == "Do not cheat the linter: found 1 additional # pylint: disable=some-rule"
+
+
+def test_no_cheat_returns_message_for_multiple_same_cheat():
+    diff_data = """
++some code # pylint: disable=some-rule
+-some other code
++some code # pylint: disable=some-rule
+"""
+    result = no_cheat(diff_data)
+    assert result == "Do not cheat the linter: found 2 additional # pylint: disable=some-rule"
+
+
+def test_no_cheat_returns_message_for_multiple_cheats_in_different_lines():
+    diff_data = """
++some code # pylint: disable=some-rule
+-some other code
++some code # pylint: disable=some-other-rule
+"""
+    result = no_cheat(diff_data)
+    assert set(result.split('\n')) == {
+        "Do not cheat the linter: found 1 additional # pylint: disable=some-rule",
+        "Do not cheat the linter: found 1 additional # pylint: disable=some-other-rule"
+    }
+
+
+def test_no_cheat_returns_message_for_multiple_cheats_in_same_lines():
+    diff_data = """
++some code # pylint: disable=some-rule, some-other-rule
+-some other code
+"""
+    result = no_cheat(diff_data)
+    assert set(result.split('\n')) == {
+        "Do not cheat the linter: found 1 additional # pylint: disable=some-rule",
+        "Do not cheat the linter: found 1 additional # pylint: disable=some-other-rule"
+    }
+
+def test_no_cheat_returns_message_for_standalone_cyclic_import():
+    diff_data = """
++some code # pylint: disable=cyclic-import
+-some other code
+"""
+    result = no_cheat(diff_data)
+    assert result == (
+        "Do not cheat the linter: found 1 additional # pylint: disable=cyclic-import"
+    )
+
+def test_no_cheat_returns_message_for_standalone_import_outside_toplevel():
+    diff_data = """
++some code # pylint: disable=import-outside-toplevel
+-some other code
+"""
+    result = no_cheat(diff_data)
+    assert result == (
+        "Do not cheat the linter: found 1 additional # pylint: disable=import-outside-toplevel"
+    )
+
+def test_no_cheat_returns_empty_string_for_combined_cyclic_import_standalone_cyclic_import():
+    diff_data = """
++some code # pylint: disable=cyclic-import, import-outside-toplevel
++some code # pylint: disable=import-outside-toplevel, cyclic-import
+-some other code
+"""
+    result = no_cheat(diff_data)
+    assert not result
+
+def test_no_cheat_returns_message_for_code_within_combined_cyclic_import_standalone_cyclic_import():
+    diff_data = """
++some code # pylint: disable=some-rule, cyclic-import, import-outside-toplevel
++some code # pylint: disable=import-outside-toplevel, cyclic-import
+-some other code
+"""
+    result = no_cheat(diff_data)
+    assert result == (
+        "Do not cheat the linter: found 1 additional # pylint: disable=some-rule"
+    )


### PR DESCRIPTION
Our current CI blocks merge of PRs if added python code contains comments such as:

`# pylint: disable=cyclic-import, import-outside-toplevel`

Local imports are discouraged, but are the most effective way of solving cyclic imports.

This PR solves the issue.