### PR TITLE
Fix labs.yml

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -13,26 +13,25 @@ commands:
     flags:
       - name: transpiler-config-path
         description: Path to the transpiler configuration file
-        default: sqlglot
       - name: source-dialect
         description: Dialect name
-        default: None
+        default: null
       - name: input-source
         description: Input SQL Folder or File
       - name: output-folder
-        default: None
+        default: null
         description: Output Location For Storing Transpiled Code, defaults to input-source folder
       - name: error-file-path
-        default: None
+        default: null
         description: Output Location For Storing Errors, defaults to input-source folder
       - name: skip-validation
         default: true
         description: Validate Transpiled Code, default True validation skipped, False validate
       - name: catalog-name
-        default: None
+        default: null
         description: Catalog Name Applicable only when Validation Mode is DATABRICKS
       - name: schema-name
-        default: None
+        default: null
         description: Schema Name Applicable only when Validation Mode is DATABRICKS
 
     table_template: |-


### PR DESCRIPTION
Our current `labs.yml` uses the literal `None` for default values.
However, the labs installer is written in `go` and expects go literals only. As such it incorrectly interprets `None` as a string literal, leading to all sorts of issues...
This PR fixes the issue by replacing `None` with `null`.