### PR TITLE
Fix pytest-cov crash

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,15 @@
+[run]
+branch = true
+parallel = true
+omit =
+    src/databricks/labs/remorph/coverage/*
+    src/databricks/labs/remorph/helpers/execution_time.py
+    tests/resources/lsp_transpiler/lsp_server.py
+    __about__.py
+
+[report]
+exclude_lines =
+    no cov
+    if __name__ == .__main__.:
+    if TYPE_CHECKING:
+    def main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,21 +131,6 @@ ban-relative-imports = "all"
   "ARG001" # tests may not use the provided fixtures
 ]
 
-[tool.coverage.run]
-branch = true
-parallel = true
-
-[tool.coverage.report]
-omit = ["src/databricks/labs/remorph/coverage/*",
-  "src/databricks/labs/remorph/helpers/execution_time.py",
-  "__about__.py"]
-exclude_lines = [
-  "no cov",
-  "if __name__ == .__main__.:",
-  "if TYPE_CHECKING:",
-  "def main()",
-]
-
 [tool.pylint.main]
 # PyLint configuration is adapted from Google Python Style Guide with modifications.
 # Sources https://google.github.io/styleguide/pylintrc


### PR DESCRIPTION
The `pytest-cov` plugin is used to gather test coverage info, using the `coverage` tool.
It suffers from a limitation where child processes created by tests do not inherit the `coverage` configuration from `pyproject.toml` because that file is not on the command line.
This limitation is described here https://github.com/nedbat/coveragepy/issues/512
With the introduction of LSP, we started encountering crashes when collecting coverage data, because LSP launches a child process.
The solution is to move `coverage` configuration into a dedicated `.coveragerc` file.

This PR does just that.

Fixes #1363