### PR TITLE
Generate table properties if DDL contain default values

### DIFF
--- a/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
+++ b/core/src/main/scala/com/databricks/labs/remorph/generators/sql/LogicalPlanGenerator.scala
@@ -208,13 +208,13 @@ class LogicalPlanGenerator(
   }
 
   private def createTable(createTable: ir.CreateTableCommand): SQL = {
-    var tableProperties:String = ""
+    var tableProperties: String = ""
     val columns = createTable.columns
       .map { col =>
         val dataType = DataTypeGenerator.generateDataType(col.dataType)
         val constraints = col.constraints.map(constraint(_)).mkCode(" ")
-        for(constrain <- col.constraints) {
-          if (constrain.isInstanceOf[ir.DefaultValueConstraint]){
+        for (constrain <- col.constraints) {
+          if (constrain.isInstanceOf[ir.DefaultValueConstraint]) {
             tableProperties = " TBLPROPERTIES ('delta.feature.allowColumnDefaults' = 'supported')"
           }
         }
@@ -224,13 +224,13 @@ class LogicalPlanGenerator(
   }
 
   private def replaceTable(createTable: ir.ReplaceTableCommand): SQL = {
-    var tableProperties:String = ""
+    var tableProperties: String = ""
     val columns = createTable.columns
       .map { col =>
         val dataType = DataTypeGenerator.generateDataType(col.dataType)
         val constraints = col.constraints.map(constraint).mkCode(" ")
-        for(constrain <- col.constraints) {
-          if (constrain.isInstanceOf[ir.DefaultValueConstraint]){
+        for (constrain <- col.constraints) {
+          if (constrain.isInstanceOf[ir.DefaultValueConstraint]) {
             tableProperties = " TBLPROPERTIES ('delta.feature.allowColumnDefaults' = 'supported')"
           }
         }

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
@@ -6,10 +6,10 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
 
   protected val transpiler = new SnowflakeToDatabricksTranspiler
 
-  "transpile ddl with default value" should{
+  "transpile ddl with default value" should {
     "transpile ddl" in {
       "CREATE TABLE tbl3 (  employee_id DECIMAL(38, 0) DEFAULT 3000,  first_name STRING NOT NULL,  last_name STRING NOT NULL);" transpilesTo
-      "CREATE TABLE tbl3 (  employee_id DECIMAL(38, 0) DEFAULT 3000,  first_name STRING NOT NULL,  last_name STRING NOT NULL) TBLPROPERTIES ('delta.feature.allowColumnDefaults' = 'supported');"
+        "CREATE TABLE tbl3 (  employee_id DECIMAL(38, 0) DEFAULT 3000,  first_name STRING NOT NULL,  last_name STRING NOT NULL) TBLPROPERTIES ('delta.feature.allowColumnDefaults' = 'supported');"
     }
   }
 

--- a/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
+++ b/core/src/test/scala/com/databricks/labs/remorph/transpilers/SnowflakeToDatabricksTranspilerTest.scala
@@ -6,6 +6,13 @@ class SnowflakeToDatabricksTranspilerTest extends AnyWordSpec with TranspilerTes
 
   protected val transpiler = new SnowflakeToDatabricksTranspiler
 
+  "transpile ddl with default value" should{
+    "transpile ddl" in {
+      "CREATE TABLE tbl3 (  employee_id DECIMAL(38, 0) DEFAULT 3000,  first_name STRING NOT NULL,  last_name STRING NOT NULL);" transpilesTo
+      "CREATE TABLE tbl3 (  employee_id DECIMAL(38, 0) DEFAULT 3000,  first_name STRING NOT NULL,  last_name STRING NOT NULL) TBLPROPERTIES ('delta.feature.allowColumnDefaults' = 'supported');"
+    }
+  }
+
   "transpile TO_NUMBER and TO_DECIMAL" should {
     "transpile TO_NUMBER" in {
       "select TO_NUMBER(EXPR) from test_tbl;" transpilesTo

--- a/src/databricks/labs/remorph/transpiler/sqlglot/generator/databricks.py
+++ b/src/databricks/labs/remorph/transpiler/sqlglot/generator/databricks.py
@@ -477,11 +477,8 @@ class Databricks(SqlglotDatabricks):  #
         def create_sql(self, expression: exp.Create) -> str:
             expression.args["indexes"] = None  # Removing indexes from create statement
             create_sql = super().create_sql(expression)
-            for from_ in expression.find_all(
-                exp.DefaultColumnConstraint
-            ):  # Generate table properties if DDL contain default values
-                create_sql = create_sql + " TBLPROPERTIES ('delta.feature.allowColumnDefaults' = 'supported')"
-                break
+            if expression.find(exp.DefaultColumnConstraint):
+                create_sql += " TBLPROPERTIES ('delta.feature.allowColumnDefaults' = 'supported')"
             return create_sql
 
         def join_sql(self, expression: exp.Join) -> str:

--- a/src/databricks/labs/remorph/transpiler/sqlglot/generator/databricks.py
+++ b/src/databricks/labs/remorph/transpiler/sqlglot/generator/databricks.py
@@ -408,8 +408,6 @@ class Databricks(SqlglotDatabricks):  #
             "%-d": "dd",
         }
 
-        WITH_PROPERTIES_PREFIX = "TBLPROPERTIES"
-
         COLLATE_IS_FUNC = True
         # [TODO]: Variant needs to be transformed better, for now parsing to string was deemed as the choice.
         TYPE_MAPPING = {
@@ -479,7 +477,9 @@ class Databricks(SqlglotDatabricks):  #
         def create_sql(self, expression: exp.Create) -> str:
             expression.args["indexes"] = None  # Removing indexes from create statement
             create_sql = super().create_sql(expression)
-            for from_ in expression.find_all(exp.DefaultColumnConstraint): # Generate table properties if DDL contain default values
+            for from_ in expression.find_all(
+                exp.DefaultColumnConstraint
+            ):  # Generate table properties if DDL contain default values
                 create_sql = create_sql + " TBLPROPERTIES ('delta.feature.allowColumnDefaults' = 'supported')"
                 break
             return create_sql

--- a/tests/resources/functional/snowflake/ddl/test_create_ddl_2.sql
+++ b/tests/resources/functional/snowflake/ddl/test_create_ddl_2.sql
@@ -10,4 +10,4 @@ CREATE TABLE employee (
   employee_id DECIMAL(38, 0) DEFAULT 3000,
   first_name STRING NOT NULL,
   last_name STRING NOT NULL
-);
+) TBLPROPERTIES ('delta.feature.allowColumnDefaults' = 'supported');

--- a/tests/resources/functional/teradata/ddl/test_table_properties.sql
+++ b/tests/resources/functional/teradata/ddl/test_table_properties.sql
@@ -1,0 +1,17 @@
+-- teradata sql:
+CREATE SET TABLE DB_FLIGHT_STATS.FSTATS_INFO_LOADED_DATA_HIST ,NO FALLBACK ,
+     NO BEFORE JOURNAL,
+     NO AFTER JOURNAL,
+     CHECKSUM = DEFAULT,
+     DEFAULT MERGEBLOCKRATIO
+     (
+      loaded_timestamp string default 's',
+      co_upd_tms TIMESTAMP(0))
+PRIMARY INDEX ( loaded_timestamp );
+
+
+--databricks sql:
+CREATE TABLE DB_FLIGHT_STATS.FSTATS_INFO_LOADED_DATA_HIST (
+                                                              loaded_timestamp STRING DEFAULT 's',
+                                                              co_upd_tms TIMESTAMP
+) TBLPROPERTIES ('delta.feature.allowColumnDefaults' = 'supported')


### PR DESCRIPTION
closes #1384 

This PR introduces a feature to generate table properties when a DDL includes default values.