### PR TITLE
Display LSP diagnostics in console

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,7 @@ dependencies = [
   "coverage[toml]>=6.5",
   "pytest",
   "pytest-cov>=5.0.0,<6.0.0",
-# disabling asyncio, see https://github.com/pytest-dev/pytest-asyncio/issues/1015
-# "pytest-asyncio>=0.24.0",
+  "pytest-asyncio>=0.24.0",
   "black>=23.1.0",
   "ruff>=0.0.243",
   "databricks-connect==15.1",
@@ -65,7 +64,10 @@ dependencies = [
 reconcile = "databricks.labs.remorph.reconcile.execute:main"
 
 [tool.hatch.envs.default.scripts]
-test        = "pytest --cov src --cov-report=xml tests/unit"
+# temporarily disabling coverage in unit testing because collection of coverage results crashes the CI
+# see https://github.com/pytest-dev/pytest-asyncio/issues/1015
+# test        = "pytest --cov src --cov-report=xml tests/unit"
+test        = "pytest src tests/unit"
 coverage    = "pytest --cov src tests/unit --cov-report=html"
 integration = "pytest --cov src tests/integration --durations 20"
 fmt         = ["black .",

--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 from pathlib import Path
@@ -80,8 +81,7 @@ def transpile(
         mode=mode,
         sdk_config=sdk_config,
     )
-
-    status, errors = do_transpile(ctx.workspace_client, engine, config)
+    status, errors = asyncio.run(do_transpile(ctx.workspace_client, engine, config))
 
     for error in errors:
         print(str(error))

--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -81,7 +81,10 @@ def transpile(
         sdk_config=sdk_config,
     )
 
-    status = do_transpile(ctx.workspace_client, engine, config)
+    status, errors = do_transpile(ctx.workspace_client, engine, config)
+
+    for error in errors:
+        print(str(error))
 
     print(json.dumps(status))
 

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -35,7 +35,7 @@ from databricks.sdk import WorkspaceClient
 logger = logging.getLogger(__name__)
 
 
-def _process_file(
+async def _process_file(
     config: TranspileConfig,
     validator: Validator | None,
     transpiler: TranspileEngine,
@@ -48,9 +48,7 @@ def _process_file(
     with input_path.open("r") as f:
         source_sql = remove_bom(f.read())
 
-    transpile_result = asyncio.run(
-        _transpile(transpiler, config.source_dialect, config.target_dialect, source_sql, input_path)
-    )
+    transpile_result = await _transpile(transpiler, config.source_dialect, config.target_dialect, source_sql, input_path)
     error_list.extend(transpile_result.error_list)
 
     with output_path.open("w") as w:
@@ -73,7 +71,7 @@ def _process_file(
     return transpile_result.success_count, error_list
 
 
-def _process_directory(
+async def _process_directory(
     config: TranspileConfig,
     validator: Validator | None,
     transpiler: TranspileEngine,
@@ -102,7 +100,7 @@ def _process_directory(
     return counter, all_errors
 
 
-def _process_input_dir(config: TranspileConfig, validator: Validator | None, transpiler: TranspileEngine):
+async def _process_input_dir(config: TranspileConfig, validator: Validator | None, transpiler: TranspileEngine):
     error_list = []
     file_list = []
     counter = 0
@@ -114,13 +112,13 @@ def _process_input_dir(config: TranspileConfig, validator: Validator | None, tra
         msg = f"Processing for sqls under this folder: {folder}"
         logger.info(msg)
         file_list.extend(files)
-        no_of_sqls, errors = _process_directory(config, validator, transpiler, root, base_root, files)
+        no_of_sqls, errors = await _process_directory(config, validator, transpiler, root, base_root, files)
         counter = counter + no_of_sqls
         error_list.extend(errors)
     return TranspileStatus(file_list, counter, error_list)
 
 
-def _process_input_file(
+async def _process_input_file(
     config: TranspileConfig, validator: Validator | None, transpiler: TranspileEngine
 ) -> TranspileStatus:
     if not is_sql_file(config.input_path):
@@ -137,14 +135,24 @@ def _process_input_file(
 
     make_dir(output_path)
     output_file = output_path / config.input_path.name
-    no_of_sqls, error_list = _process_file(config, validator, transpiler, config.input_path, output_file)
+    no_of_sqls, error_list = await _process_file(config, validator, transpiler, config.input_path, output_file)
     return TranspileStatus([config.input_path], no_of_sqls, error_list)
 
 
 @timeit
-def transpile(
+async def transpile(
     workspace_client: WorkspaceClient, engine: TranspileEngine, config: TranspileConfig
 ) -> tuple[list[dict[str, Any]], list[TranspileError]]:
+    await engine.initialize(config)
+    status, errors = await _do_transpile(workspace_client, engine, config)
+    await engine.shutdown()
+    return status, errors
+
+
+async def _do_transpile(
+    workspace_client: WorkspaceClient, engine: TranspileEngine, config: TranspileConfig
+) -> tuple[list[dict[str, Any]], list[TranspileError]]:
+
     """
     [Experimental] Transpiles the SQL queries from one dialect to another.
 
@@ -166,9 +174,9 @@ def transpile(
     if config.input_source is None:
         raise InvalidInputException("Missing input source!")
     if config.input_path.is_dir():
-        result = _process_input_dir(config, validator, engine)
+        result = await _process_input_dir(config, validator, engine)
     elif config.input_path.is_file():
-        result = _process_input_file(config, validator, engine)
+        result = await _process_input_file(config, validator, engine)
     else:
         msg = f"{config.input_source} does not exist."
         logger.error(msg)
@@ -212,9 +220,9 @@ def verify_workspace_client(workspace_client: WorkspaceClient) -> WorkspaceClien
 
 
 async def _transpile(
-    transpiler: TranspileEngine, from_dialect: str, to_dialect: str, source_code: str, input_path: Path
+    engine: TranspileEngine, from_dialect: str, to_dialect: str, source_code: str, input_path: Path
 ) -> TranspileResult:
-    return await transpiler.transpile(from_dialect, to_dialect, source_code, input_path)
+    return await engine.transpile(from_dialect, to_dialect, source_code, input_path)
 
 
 def _validation(

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 from pathlib import Path
+from typing import Any
 
 from databricks.labs.remorph.__about__ import __version__
 from databricks.labs.remorph.config import (
@@ -140,7 +141,9 @@ def _process_input_file(
 
 
 @timeit
-def transpile(workspace_client: WorkspaceClient, engine: TranspileEngine, config: TranspileConfig):
+def transpile(
+    workspace_client: WorkspaceClient, engine: TranspileEngine, config: TranspileConfig
+) -> tuple[list[dict[str, Any]], list[TranspileError]]:
     """
     [Experimental] Transpiles the SQL queries from one dialect to another.
 
@@ -190,7 +193,7 @@ def transpile(workspace_client: WorkspaceClient, engine: TranspileEngine, config
             "error_log_file": str(error_log_file),
         }
     )
-    return status
+    return status, result.error_list
 
 
 def verify_workspace_client(workspace_client: WorkspaceClient) -> WorkspaceClient:

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -48,7 +48,9 @@ async def _process_file(
     with input_path.open("r") as f:
         source_sql = remove_bom(f.read())
 
-    transpile_result = await _transpile(transpiler, config.source_dialect, config.target_dialect, source_sql, input_path)
+    transpile_result = await _transpile(
+        transpiler, config.source_dialect, config.target_dialect, source_sql, input_path
+    )
     error_list.extend(transpile_result.error_list)
 
     with output_path.open("w") as w:
@@ -93,7 +95,7 @@ async def _process_directory(
             continue
 
         output_file_name = output_folder_base / file.name
-        success_count, error_list = _process_file(config, validator, transpiler, file, output_file_name)
+        success_count, error_list = await _process_file(config, validator, transpiler, file, output_file_name)
         counter = counter + success_count
         all_errors.extend(error_list)
 
@@ -152,7 +154,6 @@ async def transpile(
 async def _do_transpile(
     workspace_client: WorkspaceClient, engine: TranspileEngine, config: TranspileConfig
 ) -> tuple[list[dict[str, Any]], list[TranspileError]]:
-
     """
     [Experimental] Transpiles the SQL queries from one dialect to another.
 

--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -30,7 +30,9 @@ from lsprotocol.types import (
     TextDocumentIdentifier,
     METHOD_TO_TYPES,
     LanguageKind,
-    _SPECIAL_PROPERTIES,
+    Range as LSPRange,
+    Position as LSPPosition,
+    _SPECIAL_PROPERTIES, DiagnosticSeverity,
 )
 from pygls.lsp.client import BaseLanguageClient
 from pygls.exceptions import FeatureRequestError
@@ -40,6 +42,8 @@ from databricks.labs.blueprint.wheels import ProductInfo
 from databricks.labs.remorph.config import TranspileConfig, TranspileResult
 from databricks.labs.remorph.errors.exceptions import IllegalStateException
 from databricks.labs.remorph.transpiler.transpile_engine import TranspileEngine
+from databricks.labs.remorph.transpiler.transpile_status import TranspileError, ErrorKind, ErrorSeverity, CodeRange, \
+    CodePosition
 
 logger = logging.getLogger(__name__)
 
@@ -231,6 +235,47 @@ class ChangeManager(abc.ABC):
         return result
 
 
+class DiagnosticConverter(abc.ABC):
+
+    _KIND_NAMES = {e.name for e in ErrorKind}
+
+    @classmethod
+    def apply(cls, file_path: Path, diagnostic: Diagnostic) -> TranspileError:
+        code = diagnostic.code
+        kind = ErrorKind.INTERNAL
+        parts = code.split("-")
+        if len(parts) >= 2 and parts[0] in cls._KIND_NAMES:
+            kind = ErrorKind[parts[0]]
+            parts.pop(0)
+            code = "-".join(parts)
+        severity = cls._convert_severity(diagnostic.severity)
+        range = cls._convert_range(diagnostic.range)
+        return TranspileError(code=code, kind=kind, severity=severity, path=file_path, message=diagnostic.message,
+                              range=range)
+
+    @classmethod
+    def _convert_range(cls, lsp_range: LSPRange | None) -> CodeRange | None:
+            if not lsp_range:
+                return None
+            return CodeRange(cls._convert_position(lsp_range.start), cls._convert_position(lsp_range.end))
+
+    @classmethod
+    def _convert_position(cls, lsp_position: LSPPosition) -> CodePosition:
+            return CodePosition(lsp_position.line, lsp_position.character)
+
+
+    @classmethod
+    def _convert_severity(cls, severity: DiagnosticSeverity) -> ErrorSeverity:
+        if severity == DiagnosticSeverity.Information:
+            return ErrorSeverity.INFO
+        elif severity == DiagnosticSeverity.Warning:
+            return ErrorSeverity.WARNING
+        elif severity == DiagnosticSeverity.Error:
+            return ErrorSeverity.ERROR
+        else:
+            return ErrorSeverity.INFO
+
+
 class LSPEngine(TranspileEngine):
 
     @classmethod
@@ -320,7 +365,8 @@ class LSPEngine(TranspileEngine):
         response = await self.transpile_document(file_path)
         self.close_document(file_path)
         transpiled_code = ChangeManager.apply(source_code, response.changes)
-        return TranspileResult(transpiled_code, 1, [])
+        transpile_errors = [DiagnosticConverter.apply(file_path, diagnostic) for diagnostic in response.diagnostics]
+        return TranspileResult(transpiled_code, 1, transpile_errors)
 
     def analyse_table_lineage(
         self, source_dialect: str, source_code: str, file_path: Path

--- a/src/databricks/labs/remorph/transpiler/sqlglot/sqlglot_engine.py
+++ b/src/databricks/labs/remorph/transpiler/sqlglot/sqlglot_engine.py
@@ -9,7 +9,7 @@ from sqlglot.errors import ErrorLevel, ParseError, TokenError, UnsupportedError
 from sqlglot.expressions import Expression
 from sqlglot.tokens import Token, TokenType
 
-from databricks.labs.remorph.config import TranspileResult
+from databricks.labs.remorph.config import TranspileResult, TranspileConfig
 from databricks.labs.remorph.helpers.string_utils import format_error_message
 from databricks.labs.remorph.transpiler.sqlglot import lca_utils
 from databricks.labs.remorph.transpiler.sqlglot.dialect_utils import get_dialect
@@ -68,6 +68,12 @@ class SqlglotEngine(TranspileEngine):
                 error = TranspileError("UNSUPPORTED_SQL", ErrorKind.PARSING, ErrorSeverity.ERROR, file_path, error_msg)
                 problem_list.append(ParserProblem(parsed_expression.original_sql, error))
         return transpiled_sqls, problem_list
+
+    async def initialize(self, config: TranspileConfig) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
 
     async def transpile(
         self, source_dialect: str, target_dialect: str, source_code: str, file_path: Path

--- a/src/databricks/labs/remorph/transpiler/transpile_engine.py
+++ b/src/databricks/labs/remorph/transpiler/transpile_engine.py
@@ -3,7 +3,7 @@ import abc
 from collections.abc import Iterable
 from pathlib import Path
 
-from databricks.labs.remorph.config import TranspileResult
+from databricks.labs.remorph.config import TranspileResult, TranspileConfig
 
 
 class TranspileEngine(abc.ABC):
@@ -29,6 +29,12 @@ class TranspileEngine(abc.ABC):
     def analyse_table_lineage(
         self, source_dialect: str, source_code: str, file_path: Path
     ) -> Iterable[tuple[str, str]]: ...
+
+    @abc.abstractmethod
+    async def initialize(self, config: TranspileConfig) -> None: ...
+
+    @abc.abstractmethod
+    async def shutdown(self) -> None: ...
 
     @abc.abstractmethod
     async def transpile(

--- a/tests/resources/lsp_transpiler/internal.sql
+++ b/tests/resources/lsp_transpiler/internal.sql
@@ -1,0 +1,1 @@
+create table stuff(name varchar(12))

--- a/tests/resources/lsp_transpiler/lsp_server.py
+++ b/tests/resources/lsp_transpiler/lsp_server.py
@@ -23,7 +23,8 @@ from lsprotocol.types import (
     Range,
     Position,
     METHOD_TO_TYPES,
-    _SPECIAL_PROPERTIES, DiagnosticSeverity,
+    _SPECIAL_PROPERTIES,
+    DiagnosticSeverity,
 )
 from pygls.lsp.server import LanguageServer
 
@@ -115,37 +116,35 @@ class TestLspServer(LanguageServer):
         source_lines = source_sql.split("\n")
         range = Range(start=Position(0, 0), end=Position(len(source_lines), len(source_lines[-1])))
         transpiled_sql, diagnostics = self._transpile(Path(params.uri).name, range, source_sql)
-        changes = [ TextEdit( range=range, new_text=transpiled_sql) ]
+        changes = [TextEdit(range=range, new_text=transpiled_sql)]
         return TranspileDocumentResult(uri=params.uri, changes=changes, diagnostics=diagnostics)
 
-    def _transpile(self, file_name: str, range: Range, source_sql: str) -> tuple[str, list[Diagnostic]] :
+    def _transpile(self, file_name: str, lsp_range: Range, source_sql: str) -> tuple[str, list[Diagnostic]]:
         if file_name == "no_transpile.sql":
             diagnostic = Diagnostic(
-                range=range,
+                range=lsp_range,
                 message="No transpilation required",
                 severity=DiagnosticSeverity.Information,
-                code="GENERATION-NOT_REQUIRED"
+                code="GENERATION-NOT_REQUIRED",
             )
             return source_sql, [diagnostic]
         elif file_name == "unsupported_lca.sql":
             diagnostic = Diagnostic(
-                range=range,
+                range=lsp_range,
                 message="LCA conversion not supported",
                 severity=DiagnosticSeverity.Error,
-                code="ANALYSIS-UNSUPPORTED_LCA"
+                code="ANALYSIS-UNSUPPORTED_LCA",
             )
             return source_sql, [diagnostic]
         elif file_name == "internal.sql":
             diagnostic = Diagnostic(
-                range=range,
-                message="Something went wrong",
-                severity=DiagnosticSeverity.Warning,
-                code="SOME_ERROR_CODE"
+                range=lsp_range, message="Something went wrong", severity=DiagnosticSeverity.Warning, code="SOME_ERROR_CODE"
             )
             return source_sql, [diagnostic]
         else:
             # general test case
             return source_sql.upper(), []
+
 
 server = TestLspServer("test-lsp-server", "v0.1")
 

--- a/tests/resources/lsp_transpiler/lsp_server.py
+++ b/tests/resources/lsp_transpiler/lsp_server.py
@@ -138,7 +138,10 @@ class TestLspServer(LanguageServer):
             return source_sql, [diagnostic]
         elif file_name == "internal.sql":
             diagnostic = Diagnostic(
-                range=lsp_range, message="Something went wrong", severity=DiagnosticSeverity.Warning, code="SOME_ERROR_CODE"
+                range=lsp_range,
+                message="Something went wrong",
+                severity=DiagnosticSeverity.Warning,
+                code="SOME_ERROR_CODE",
             )
             return source_sql, [diagnostic]
         else:

--- a/tests/resources/lsp_transpiler/no_transpile.sql
+++ b/tests/resources/lsp_transpiler/no_transpile.sql
@@ -1,0 +1,1 @@
+create table stuff(name varchar(12))

--- a/tests/resources/lsp_transpiler/unsupported_lca.sql
+++ b/tests/resources/lsp_transpiler/unsupported_lca.sql
@@ -1,0 +1,1 @@
+create table stuff(name varchar(12))

--- a/tests/unit/test_cli_transpile.py
+++ b/tests/unit/test_cli_transpile.py
@@ -36,7 +36,7 @@ def test_transpile_with_no_sdk_config():
     workspace_client = create_autospec(WorkspaceClient)
     with (
         patch("databricks.labs.remorph.cli.ApplicationContext", autospec=True) as mock_app_context,
-        patch("databricks.labs.remorph.cli.do_transpile", return_value={}) as mock_transpile,
+        patch("databricks.labs.remorph.cli.do_transpile", return_value=({}, [])) as mock_transpile,
         patch("os.path.exists", return_value=True),
     ):
         default_config = TranspileConfig(
@@ -85,7 +85,7 @@ def test_transpile_with_warehouse_id_in_sdk_config():
     with (
         patch("databricks.labs.remorph.cli.ApplicationContext", autospec=True) as mock_app_context,
         patch("os.path.exists", return_value=True),
-        patch("databricks.labs.remorph.cli.do_transpile", return_value={}) as mock_transpile,
+        patch("databricks.labs.remorph.cli.do_transpile", return_value=({}, [])) as mock_transpile,
     ):
         sdk_config = {"warehouse_id": "w_id"}
         default_config = TranspileConfig(
@@ -134,7 +134,7 @@ def test_transpile_with_cluster_id_in_sdk_config():
     with (
         patch("databricks.labs.remorph.cli.ApplicationContext", autospec=True) as mock_app_context,
         patch("os.path.exists", return_value=True),
-        patch("databricks.labs.remorph.cli.do_transpile", return_value={}) as mock_transpile,
+        patch("databricks.labs.remorph.cli.do_transpile", return_value=({}, [])) as mock_transpile,
     ):
         sdk_config = {"cluster_id": "c_id"}
         default_config = TranspileConfig(
@@ -237,7 +237,7 @@ def test_transpile_with_single_transpiler_dialect(mock_workspace_client_cli):
     with (
         patch("os.path.exists", return_value=True),
         patch("databricks.labs.remorph.transpiler.transpile_engine.TranspileEngine.load_engine", return_value=engine),
-        patch("databricks.labs.remorph.cli.do_transpile", return_value={}),
+        patch("databricks.labs.remorph.cli.do_transpile", return_value=({}, [])),
     ):
         cli.transpile(
             mock_workspace_client_cli,
@@ -323,7 +323,7 @@ def test_transpile_with_valid_input(mock_workspace_client_cli):
 
     with (
         patch("os.path.exists", return_value=True),
-        patch("databricks.labs.remorph.cli.do_transpile", return_value={}) as mock_transpile,
+        patch("databricks.labs.remorph.cli.do_transpile", return_value=({}, [])) as mock_transpile,
     ):
         cli.transpile(
             mock_workspace_client_cli,
@@ -364,7 +364,7 @@ def test_transpile_with_valid_transpiler(mock_workspace_client_cli):
     mode = "current"
     sdk_config = {'cluster_id': 'test_cluster'}
 
-    with (patch("databricks.labs.remorph.cli.do_transpile", return_value={}) as mock_transpile,):
+    with (patch("databricks.labs.remorph.cli.do_transpile", return_value=({}, [])) as mock_transpile,):
         cli.transpile(
             mock_workspace_client_cli,
             transpiler,
@@ -407,7 +407,7 @@ def test_transpile_empty_output_folder(mock_workspace_client_cli):
 
     with (
         patch("os.path.exists", return_value=True),
-        patch("databricks.labs.remorph.cli.do_transpile", return_value={}) as mock_transpile,
+        patch("databricks.labs.remorph.cli.do_transpile", return_value=({}, [])) as mock_transpile,
     ):
         cli.transpile(
             mock_workspace_client_cli,

--- a/tests/unit/test_cli_transpile.py
+++ b/tests/unit/test_cli_transpile.py
@@ -8,6 +8,7 @@ from databricks.labs.remorph.config import TranspileConfig
 from databricks.sdk import WorkspaceClient
 
 from databricks.labs.remorph.transpiler.transpile_engine import TranspileEngine
+from tests.unit.conftest import path_to_resource
 
 
 def test_transpile_with_missing_installation():
@@ -309,7 +310,7 @@ def test_transpile_with_valid_input(mock_workspace_client_cli):
 
 
 def test_transpile_with_valid_transpiler(mock_workspace_client_cli):
-    transpiler = path_to_resource("lsp_transpiler", "lsp_config.yml")
+    transpiler_config_path = path_to_resource("lsp_transpiler", "lsp_config.yml")
     source_dialect = "snowflake"
     input_source = path_to_resource("functional", "snowflake", "aggregates", "least_1.sql")
     output_folder = path_to_resource("lsp_transpiler")
@@ -322,7 +323,7 @@ def test_transpile_with_valid_transpiler(mock_workspace_client_cli):
     with (patch("databricks.labs.remorph.cli.do_transpile", return_value=({}, [])) as mock_transpile,):
         cli.transpile(
             mock_workspace_client_cli,
-            transpiler,
+            transpiler_config_path,
             source_dialect,
             input_source,
             output_folder,
@@ -335,7 +336,7 @@ def test_transpile_with_valid_transpiler(mock_workspace_client_cli):
             mock_workspace_client_cli,
             ANY,
             TranspileConfig(
-                transpiler=transpiler,
+                transpiler_config_path=transpiler_config_path,
                 source_dialect=source_dialect,
                 input_source=input_source,
                 output_folder=output_folder,

--- a/tests/unit/test_cli_transpile.py
+++ b/tests/unit/test_cli_transpile.py
@@ -1,4 +1,3 @@
-import asyncio
 from unittest.mock import create_autospec, patch, PropertyMock, ANY
 
 import pytest
@@ -444,4 +443,3 @@ def test_transpile_prints_errors(capsys, tmp_path, mock_workspace_client_cli):
     captured = capsys.readouterr()
     assert "TranspileError" in captured.out
     assert "UNSUPPORTED_LCA" in captured.out
-

--- a/tests/unit/test_cli_transpile.py
+++ b/tests/unit/test_cli_transpile.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import create_autospec, patch, PropertyMock, ANY
 
 import pytest
@@ -418,3 +419,29 @@ def test_transpile_with_invalid_mode(mock_workspace_client_cli):
             schema_name,
             mode,
         )
+
+
+def test_transpile_prints_errors(capsys, tmp_path, mock_workspace_client_cli):
+    transpiler_config_path = path_to_resource("lsp_transpiler", "lsp_config.yml")
+    source_dialect = "snowflake"
+    input_source = path_to_resource("lsp_transpiler", "unsupported_lca.sql")
+    output_folder = str(tmp_path)
+    skip_validation = "true"
+    catalog_name = "my_catalog"
+    schema_name = "my_schema"
+    mode = "current"
+    cli.transpile(
+        mock_workspace_client_cli,
+        transpiler_config_path,
+        source_dialect,
+        input_source,
+        output_folder,
+        skip_validation,
+        catalog_name,
+        schema_name,
+        mode,
+    )
+    captured = capsys.readouterr()
+    assert "TranspileError" in captured.out
+    assert "UNSUPPORTED_LCA" in captured.out
+

--- a/tests/unit/transpiler/test_execute.py
+++ b/tests/unit/transpiler/test_execute.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 import shutil
 from pathlib import Path
@@ -8,11 +9,13 @@ import pytest
 from databricks.connect import DatabricksSession
 from databricks.labs.lsql.backends import MockBackend
 from databricks.labs.lsql.core import Row
+from databricks.sdk import WorkspaceClient
+
 from databricks.labs.remorph.config import TranspileConfig, ValidationResult
 from databricks.labs.remorph.helpers.file_utils import make_dir
 from databricks.labs.remorph.helpers.validation import Validator
 from databricks.labs.remorph.transpiler.execute import (
-    transpile,
+    transpile as do_transpile,
     transpile_column_exp,
     transpile_sql,
 )
@@ -22,6 +25,10 @@ from databricks.labs.remorph.transpiler.sqlglot.sqlglot_engine import SqlglotEng
 
 
 # pylint: disable=unspecified-encoding
+
+
+def transpile(workspace_client: WorkspaceClient, engine: SqlglotEngine, config: TranspileConfig):
+    return asyncio.run(do_transpile(workspace_client, engine, config))
 
 
 def safe_remove_dir(dir_path: Path):

--- a/tests/unit/transpiler/test_execute.py
+++ b/tests/unit/transpiler/test_execute.py
@@ -163,7 +163,7 @@ def test_with_dir_skip_validation(initial_setup, mock_workspace_client):
 
     # call transpile
     with patch('databricks.labs.remorph.helpers.db_sql.get_sql_backend', return_value=MockBackend()):
-        status = transpile(mock_workspace_client, SqlglotEngine(), config)
+        status, _errors = transpile(mock_workspace_client, SqlglotEngine(), config)
     # assert the status
     assert status is not None, "Status returned by morph function is None"
     assert isinstance(status, list), "Status returned by morph function is not a list"
@@ -222,7 +222,7 @@ def test_with_dir_with_output_folder_skip_validation(initial_setup, mock_workspa
         skip_validation=True,
     )
     with patch('databricks.labs.remorph.helpers.db_sql.get_sql_backend', return_value=MockBackend()):
-        status = transpile(mock_workspace_client, SqlglotEngine(), config)
+        status, _errors = transpile(mock_workspace_client, SqlglotEngine(), config)
     # assert the status
     assert status is not None, "Status returned by morph function is None"
     assert isinstance(status, list), "Status returned by morph function is not a list"
@@ -295,7 +295,7 @@ def test_with_file(initial_setup, mock_workspace_client):
         ),
         patch("databricks.labs.remorph.transpiler.execute.Validator", return_value=mock_validate),
     ):
-        status = transpile(mock_workspace_client, SqlglotEngine(), config)
+        status, _errors = transpile(mock_workspace_client, SqlglotEngine(), config)
 
     # assert the status
     assert status is not None, "Status returned by transpile function is None"
@@ -344,7 +344,7 @@ def test_with_file_with_output_folder_skip_validation(initial_setup, mock_worksp
         'databricks.labs.remorph.helpers.db_sql.get_sql_backend',
         return_value=MockBackend(),
     ):
-        status = transpile(mock_workspace_client, SqlglotEngine(), config)
+        status, _errors = transpile(mock_workspace_client, SqlglotEngine(), config)
 
     # assert the status
     assert status is not None, "Status returned by morph function is None"
@@ -379,7 +379,7 @@ def test_with_not_a_sql_file_skip_validation(initial_setup, mock_workspace_clien
         'databricks.labs.remorph.helpers.db_sql.get_sql_backend',
         return_value=MockBackend(),
     ):
-        status = transpile(mock_workspace_client, SqlglotEngine(), config)
+        status, _errors = transpile(mock_workspace_client, SqlglotEngine(), config)
 
     # assert the status
     assert status is not None, "Status returned by transpile function is None"
@@ -497,7 +497,7 @@ def test_with_file_with_success(initial_setup, mock_workspace_client):
         ),
         patch("databricks.labs.remorph.transpiler.execute.Validator", return_value=mock_validate),
     ):
-        status = transpile(mock_workspace_client, SqlglotEngine(), config)
+        status, _errors = transpile(mock_workspace_client, SqlglotEngine(), config)
         # assert the status
         assert status is not None, "Status returned by morph function is None"
         assert isinstance(status, list), "Status returned by morph function is not a list"
@@ -540,7 +540,7 @@ def test_parse_error_handling(initial_setup, mock_workspace_client):
     )
 
     with patch('databricks.labs.remorph.helpers.db_sql.get_sql_backend', return_value=MockBackend()):
-        status = transpile(mock_workspace_client, SqlglotEngine(), config)
+        status, _errors = transpile(mock_workspace_client, SqlglotEngine(), config)
 
     # assert the status
     assert status is not None, "Status returned by morph function is None"
@@ -597,7 +597,7 @@ def test_token_error_handling(initial_setup, mock_workspace_client):
     )
 
     with patch('databricks.labs.remorph.helpers.db_sql.get_sql_backend', return_value=MockBackend()):
-        status = transpile(mock_workspace_client, SqlglotEngine(), config)
+        status, _errors = transpile(mock_workspace_client, SqlglotEngine(), config)
     # assert the status
     assert status is not None, "Status returned by morph function is None"
     assert isinstance(status, list), "Status returned by morph function is not a list"

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -1,4 +1,5 @@
 import asyncio
+import dataclasses
 from pathlib import Path
 from time import sleep
 
@@ -10,6 +11,7 @@ from databricks.labs.remorph.transpiler.lsp.lsp_engine import (
     LSPEngine,
     ChangeManager,
 )
+from databricks.labs.remorph.transpiler.transpile_status import TranspileError, ErrorSeverity, ErrorKind
 from tests.unit.conftest import path_to_resource
 
 
@@ -134,3 +136,20 @@ async def test_server_transpiles_document(lsp_engine, transpile_config):
 def test_change_mgr_replaces_text(source, changes, result):
     transformed = ChangeManager.apply(source, changes)
     assert transformed == result
+
+
+@pytest.mark.parametrize("resource, errors", [
+    ("source_stuff.sql", []),
+    ("no_transpile.sql", [TranspileError("NOT_REQUIRED", ErrorKind.GENERATION, ErrorSeverity.INFO, Path("no_transpile.sql"), "No transpilation required")]),
+    ("unsupported_lca.sql", [TranspileError("UNSUPPORTED_LCA", ErrorKind.ANALYSIS, ErrorSeverity.ERROR, Path("unsupported_lca.sql"), "LCA conversion not supported")]),
+    ("internal.sql", [TranspileError("SOME_ERROR_CODE", ErrorKind.INTERNAL, ErrorSeverity.WARNING, Path("internal.sql"), "Something went wrong")]),
+])
+async def test_client_translates_diagnostics(lsp_engine, transpile_config, resource, errors):
+    sample_path = Path(path_to_resource("lsp_transpiler", resource))
+    await lsp_engine.initialize(transpile_config)
+    result = await lsp_engine.transpile(
+        transpile_config.source_dialect, "databricks", sample_path.read_text(encoding="utf-8"), sample_path
+    )
+    await lsp_engine.shutdown()
+    actual = [ dataclasses.replace(error, path = Path(error.path.name), range = None) for error in result.error_list]
+    assert actual == errors

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -138,12 +138,48 @@ def test_change_mgr_replaces_text(source, changes, result):
     assert transformed == result
 
 
-@pytest.mark.parametrize("resource, errors", [
-    ("source_stuff.sql", []),
-    ("no_transpile.sql", [TranspileError("NOT_REQUIRED", ErrorKind.GENERATION, ErrorSeverity.INFO, Path("no_transpile.sql"), "No transpilation required")]),
-    ("unsupported_lca.sql", [TranspileError("UNSUPPORTED_LCA", ErrorKind.ANALYSIS, ErrorSeverity.ERROR, Path("unsupported_lca.sql"), "LCA conversion not supported")]),
-    ("internal.sql", [TranspileError("SOME_ERROR_CODE", ErrorKind.INTERNAL, ErrorSeverity.WARNING, Path("internal.sql"), "Something went wrong")]),
-])
+@pytest.mark.parametrize(
+    "resource, errors",
+    [
+        ("source_stuff.sql", []),
+        (
+            "no_transpile.sql",
+            [
+                TranspileError(
+                    "NOT_REQUIRED",
+                    ErrorKind.GENERATION,
+                    ErrorSeverity.INFO,
+                    Path("no_transpile.sql"),
+                    "No transpilation required",
+                )
+            ],
+        ),
+        (
+            "unsupported_lca.sql",
+            [
+                TranspileError(
+                    "UNSUPPORTED_LCA",
+                    ErrorKind.ANALYSIS,
+                    ErrorSeverity.ERROR,
+                    Path("unsupported_lca.sql"),
+                    "LCA conversion not supported",
+                )
+            ],
+        ),
+        (
+            "internal.sql",
+            [
+                TranspileError(
+                    "SOME_ERROR_CODE",
+                    ErrorKind.INTERNAL,
+                    ErrorSeverity.WARNING,
+                    Path("internal.sql"),
+                    "Something went wrong",
+                )
+            ],
+        ),
+    ],
+)
 async def test_client_translates_diagnostics(lsp_engine, transpile_config, resource, errors):
     sample_path = Path(path_to_resource("lsp_transpiler", resource))
     await lsp_engine.initialize(transpile_config)
@@ -151,5 +187,5 @@ async def test_client_translates_diagnostics(lsp_engine, transpile_config, resou
         transpile_config.source_dialect, "databricks", sample_path.read_text(encoding="utf-8"), sample_path
     )
     await lsp_engine.shutdown()
-    actual = [ dataclasses.replace(error, path = Path(error.path.name), range = None) for error in result.error_list]
+    actual = [dataclasses.replace(error, path=Path(error.path.name), range=None) for error in result.error_list]
     assert actual == errors


### PR DESCRIPTION
Our current implementation ignores LSP diagnostics.
Also it stores transpile errors in the target directory, but does not display them in the console.
This PR:
 - converts LSP diagnostics into `TranspileErrors`
 - displays them in the console

Fixes #1301 