### PR TITLE
Add language_id in TranspileDocumentResult

### DIFF
--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -115,6 +115,7 @@ class TranspileDocumentRequest:
 @attrs.define
 class TranspileDocumentResult:
     uri: str = attrs.field()
+    language_id: str = attrs.field()
     changes: Sequence[TextEdit] = attrs.field()
     diagnostics: Sequence[Diagnostic] = attrs.field()
 

--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -115,7 +115,7 @@ class TranspileDocumentRequest:
 @attrs.define
 class TranspileDocumentResult:
     uri: str = attrs.field()
-    language_id: str = attrs.field()
+    language_id: LanguageKind | str = attrs.field()
     changes: Sequence[TextEdit] = attrs.field()
     diagnostics: Sequence[Diagnostic] = attrs.field()
 

--- a/tests/resources/lsp_transpiler/lsp_server.py
+++ b/tests/resources/lsp_transpiler/lsp_server.py
@@ -25,6 +25,7 @@ from lsprotocol.types import (
     METHOD_TO_TYPES,
     _SPECIAL_PROPERTIES,
     DiagnosticSeverity,
+    LanguageKind,
 )
 from pygls.lsp.server import LanguageServer
 
@@ -44,7 +45,7 @@ TRANSPILE_TO_DATABRICKS_CAPABILITY = {"id": str(uuid4()), "method": TRANSPILE_TO
 @attrs.define
 class TranspileDocumentParams:
     uri: str = attrs.field()
-    language_id: str = attrs.field()
+    language_id: LanguageKind | str = attrs.field()
 
 
 @attrs.define
@@ -60,7 +61,7 @@ class TranspileDocumentRequest:
 @attrs.define
 class TranspileDocumentResult:
     uri: str = attrs.field()
-    language_id: str = attrs.field() #
+    language_id: LanguageKind | str = attrs.field()  #
     changes: Sequence[TextEdit] = attrs.field()
     diagnostics: Sequence[Diagnostic] = attrs.field()
 
@@ -118,7 +119,9 @@ class TestLspServer(LanguageServer):
         range = Range(start=Position(0, 0), end=Position(len(source_lines), len(source_lines[-1])))
         transpiled_sql, diagnostics = self._transpile(Path(params.uri).name, range, source_sql)
         changes = [TextEdit(range=range, new_text=transpiled_sql)]
-        return TranspileDocumentResult(uri=params.uri, language_id=LanguageKind.Sql, changes=changes, diagnostics=diagnostics)
+        return TranspileDocumentResult(
+            uri=params.uri, language_id=LanguageKind.Sql, changes=changes, diagnostics=diagnostics
+        )
 
     def _transpile(self, file_name: str, lsp_range: Range, source_sql: str) -> tuple[str, list[Diagnostic]]:
         if file_name == "no_transpile.sql":

--- a/tests/resources/lsp_transpiler/lsp_server.py
+++ b/tests/resources/lsp_transpiler/lsp_server.py
@@ -60,6 +60,7 @@ class TranspileDocumentRequest:
 @attrs.define
 class TranspileDocumentResult:
     uri: str = attrs.field()
+    language_id: str = attrs.field() #
     changes: Sequence[TextEdit] = attrs.field()
     diagnostics: Sequence[Diagnostic] = attrs.field()
 
@@ -100,8 +101,8 @@ class TestLspServer(LanguageServer):
 
     async def did_initialize(self, init_params: InitializeParams) -> None:
         self.initialization_options = init_params.initialization_options
-        logger.debug(f"dialect={server.dialect}")
-        logger.debug(f"whatever={server.whatever}")
+        logger.debug(f"dialect={self.dialect}")
+        logger.debug(f"whatever={self.whatever}")
         # TODO check whether the client supports dynamic registration
         registrations = [
             Registration(
@@ -117,7 +118,7 @@ class TestLspServer(LanguageServer):
         range = Range(start=Position(0, 0), end=Position(len(source_lines), len(source_lines[-1])))
         transpiled_sql, diagnostics = self._transpile(Path(params.uri).name, range, source_sql)
         changes = [TextEdit(range=range, new_text=transpiled_sql)]
-        return TranspileDocumentResult(uri=params.uri, changes=changes, diagnostics=diagnostics)
+        return TranspileDocumentResult(uri=params.uri, language_id=LanguageKind.Sql, changes=changes, diagnostics=diagnostics)
 
     def _transpile(self, file_name: str, lsp_range: Range, source_sql: str) -> tuple[str, list[Diagnostic]]:
         if file_name == "no_transpile.sql":

--- a/tests/unit/transpiler/test_snow.py
+++ b/tests/unit/transpiler/test_snow.py
@@ -1,5 +1,5 @@
 """
-    Test Cases to validate source Snowflake dialect
+Test Cases to validate source Snowflake dialect
 """
 
 


### PR DESCRIPTION
In preparation of translating SQL stored procs to Python UDFs, Remorph needs to know the language to which the source was transpiled.
This PR adds that field.