### PR TITLE
Prefer root uri in initialization

### DIFF
--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -381,7 +381,8 @@ class LSPEngine(TranspileEngine):
         root_path = input_path if input_path.is_dir() else input_path.parent
         params = InitializeParams(
             capabilities=self._client_capabilities(),
-            root_path=str(root_path),
+            root_uri=str(root_path.absolute().as_uri()),
+            workspace_folders=None, # for now, we only support a single workspace = root_uri
             initialization_options=self._initialization_options(config),
         )
         self._init_response = await self._client.initialize_async(params)

--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -382,7 +382,7 @@ class LSPEngine(TranspileEngine):
         params = InitializeParams(
             capabilities=self._client_capabilities(),
             root_uri=str(root_path.absolute().as_uri()),
-            workspace_folders=None, # for now, we only support a single workspace = root_uri
+            workspace_folders=None,  # for now, we only support a single workspace = root_uri
             initialization_options=self._initialization_options(config),
         )
         self._init_response = await self._client.initialize_async(params)

--- a/tests/resources/lsp_transpiler/lsp_server.py
+++ b/tests/resources/lsp_transpiler/lsp_server.py
@@ -120,6 +120,11 @@ class TestLspServer(LanguageServer):
         ]
         register_params = RegistrationParams(registrations)
         await self.client_register_capability_async(register_params)
+        # ensure we can fetch a workspace file
+        uri = self.workspace.root_uri + "/workspace_file.yml"
+        doc = self.workspace.get_text_document(uri)
+        logger.debug(f"fetch-document-uri={uri}: {doc.source}")
+
 
     def transpile_to_databricks(self, params: TranspileDocumentParams) -> TranspileDocumentResult:
         source_sql = self.workspace.get_text_document(params.uri).source

--- a/tests/resources/lsp_transpiler/lsp_server.py
+++ b/tests/resources/lsp_transpiler/lsp_server.py
@@ -125,7 +125,6 @@ class TestLspServer(LanguageServer):
         doc = self.workspace.get_text_document(uri)
         logger.debug(f"fetch-document-uri={uri}: {doc.source}")
 
-
     def transpile_to_databricks(self, params: TranspileDocumentParams) -> TranspileDocumentResult:
         source_sql = self.workspace.get_text_document(params.uri).source
         source_lines = source_sql.split("\n")

--- a/tests/resources/lsp_transpiler/workspace_file.yml
+++ b/tests/resources/lsp_transpiler/workspace_file.yml
@@ -1,0 +1,1 @@
+test: test


### PR DESCRIPTION
As per LSP, rootUri is preferred over rootPath during initialization.
This PR fixes that and also tests loading a document at startup by the server.