### PR TITLE
Configure lsp custom options during install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
 ]
 dependencies = [
   "databricks-sdk>=0.29,<0.42",
+  "pyspark>=3.5.5,<3.6",
   "sqlglot==26.1.3",
   "databricks-labs-blueprint[yaml]>=0.2.3",
   "databricks-labs-lsql>=0.7.5,<0.14.0",  # TODO: Limit the LSQL version until dependencies are correct.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
 dependencies = [
   "databricks-sdk>=0.29,<0.42",
   "databricks-connect==15.1",
+  "standard-distutils; python_version>='3.11'",
   "sqlglot==26.1.3",
   "databricks-labs-blueprint[yaml]>=0.2.3",
   "databricks-labs-lsql>=0.7.5,<0.14.0",  # TODO: Limit the LSQL version until dependencies are correct.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
   "databricks-sdk>=0.29,<0.42",
-  "pyspark>=3.5.5,<3.6",
+  "databricks-connect==15.1",
   "sqlglot==26.1.3",
   "databricks-labs-blueprint[yaml]>=0.2.3",
   "databricks-labs-lsql>=0.7.5,<0.14.0",  # TODO: Limit the LSQL version until dependencies are correct.

--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -6,10 +6,8 @@ from pathlib import Path
 
 from databricks.labs.blueprint.cli import App
 from databricks.labs.blueprint.entrypoint import get_logger
-from mypy.semanal_shared import parse_bool
 
 from databricks.labs.remorph.assessments.configure_assessment import ConfigureAssessment
-from databricks.labs.remorph.config import TranspileConfig
 from databricks.labs.remorph.connections.credential_manager import create_credential_manager
 from databricks.labs.remorph.connections.env_getter import EnvGetter
 from databricks.labs.remorph.contexts.application import ApplicationContext
@@ -102,7 +100,7 @@ def transpile(
     if error_file_path:
         config = dataclasses.replace(config, error_file_path=error_file_path)
     if skip_validation is not None:
-        config = dataclasses.replace(config, skip_validation=parse_bool(skip_validation.capitalize()))
+        config = dataclasses.replace(config, skip_validation=skip_validation.lower()=="true")
     if catalog_name:
         config = dataclasses.replace(config, catalog_name=catalog_name)
     if schema_name:

--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -90,7 +90,6 @@ def transpile(
     _override_workspace_client_config(ctx, config.sdk_config)
     if transpiler_config_path:
         config = dataclasses.replace(config,transpiler_config_path=transpiler_config_path)
-    engine = TranspileEngine.load_engine(Path(transpiler_config_path))
     if source_dialect:
         config = dataclasses.replace(config,source_dialect=source_dialect)
     if input_source:
@@ -105,7 +104,7 @@ def transpile(
         config = dataclasses.replace(config, catalog_name=catalog_name)
     if schema_name:
         config = dataclasses.replace(config, schema_name=schema_name)
-
+    engine = TranspileEngine.load_engine(Path(config.transpiler_config_path))
     engine.check_source_dialect(config.source_dialect)
     if not config.input_source or not os.path.exists(config.input_source):
         raise_validation_exception(f"Invalid value for '--input-source': Path '{config.input_source}' does not exist.")

--- a/src/databricks/labs/remorph/config.py
+++ b/src/databricks/labs/remorph/config.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class LSPPromptMethod(Enum):
-    FORCE = auto() # for mandatory values that are specific to a dialect
+    FORCE = auto()  # for mandatory values that are specific to a dialect
     QUESTION = auto()
     CHOICE = auto()
     CONFIRM = auto()
@@ -30,7 +30,7 @@ class LSPConfigOptionV1:
 
     @classmethod
     def parse_all(cls, data: dict[str, Any]) -> dict[str, list[LSPConfigOptionV1]]:
-        return { key: list(LSPConfigOptionV1.parse(item) for item in value) for (key, value) in data.items() }
+        return {key: list(LSPConfigOptionV1.parse(item) for item in value) for (key, value) in data.items()}
 
     @classmethod
     def parse(cls, data: Any) -> LSPConfigOptionV1:
@@ -42,10 +42,7 @@ class LSPConfigOptionV1:
         method_name: str = data.get("method", "")
         if not method_name:
             raise ValueError(f"Missing 'method' entry in {data}")
-        try:
-            method: LSPPromptMethod = cast(LSPPromptMethod, LSPPromptMethod[method_name])
-        except:
-            raise ValueError(f"Invalid transpiler config option, expecting a prompt method, got {method_name}")
+        method: LSPPromptMethod = cast(LSPPromptMethod, LSPPromptMethod[method_name])
         prompt: str = data.get("prompt", "")
         if not prompt:
             raise ValueError(f"Missing 'prompt' entry in {data}")
@@ -68,7 +65,9 @@ class TranspileConfig:
     skip_validation: bool = False
     catalog_name: str = "remorph"
     schema_name: str = "transpiler"
-    transpiler_options: dict[str, bool | str | int | float | object | list] | None = None # need a union because blueprint doesn't support 'Any' type
+    transpiler_options: dict[str, bool | str | int | float | object | list] | None = (
+        None  # need a union because blueprint doesn't support 'Any' type
+    )
 
     @property
     def transpiler_path(self):

--- a/src/databricks/labs/remorph/config.py
+++ b/src/databricks/labs/remorph/config.py
@@ -24,9 +24,9 @@ class LSPPromptMethod(Enum):
 class LSPConfigOptionV1:
     flag: str
     method: LSPPromptMethod
-    prompt: str
-    choices: list[str] | None
-    default: str | None
+    prompt: str = ""
+    choices: list[str] | None = None
+    default: Any = None
 
     @classmethod
     def parse_all(cls, data: dict[str, Any]) -> dict[str, list[LSPConfigOptionV1]]:
@@ -68,7 +68,7 @@ class TranspileConfig:
     skip_validation: bool = False
     catalog_name: str = "remorph"
     schema_name: str = "transpiler"
-    transpiler_options: dict[str, str] | None = None
+    transpiler_options: dict[str, bool | str | int | float | object | list] | None = None # need a union because blueprint doesn't support 'Any' type
 
     @property
     def transpiler_path(self):

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -72,11 +72,14 @@ class TranspilerInstaller(abc.ABC):
 
     @classmethod
     def get_maven_version(cls, group_id: str, artifact_id: str) -> str | None:
-        url = f"https://search.maven.org/solrsearch/select?q=g:{group_id}+AND+a:{artifact_id}&core=gav&rows=1&wt=json"
-        with request.urlopen(url) as server:
-            text = server.read()
-        data: dict[str, Any] = loads(text)
-        return data.get("response", {}).get('docs', [{}])[0].get("v", None)
+        try:
+            url = f"https://search.maven.org/solrsearch/select?q=g:{group_id}+AND+a:{artifact_id}&core=gav&rows=1&wt=json"
+            with request.urlopen(url) as server:
+                text = server.read()
+            data: dict[str, Any] = loads(text)
+            return data.get("response", {}).get('docs', [{}])[0].get("v", None)
+        except:
+            return None
 
     @classmethod
     def download_from_maven(cls, group_id: str, artifact_id: str, version: str, target: Path, extension="jar"):
@@ -95,10 +98,13 @@ class TranspilerInstaller(abc.ABC):
 
     @classmethod
     def get_pypi_version(cls, product_name: str) -> str | None:
-        with request.urlopen(f"https://pypi.org/pypi/{product_name}/json") as server:
-            text = server.read()
-        data: dict[str, Any] = loads(text)
-        return data.get("info", {}).get('version', None)
+        try:
+            with request.urlopen(f"https://pypi.org/pypi/{product_name}/json") as server:
+                text = server.read()
+            data: dict[str, Any] = loads(text)
+            return data.get("info", {}).get('version', None)
+        except:
+            return None
 
     @classmethod
     def install_from_pypi(cls, product_name: str, pypi_name: str):
@@ -216,6 +222,8 @@ class MorpheusInstaller(TranspilerInstaller):
         if current_version == latest_version:
             logger.info(f"Databricks Morpheus transpiler v{latest_version} already installed")
             return
+        if latest_version is None:
+            return
         logger.info(f"Installing Databricks Morpheus transpiler v{latest_version}")
         product_path = cls.transpilers_path() / cls.MORPHEUS_TRANSPILER_NAME
         if current_version is not None:
@@ -279,7 +287,7 @@ class WorkspaceInstaller:
         module: str,
         config: RemorphConfigs | None = None,
     ) -> RemorphConfigs:
-        if module in {"transpiler", "all"}:
+        if module in {"transpile", "all"}:
             self.install_rct()
             self.install_morpheus()
         logger.info(f"Installing Remorph v{self._product_info.version()}")

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -181,8 +181,13 @@ class TranspilerInstaller(abc.ABC):
 
     @classmethod
     def _transpiler_config(cls, path: Path) -> LSPConfig | None:
+        if not path.is_dir() or not (path / "lib").is_dir():
+            return None
+        config_path = path / "lib" / "config.yml"
+        if not config_path.is_file():
+            return None
         try:
-            return LSPConfig.load(path / "lib" / "config.yml")
+            return LSPConfig.load(config_path)
         except ValueError as e:
             logger.error(f"Could not load config: {path!s}", exc_info=e)
             return None

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -261,7 +261,7 @@ class WorkspaceInstaller:
         module: str,
         config: RemorphConfigs | None = None,
     ) -> RemorphConfigs:
-        if module in ("transpiler", "all"):
+        if module in {"transpiler", "all"}:
             self.install_rct()
             self.install_morpheus()
         logger.info(f"Installing Remorph v{self._product_info.version()}")

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -182,7 +182,8 @@ class TranspilerInstaller(abc.ABC):
     def _transpiler_config(cls, path: Path) -> LSPConfig | None:
         try:
             return LSPConfig.load(path / "lib" / "config.yml")
-        except ValueError:
+        except ValueError as e:
+            logger.error(f"Could not load config: {path!s}", exc_info=e)
             return None
 
 

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -28,14 +28,13 @@ from databricks.labs.remorph.config import (
     ReconcileConfig,
     DatabaseConfig,
     RemorphConfigs,
-    ReconcileMetadataConfig,
+    ReconcileMetadataConfig, LSPConfigOptionV1, LSPPromptMethod,
 )
 
 from databricks.labs.remorph.deployment.configurator import ResourceConfigurator
 from databricks.labs.remorph.deployment.installation import WorkspaceInstallation
 from databricks.labs.remorph.reconcile.constants import ReconReportType, ReconSourceType
 from databricks.labs.remorph.transpiler.lsp.lsp_engine import LSPConfig
-
 
 logger = logging.getLogger(__name__)
 
@@ -156,12 +155,24 @@ class TranspilerInstaller(abc.ABC):
 
     @classmethod
     def transpiler_config_path(cls, transpiler_name):
-        config = cls.all_transpiler_configs()[transpiler_name]
+        config = cls.all_transpiler_configs().get(transpiler_name, None)
+        if not config:
+            raise ValueError(f"No such transpiler: {transpiler_name}")
         return f"{config.path!s}"
 
     @classmethod
+    def transpiler_config_options(cls, transpiler_name, source_dialect) -> list[LSPConfigOptionV1]:
+        config = cls.all_transpiler_configs().get(transpiler_name, None)
+        if not config:
+            return [] # gracefully returns an empty list, since this can only happen during testing
+        return config.options.get(source_dialect, config.options.get("all", []))
+
+    @classmethod
     def _all_transpiler_configs(cls) -> Iterable[LSPConfig]:
-        all_files = os.listdir(cls.transpilers_path())
+        path = cls.transpilers_path()
+        if not path.exists():
+            return []
+        all_files = os.listdir(path)
         for file in all_files:
             config = cls._transpiler_config(cls.transpilers_path() / file)
             if config:
@@ -173,6 +184,7 @@ class TranspilerInstaller(abc.ABC):
             return LSPConfig.load(path / "lib" / "config.yml")
         except ValueError:
             return None
+
 
 
 class RCTInstaller(TranspilerInstaller):
@@ -361,6 +373,7 @@ class WorkspaceInstaller:
             transpiler_name = next(t for t in transpilers)
             logger.info(f"Remorph will use the {transpiler_name} transpiler")
         transpiler_config_path = self._transpiler_config_path(transpiler_name)
+        transpiler_options = self._prompt_for_transpiler_options(transpiler_name, source_dialect)
         input_source = self._prompts.question("Enter input SQL path (directory/file)")
         output_folder = self._prompts.question("Enter output directory", default="transpiled")
         error_file_path = self._prompts.question("Enter error file path", default="errors.log")
@@ -370,12 +383,29 @@ class WorkspaceInstaller:
 
         return TranspileConfig(
             transpiler_config_path=transpiler_config_path,
+            transpiler_options=transpiler_options,
             source_dialect=source_dialect,
             skip_validation=(not run_validation),
             input_source=input_source,
             output_folder=output_folder,
             error_file_path=error_file_path,
         )
+
+    def _prompt_for_transpiler_options(self, transpiler_name: str, source_dialect: str) -> dict[str, Any]:
+        config_options = TranspilerInstaller.transpiler_config_options(transpiler_name, source_dialect)
+        return { cfg.flag: self._prompt_for_transpiler_option(cfg) for cfg in config_options }
+
+    def _prompt_for_transpiler_option(self, config_option: LSPConfigOptionV1) -> Any:
+        if config_option.method == LSPPromptMethod.FORCE:
+            return config_option.default
+        elif config_option.method == LSPPromptMethod.CONFIRM:
+            return self._prompts.confirm(config_option.prompt)
+        elif config_option.method == LSPPromptMethod.QUESTION:
+            return self._prompts.question(config_option.prompt, default=config_option.default)
+        elif config_option.method == LSPPromptMethod.CHOICE:
+            return self._prompts.choice(config_option.prompt, config_option.choices)
+        else:
+            raise ValueError(f"Unsupported prompt method: {config_option.method}")
 
     def _configure_catalog(
         self,

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -261,8 +261,9 @@ class WorkspaceInstaller:
         module: str,
         config: RemorphConfigs | None = None,
     ) -> RemorphConfigs:
-        self.install_rct()
-        self.install_morpheus()
+        if module == "transpiler":
+            self.install_rct()
+            self.install_morpheus()
         logger.info(f"Installing Remorph v{self._product_info.version()}")
         if not config:
             config = self.configure(module)

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -261,7 +261,7 @@ class WorkspaceInstaller:
         module: str,
         config: RemorphConfigs | None = None,
     ) -> RemorphConfigs:
-        if module == "transpiler":
+        if module in ("transpiler", "all"):
             self.install_rct()
             self.install_morpheus()
         logger.info(f"Installing Remorph v{self._product_info.version()}")

--- a/src/databricks/labs/remorph/resources/transpilers/rct/lib/config.yml
+++ b/src/databricks/labs/remorph/resources/transpilers/rct/lib/config.yml
@@ -19,5 +19,8 @@ remorph:
   command_line:
     - python
     - databricks/labs/remorph/transpiler/server.py
-custom:
-  experimental: true
+options:
+  all:
+    - flag: "-experimental"
+      method: CONFIRM
+      prompt: Do you want to use the experimental Databricks generator ?

--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -7,9 +7,8 @@ import os
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
-from enum import Enum, auto
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 import attrs
 import yaml

--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -402,6 +402,7 @@ class LSPEngine(TranspileEngine):
             "remorph": {
                 "source-dialect": config.source_dialect,
             },
+            "options": config.transpiler_options,
             "custom": self._config.custom,
         }
 

--- a/tests/resources/lsp_transpiler/lsp_config.yml
+++ b/tests/resources/lsp_transpiler/lsp_config.yml
@@ -9,5 +9,10 @@ remorph:
     - python
     - lsp_server.py
     - --stuff=12
+options:
+  all:
+    - flag: "-experimental"
+      method: CONFIRM
+      prompt: Do you want to use the experimental Databricks generator ?
 custom:
   whatever: xyz

--- a/tests/resources/lsp_transpiler/lsp_server.py
+++ b/tests/resources/lsp_transpiler/lsp_server.py
@@ -105,15 +105,17 @@ class TestLspServer(LanguageServer):
         return self.initialization_options["remorph"]["source-dialect"]
 
     @property
-    def experimental(self) -> str:
-        return self.initialization_options["options"]["-experimental"]
+    def experimental(self) -> str | None:
+        options = self.initialization_options.get("options", {}) or {}
+        return options.get("-experimental", None)
 
     @property
-    def whatever(self) -> str:
-        return self.initialization_options["custom"]["whatever"]
+    def whatever(self) -> str | None:
+        custom = self.initialization_options.get("custom", {}) or {}
+        return custom.get("whatever", None)
 
     async def did_initialize(self, init_params: InitializeParams) -> None:
-        self.initialization_options = init_params.initialization_options
+        self.initialization_options = init_params.initialization_options or {}
         logger.debug(f"dialect={self.dialect}")
         logger.debug(f"whatever={self.whatever}")
         logger.debug(f"experimental={self.experimental}")

--- a/tests/resources/lsp_transpiler/lsp_server.py
+++ b/tests/resources/lsp_transpiler/lsp_server.py
@@ -105,6 +105,10 @@ class TestLspServer(LanguageServer):
         return self.initialization_options["remorph"]["source-dialect"]
 
     @property
+    def experimental(self) -> str:
+        return self.initialization_options["options"]["-experimental"]
+
+    @property
     def whatever(self) -> str:
         return self.initialization_options["custom"]["whatever"]
 
@@ -112,6 +116,7 @@ class TestLspServer(LanguageServer):
         self.initialization_options = init_params.initialization_options
         logger.debug(f"dialect={self.dialect}")
         logger.debug(f"whatever={self.whatever}")
+        logger.debug(f"experimental={self.experimental}")
         # TODO check whether the client supports dynamic registration
         registrations = [
             Registration(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -38,6 +38,7 @@ def mock_databricks_config():
 def transpile_config():
     yield TranspileConfig(
         transpiler_config_path="sqlglot",
+        transpiler_options={"-experimental": True},
         source_dialect="snowflake",
         input_source="input_sql",
         output_folder="output_folder",

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -5,8 +5,14 @@ from databricks.labs.blueprint.installation import MockInstallation
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import iam
 from databricks.labs.blueprint.tui import MockPrompts
-from databricks.labs.remorph.config import RemorphConfigs, ReconcileConfig, DatabaseConfig, ReconcileMetadataConfig, \
-    LSPConfigOptionV1, LSPPromptMethod
+from databricks.labs.remorph.config import (
+    RemorphConfigs,
+    ReconcileConfig,
+    DatabaseConfig,
+    ReconcileMetadataConfig,
+    LSPConfigOptionV1,
+    LSPPromptMethod,
+)
 from databricks.labs.remorph.contexts.application import ApplicationContext
 from databricks.labs.remorph.deployment.configurator import ResourceConfigurator
 from databricks.labs.remorph.deployment.installation import WorkspaceInstallation
@@ -1098,6 +1104,7 @@ def test_runs_upgrades_on_more_recent_version(ws_installer, ws):
         )
     )
 
+
 def test_runs_and_stores_confirm_config_option(ws_installer, ws):
     prompts = MockPrompts(
         {
@@ -1136,7 +1143,7 @@ def test_runs_and_stores_confirm_config_option(ws_installer, ws):
         ctx.workspace_installation,
     )
 
-    TranspilerInstaller.transpilers_path = lambda: TranspilerInstaller.resources_folder()
+    TranspilerInstaller.transpilers_path = TranspilerInstaller.resources_folder
 
     config = workspace_installer.configure(module="transpile")
 
@@ -1169,6 +1176,7 @@ def test_runs_and_stores_confirm_config_option(ws_installer, ws):
             "version": 3,
         },
     )
+
 
 def test_runs_and_stores_force_config_option(ws_installer, ws):
     prompts = MockPrompts(
@@ -1207,7 +1215,9 @@ def test_runs_and_stores_force_config_option(ws_installer, ws):
         ctx.workspace_installation,
     )
 
-    TranspilerInstaller.transpiler_config_options = lambda a, b: [ LSPConfigOptionV1(flag="-XX", method=LSPPromptMethod.FORCE, default=1254) ]
+    TranspilerInstaller.transpiler_config_options = lambda a, b: [
+        LSPConfigOptionV1(flag="-XX", method=LSPPromptMethod.FORCE, default=1254)
+    ]
 
     config = workspace_installer.configure(module="transpile")
 
@@ -1240,6 +1250,7 @@ def test_runs_and_stores_force_config_option(ws_installer, ws):
             "version": 3,
         },
     )
