### PR TITLE
Transpiler logging improvements

### DIFF
--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -118,7 +118,7 @@ def transpile(
     status, errors = asyncio.run(do_transpile(ctx.workspace_client, engine, config))
 
     for error in errors:
-        logger.error(f"Transpile error: {error}")
+        print(str(error))
 
     logger.info(f"Finished transpilation: {status}")
 

--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import os
 from pathlib import Path
 

--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 from pathlib import Path
 
@@ -120,7 +121,7 @@ def transpile(
     for error in errors:
         print(str(error))
 
-    logger.info(f"Finished transpilation: {status}")
+    print(json.dumps(status))
 
 
 def _override_workspace_client_config(ctx: ApplicationContext, overrides: dict[str, str] | None):

--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -119,9 +119,9 @@ def transpile(
     status, errors = asyncio.run(do_transpile(ctx.workspace_client, engine, config))
 
     for error in errors:
-        print(str(error))
+        logger.error(f"Transpile error: {error}")
 
-    print(json.dumps(status))
+    logger.info(f"Finished transpilation: {status}")
 
 
 def _override_workspace_client_config(ctx: ApplicationContext, overrides: dict[str, str] | None):

--- a/src/databricks/labs/remorph/helpers/execution_time.py
+++ b/src/databricks/labs/remorph/helpers/execution_time.py
@@ -14,7 +14,7 @@ def timeit(func):
         end_time = time.perf_counter()
         total_time = end_time - start_time
         name = inspect.getmodule(func).__name__.split(".")[3].capitalize()
-        logger.info(f"{name} Took {total_time:.4f} seconds")
+        logger.info(f"{name} took {total_time:.4f} seconds")
         return result
 
     return timeit_wrapper

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -164,13 +164,16 @@ async def _do_transpile(
     if config.input_source is None:
         raise InvalidInputException("Missing input source!")
     if config.input_path.is_dir():
+        logger.debug(f"Starting to process input directory: {config.input_path}")
         result = await _process_input_dir(config, validator, engine)
     elif config.input_path.is_file():
+        logger.debug(f"Starting to process input file: {config.input_path}")
         result = await _process_input_file(config, validator, engine)
     else:
         msg = f"{config.input_source} does not exist."
         logger.error(msg)
         raise FileNotFoundError(msg)
+    logger.debug(f"Transpiler results: {result}")
 
     if not config.skip_validation:
         logger.info(f"No of Sql Failed while Validating: {result.validation_error_count}")

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -133,7 +133,6 @@ async def _process_input_file(
     return TranspileStatus([config.input_path], no_of_sqls, error_list)
 
 
-@timeit
 async def transpile(
     workspace_client: WorkspaceClient, engine: TranspileEngine, config: TranspileConfig
 ) -> tuple[dict[str, Any], list[TranspileError]]:

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -83,7 +83,7 @@ async def _process_many_files(
     all_errors: list[TranspileError] = []
 
     for file in files:
-        logger.info(f"Processing file :{file}")
+        logger.info(f"Processing file: {file}")
         if not is_sql_file(file):
             continue
         output_file_name = output_folder / file.name
@@ -176,7 +176,7 @@ async def _do_transpile(
     logger.debug(f"Transpiler results: {result}")
 
     if not config.skip_validation:
-        logger.info(f"No of Sql Failed while Validating: {result.validation_error_count}")
+        logger.info(f"SQL validation errors: {result.validation_error_count}")
 
     error_log_path: Path | None = None
     if result.error_list:

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -40,7 +40,7 @@ async def _process_one_file(
     input_path: Path,
     output_path: Path,
 ) -> tuple[int, list[TranspileError]]:
-    logger.info(f"started processing for the file ${input_path}")
+    logger.debug(f"Started processing file: {input_path}")
     error_list: list[TranspileError] = []
 
     with input_path.open("r") as f:
@@ -68,6 +68,7 @@ async def _process_one_file(
             w.write(transpile_result.transpiled_code)
             w.write("\n;\n")
 
+    logger.info(f"Processed file: {input_path} (success: {transpile_result.success_count}, errors: {len(error_list)})")
     return transpile_result.success_count, error_list
 
 

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -49,11 +49,15 @@ async def _process_one_file(
     transpile_result = await _transpile(
         transpiler, config.source_dialect, config.target_dialect, source_sql, input_path
     )
+    logger.debug("Finished transpiling file: %s (result: %r)", input_path, transpile_result)
+
     error_list.extend(transpile_result.error_list)
 
     with output_path.open("w") as w:
         if validator:
+            logger.debug(f"Validating transpiled code for file: {input_path}")
             validation_result = _validation(validator, config, transpile_result.transpiled_code)
+            logger.debug("Finished validating transpiled code for file: %s (result: %r)", input_path, validation_result)
             w.write(validation_result.validated_sql)
             if validation_result.exception_msg is not None:
                 error = TranspileError(

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -49,7 +49,9 @@ async def _process_one_file(
     transpile_result = await _transpile(
         transpiler, config.source_dialect, config.target_dialect, source_sql, input_path
     )
-    logger.debug("Finished transpiling file: %s (result: %r)", input_path, transpile_result)
+    # Potentially expensive, only evaluate if debug is enabled
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(f"Finished transpiling file: {input_path} (result: {transpile_result})")
 
     error_list.extend(transpile_result.error_list)
 
@@ -57,7 +59,10 @@ async def _process_one_file(
         if validator:
             logger.debug(f"Validating transpiled code for file: {input_path}")
             validation_result = _validation(validator, config, transpile_result.transpiled_code)
-            logger.debug("Finished validating transpiled code for file: %s (result: %r)", input_path, validation_result)
+            # Potentially expensive, only evaluate if debug is enabled
+            if logger.isEnabledFor(logging.DEBUG):
+                msg = f"Finished validating transpiled code for file: {input_path} (result: {validation_result})"
+                logger.debug(msg)
             w.write(validation_result.validated_sql)
             if validation_result.exception_msg is not None:
                 error = TranspileError(

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -68,7 +68,7 @@ async def _process_one_file(
             w.write(transpile_result.transpiled_code)
             w.write("\n;\n")
 
-    logger.info(f"Processed file: {input_path} (success: {transpile_result.success_count}, errors: {len(error_list)})")
+    logger.info(f"Processed file: {input_path} (errors: {len(error_list)})")
     return transpile_result.success_count, error_list
 
 

--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -376,6 +376,7 @@ class LSPEngine(TranspileEngine):
         for name, value in self._config.remorph.env_vars.items():
             env[name] = value
         args = self._config.remorph.command_line[1:]
+        logger.debug(f"Starting LSP engine: {executable} {args} (cwd={os.getcwd()})")
         await self._client.start_io(executable, env=env, *args)
         input_path = config.input_path
         root_path = input_path if input_path.is_dir() else input_path.parent


### PR DESCRIPTION
This PR updates some of the logging when transpiling, mainly to improve the readability and help with debugging. Changes include:

 - Remove the timer. (It doesn't work because we're using coroutines and therefore it always reports 0.00 seconds before anything has started.)
 - Debug logging for the command used to launch the LSP program. (This helps with debugging when the plugin doesn't work.)
 - Minor formatting fixes.
 - Improved debug/info logging during transpilation progress.
 - ~Final output uses the logging facility instead of `print()`.~ Left as-is, it seems this is expected.