### PR TITLE
restore lost file and fix gitignore that led to that loss

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,15 @@
+[run]
+branch = true
+parallel = true
+omit =
+    src/databricks/labs/remorph/coverage/*
+    src/databricks/labs/remorph/helpers/execution_time.py
+    tests/resources/lsp_transpiler/lsp_server.py
+    __about__.py
+
+[report]
+exclude_lines =
+    no cov
+    if __name__ == .__main__.:
+    if TYPE_CHECKING:
+    def main()

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ dist
 /htmlcov/
 *.iml
 target/
-.coverage*
+.coverage
+.coverage.*
 coverage.*
 *.iws
 /core/gen/


### PR DESCRIPTION
As part of the repo split, the` .coveragerc `file was lost, probably due to an incorrect `.gitignore`
This PR fixes that.