+
 
 def test_runs_and_stores_question_config_option(ws_installer, ws):
     prompts = MockPrompts(
@@ -1279,7 +1290,9 @@ def test_runs_and_stores_question_config_option(ws_installer, ws):
         ctx.workspace_installation,
     )
 
-    TranspilerInstaller.transpiler_config_options = lambda a, b: [ LSPConfigOptionV1(flag="-XX", method=LSPPromptMethod.QUESTION, prompt="Max number of heaps:") ]
+    TranspilerInstaller.transpiler_config_options = lambda a, b: [
+        LSPConfigOptionV1(flag="-XX", method=LSPPromptMethod.QUESTION, prompt="Max number of heaps:")
+    ]
 
     config = workspace_installer.configure(module="transpile")
 
@@ -1352,7 +1365,14 @@ def test_runs_and_stores_choice_config_option(ws_installer, ws):
         ctx.workspace_installation,
     )
 
-    TranspilerInstaller.transpiler_config_options = lambda a, b: [ LSPConfigOptionV1(flag="-currency", method=LSPPromptMethod.CHOICE, prompt="Select currency:", choices=["CHF", "EUR", "GBP", "USD"]) ]
+    TranspilerInstaller.transpiler_config_options = lambda a, b: [
+        LSPConfigOptionV1(
+            flag="-currency",
+            method=LSPPromptMethod.CHOICE,
+            prompt="Select currency:",
+            choices=["CHF", "EUR", "GBP", "USD"],
+        )
+    ]
 
     config = workspace_installer.configure(module="transpile")
 

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -29,7 +29,7 @@ def ws():
 
 ALL_INSTALLED_DIALECTS = sorted(["tsql", "snowflake"])
 TRANSPILERS_FOR_SNOWFLAKE = sorted(["Remorph Community Transpiler", "Morpheus"])
