### PR TITLE
bump max args

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -407,7 +407,7 @@ bad-functions = ["map", "input"]
 # ignored-parents =
 
 # Maximum number of arguments for function / method.
-max-args = 9
+max-args = 12
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes = 13


### PR DESCRIPTION
Our current pylint settings limit the # of arguments to 9, which is insufficient.
This PR increases that # to 12.