### PR TITLE
Enhancement: Introduced mandatory password check for snowflake JDBC connection.

### DIFF
--- a/src/databricks/labs/remorph/reconcile/connectors/snowflake.py
+++ b/src/databricks/labs/remorph/reconcile/connectors/snowflake.py
@@ -61,9 +61,16 @@ class SnowflakeDataSource(DataSource, SecretsMixin, JDBCReaderMixin):
 
     @property
     def get_jdbc_url(self) -> str:
+        try:
+            sf_password = self._get_secret('sfPassword')
+        except (NotFound, KeyError) as e:
+            message = "sfPassword is mandatory for jdbc connectivity with Snowflake."
+            logger.error(message)
+            raise NotFound(message) from e
+
         return (
             f"jdbc:{SnowflakeDataSource._DRIVER}://{self._get_secret('sfAccount')}.snowflakecomputing.com"
-            f"/?user={self._get_secret('sfUser')}&password={self._get_secret('sfPassword')}"
+            f"/?user={self._get_secret('sfUser')}&password={sf_password}"
             f"&db={self._get_secret('sfDatabase')}&schema={self._get_secret('sfSchema')}"
             f"&warehouse={self._get_secret('sfWarehouse')}&role={self._get_secret('sfRole')}"
         )


### PR DESCRIPTION
PR: Introduced mandatory Password for snowflake connector when JDBC options are provided.

1. Added check for sfPassword while creating the JDBC URL for Snowflake connections.
2. If sfPassword is not found, it will fail with the following error 
`sfPassword is mandatory for jdbc connectivity with Snowflake.`

To test: Run recon with out sfPassword in Secret Scope along with jdbc_options.

Closes #issue-1449-mandatory_pwd_for_jdbc_options