-PATH_TO_TRANSPILER_COMFIG = "/some/path/to/config.yml"
+PATH_TO_TRANSPILER_CONFIG = "/some/path/to/config.yml"
 
 
 @pytest.fixture()
@@ -53,7 +53,7 @@ def ws_installer():
             return TRANSPILERS_FOR_SNOWFLAKE
 
         def _transpiler_config_path(self, transpiler):
-            return PATH_TO_TRANSPILER_COMFIG
+            return PATH_TO_TRANSPILER_CONFIG
 
     def installer(*args, **kwargs) -> WorkspaceInstaller:
         return TestWorkspaceInstaller(*args, **kwargs)
@@ -183,7 +183,7 @@ def test_workspace_installer_run_install_called_with_generated_config(ws_install
         "config.yml",
         {
             "catalog_name": "remorph",
-            "transpiler_config_path": PATH_TO_TRANSPILER_COMFIG,
+            "transpiler_config_path": PATH_TO_TRANSPILER_CONFIG,
             "source_dialect": "snowflake",
             "input_source": "/tmp/queries/snow",
             "output_folder": "/tmp/queries/databricks",
@@ -228,7 +228,7 @@ def test_configure_transpile_no_existing_installation(ws_installer, ws):
 
     config = workspace_installer.configure(module="transpile")
     expected_morph_config = TranspileConfig(
-        transpiler_config_path=PATH_TO_TRANSPILER_COMFIG,
+        transpiler_config_path=PATH_TO_TRANSPILER_CONFIG,
         transpiler_options={},
         source_dialect="snowflake",
         input_source="/tmp/queries/snow",
@@ -244,7 +244,7 @@ def test_configure_transpile_no_existing_installation(ws_installer, ws):
         "config.yml",
         {
             "catalog_name": "remorph",
-            "transpiler_config_path": PATH_TO_TRANSPILER_COMFIG,
+            "transpiler_config_path": PATH_TO_TRANSPILER_CONFIG,
             "input_source": "/tmp/queries/snow",
             "output_folder": "/tmp/queries/databricks",
             "error_file_path": "/tmp/queries/errors.log",
@@ -270,7 +270,7 @@ def test_configure_transpile_installation_no_override(ws):
         installation=MockInstallation(
             {
                 "config.yml": {
-                    "transpiler_config_path": PATH_TO_TRANSPILER_COMFIG,
+                    "transpiler_config_path": PATH_TO_TRANSPILER_CONFIG,
                     "source_dialect": "snowflake",
                     "catalog_name": "transpiler_test",
                     "input_source": "sf_queries",
@@ -348,7 +348,7 @@ def test_configure_transpile_installation_config_error_continue_install(ws_insta
     config = workspace_installer.configure(module="transpile")
 
     expected_morph_config = TranspileConfig(
-        transpiler_config_path=PATH_TO_TRANSPILER_COMFIG,
+        transpiler_config_path=PATH_TO_TRANSPILER_CONFIG,
         transpiler_options={},
         source_dialect="snowflake",
         input_source="/tmp/queries/snow",
@@ -363,7 +363,7 @@ def test_configure_transpile_installation_config_error_continue_install(ws_insta
     installation.assert_file_written(
         "config.yml",
         {
-            "transpiler_config_path": PATH_TO_TRANSPILER_COMFIG,
+            "transpiler_config_path": PATH_TO_TRANSPILER_CONFIG,
             "catalog_name": "remorph",
             "input_source": "/tmp/queries/snow",
             "output_folder": "/tmp/queries/databricks",
@@ -411,7 +411,7 @@ def test_configure_transpile_installation_with_no_validation(ws, ws_installer):
     config = workspace_installer.configure(module="transpile")
 
     expected_morph_config = TranspileConfig(
-        transpiler_config_path=PATH_TO_TRANSPILER_COMFIG,
+        transpiler_config_path=PATH_TO_TRANSPILER_CONFIG,
         transpiler_options={},
         source_dialect="snowflake",
         input_source="/tmp/queries/snow",
@@ -426,7 +426,7 @@ def test_configure_transpile_installation_with_no_validation(ws, ws_installer):
     installation.assert_file_written(
         "config.yml",
         {
-            "transpiler_config_path": PATH_TO_TRANSPILER_COMFIG,
+            "transpiler_config_path": PATH_TO_TRANSPILER_CONFIG,
             "catalog_name": "remorph",
             "input_source": "/tmp/queries/snow",
             "output_folder": "/tmp/queries/databricks",
@@ -481,7 +481,7 @@ def test_configure_transpile_installation_with_validation_and_cluster_id_in_conf
 
     expected_config = RemorphConfigs(
         transpile=TranspileConfig(
-            transpiler_config_path=PATH_TO_TRANSPILER_COMFIG,
+            transpiler_config_path=PATH_TO_TRANSPILER_CONFIG,
             transpiler_options={},
             source_dialect="snowflake",
             input_source="/tmp/queries/snow",
@@ -496,7 +496,7 @@ def test_configure_transpile_installation_with_validation_and_cluster_id_in_conf
     installation.assert_file_written(
         "config.yml",
         {
-            "transpiler_config_path": PATH_TO_TRANSPILER_COMFIG,
+            "transpiler_config_path": PATH_TO_TRANSPILER_CONFIG,
             "catalog_name": "remorph_test",
             "input_source": "/tmp/queries/snow",
             "output_folder": "/tmp/queries/databricks",
@@ -552,7 +552,7 @@ def test_configure_transpile_installation_with_validation_and_cluster_id_from_pr
 
     expected_config = RemorphConfigs(
         transpile=TranspileConfig(
-            transpiler_config_path=PATH_TO_TRANSPILER_COMFIG,
+            transpiler_config_path=PATH_TO_TRANSPILER_CONFIG,
             transpiler_options={},
             source_dialect="snowflake",
             input_source="/tmp/queries/snow",
@@ -567,7 +567,7 @@ def test_configure_transpile_installation_with_validation_and_cluster_id_from_pr
     installation.assert_file_written(
         "config.yml",
         {
-            "transpiler_config_path": PATH_TO_TRANSPILER_COMFIG,
+            "transpiler_config_path": PATH_TO_TRANSPILER_CONFIG,
             "catalog_name": "remorph_test",
             "input_source": "/tmp/queries/snow",
             "output_folder": "/tmp/queries/databricks",
@@ -621,7 +621,7 @@ def test_configure_transpile_installation_with_validation_and_warehouse_id_from_
 
     expected_config = RemorphConfigs(
         transpile=TranspileConfig(
-            transpiler_config_path=PATH_TO_TRANSPILER_COMFIG,
+            transpiler_config_path=PATH_TO_TRANSPILER_CONFIG,
             transpiler_options={},
             source_dialect="snowflake",
             input_source="/tmp/queries/snow",
@@ -636,7 +636,7 @@ def test_configure_transpile_installation_with_validation_and_warehouse_id_from_
     installation.assert_file_written(
         "config.yml",
         {
-            "transpiler_config_path": PATH_TO_TRANSPILER_COMFIG,
+            "transpiler_config_path": PATH_TO_TRANSPILER_CONFIG,
             "catalog_name": "remorph_test",
             "input_source": "/tmp/queries/snow",
             "output_folder": "/tmp/queries/databricks",
@@ -894,7 +894,7 @@ def test_configure_all_override_installation(ws_installer, ws):
     installation = MockInstallation(
         {
             "config.yml": {
-                "transpiler_config_path": PATH_TO_TRANSPILER_COMFIG,
+                "transpiler_config_path": PATH_TO_TRANSPILER_CONFIG,
                 "source_dialect": "snowflake",
                 "catalog_name": "transpiler_test",
                 "input_source": "sf_queries",
@@ -952,7 +952,7 @@ def test_configure_all_override_installation(ws_installer, ws):
     config = workspace_installer.configure(module="all")
 
     expected_transpile_config = TranspileConfig(
-        transpiler_config_path=PATH_TO_TRANSPILER_COMFIG,
+        transpiler_config_path=PATH_TO_TRANSPILER_CONFIG,
         transpiler_options={},
         source_dialect="snowflake",
         input_source="/tmp/queries/snow",
@@ -984,7 +984,7 @@ def test_configure_all_override_installation(ws_installer, ws):
     installation.assert_file_written(
         "config.yml",
         {
-            "transpiler_config_path": PATH_TO_TRANSPILER_COMFIG,
+            "transpiler_config_path": PATH_TO_TRANSPILER_CONFIG,
             "catalog_name": "remorph",
             "input_source": "/tmp/queries/snow",
             "output_folder": "/tmp/queries/databricks",
@@ -1029,7 +1029,7 @@ def test_runs_upgrades_on_more_recent_version(ws_installer, ws):
                 }
             },
             'config.yml': {
-                "transpiler-config-path": PATH_TO_TRANSPILER_COMFIG,
+                "transpiler-config-path": PATH_TO_TRANSPILER_CONFIG,
                 "source_dialect": "snowflake",
                 "catalog_name": "upgrades",
                 "input_source": "queries",
@@ -1084,7 +1084,7 @@ def test_runs_upgrades_on_more_recent_version(ws_installer, ws):
     mock_workspace_installation.install.assert_called_once_with(
         RemorphConfigs(
             transpile=TranspileConfig(
-                transpiler_config_path=PATH_TO_TRANSPILER_COMFIG,
+                transpiler_config_path=PATH_TO_TRANSPILER_CONFIG,
                 transpiler_options={},
                 source_dialect="snowflake",
                 input_source="/tmp/queries/snow",

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -229,6 +229,7 @@ def test_configure_transpile_no_existing_installation(ws_installer, ws):
     config = workspace_installer.configure(module="transpile")
     expected_morph_config = TranspileConfig(
         transpiler_config_path=PATH_TO_TRANSPILER_COMFIG,
+        transpiler_options={},
         source_dialect="snowflake",
         input_source="/tmp/queries/snow",
         output_folder="/tmp/queries/databricks",
@@ -348,6 +349,7 @@ def test_configure_transpile_installation_config_error_continue_install(ws_insta
 
     expected_morph_config = TranspileConfig(
         transpiler_config_path=PATH_TO_TRANSPILER_COMFIG,
+        transpiler_options={},
         source_dialect="snowflake",
         input_source="/tmp/queries/snow",
         output_folder="/tmp/queries/databricks",
@@ -410,6 +412,7 @@ def test_configure_transpile_installation_with_no_validation(ws, ws_installer):
 
     expected_morph_config = TranspileConfig(
         transpiler_config_path=PATH_TO_TRANSPILER_COMFIG,
+        transpiler_options={},
         source_dialect="snowflake",
         input_source="/tmp/queries/snow",
         output_folder="/tmp/queries/databricks",
@@ -479,6 +482,7 @@ def test_configure_transpile_installation_with_validation_and_cluster_id_in_conf
     expected_config = RemorphConfigs(
         transpile=TranspileConfig(
             transpiler_config_path=PATH_TO_TRANSPILER_COMFIG,
+            transpiler_options={},
             source_dialect="snowflake",
             input_source="/tmp/queries/snow",
             output_folder="/tmp/queries/databricks",
@@ -549,6 +553,7 @@ def test_configure_transpile_installation_with_validation_and_cluster_id_from_pr
     expected_config = RemorphConfigs(
         transpile=TranspileConfig(
             transpiler_config_path=PATH_TO_TRANSPILER_COMFIG,
+            transpiler_options={},
             source_dialect="snowflake",
             input_source="/tmp/queries/snow",
             output_folder="/tmp/queries/databricks",
@@ -617,6 +622,7 @@ def test_configure_transpile_installation_with_validation_and_warehouse_id_from_
     expected_config = RemorphConfigs(
         transpile=TranspileConfig(
             transpiler_config_path=PATH_TO_TRANSPILER_COMFIG,
+            transpiler_options={},
             source_dialect="snowflake",
             input_source="/tmp/queries/snow",
             output_folder="/tmp/queries/databricks",
@@ -947,6 +953,7 @@ def test_configure_all_override_installation(ws_installer, ws):
 
     expected_transpile_config = TranspileConfig(
         transpiler_config_path=PATH_TO_TRANSPILER_COMFIG,
+        transpiler_options={},
         source_dialect="snowflake",
         input_source="/tmp/queries/snow",
         output_folder="/tmp/queries/databricks",
@@ -1078,6 +1085,7 @@ def test_runs_upgrades_on_more_recent_version(ws_installer, ws):
         RemorphConfigs(
             transpile=TranspileConfig(
                 transpiler_config_path=PATH_TO_TRANSPILER_COMFIG,
+                transpiler_options={},
                 source_dialect="snowflake",
                 input_source="/tmp/queries/snow",
                 output_folder="/tmp/queries/databricks",

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -49,6 +49,11 @@ async def test_sets_env_variables(lsp_engine, transpile_config):
     assert "SOME_ENV=abc" in log  # see environment in lsp_transpiler/config.yml
     await lsp_engine.shutdown()
 
+async def test_passes_options(lsp_engine, transpile_config):
+    await lsp_engine.initialize(transpile_config)
+    log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
+    assert "experimental=True" in log  # see environment in lsp_transpiler/config.yml
+    await lsp_engine.shutdown()
 
 async def test_passes_extra_args(lsp_engine, transpile_config):
     await lsp_engine.initialize(transpile_config)

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -49,11 +49,13 @@ async def test_sets_env_variables(lsp_engine, transpile_config):
     assert "SOME_ENV=abc" in log  # see environment in lsp_transpiler/config.yml
     await lsp_engine.shutdown()
 
+
 async def test_passes_options(lsp_engine, transpile_config):
     await lsp_engine.initialize(transpile_config)
     log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
     assert "experimental=True" in log  # see environment in lsp_transpiler/config.yml
     await lsp_engine.shutdown()
+
 
 async def test_passes_extra_args(lsp_engine, transpile_config):
     await lsp_engine.initialize(transpile_config)


### PR DESCRIPTION
Each transpiler may require options that `remorph` doesn't know about, but need to be configured via the CLI before 
calling the transpiler.

This PR implements a mechanism for doing so, as follows:
 - the `TranspileConfig` structure now comprises a `transpiler_options` entry that can hold key/value pairs
 - the transpiler `config.yml` now comprises an optional `options` section which describes CLI actions for populating the `transpiler_options` above. 4 actions are supported: `FORCE`, `CONFIRM`, `QUESTION` and `CHOICE`. 
 - the CLI uses the above section to interact with the user and gather configuration options
 - the LSP client passes these options to the server as part of initialization

Fixes #1478
 