### PR TITLE
Drop proxy commands

### DIFF
--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -35,13 +35,6 @@ def raise_validation_exception(msg: str) -> Exception:
     raise ValueError(msg)
 
 
-proxy_command(remorph, "debug-script")
-proxy_command(remorph, "debug-me")
-proxy_command(remorph, "debug-coverage")
-proxy_command(remorph, "debug-estimate")
-proxy_command(remorph, "debug-bundle")
-
-
 def _installer(ws: WorkspaceClient) -> WorkspaceInstaller:
     app_context = ApplicationContext(_verify_workspace_client(ws))
     return WorkspaceInstaller(

--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -19,7 +19,6 @@ from databricks.labs.remorph.reconcile.runner import ReconcileRunner
 from databricks.labs.remorph.lineage import lineage_generator
 from databricks.labs.remorph.transpiler.execute import transpile as do_transpile
 from databricks.labs.remorph.reconcile.execute import RECONCILE_OPERATION_NAME, AGG_RECONCILE_OPERATION_NAME
-from databricks.labs.remorph.jvmproxy import proxy_command
 from databricks.sdk.core import with_user_agent_extra
 
 from databricks.sdk import WorkspaceClient


### PR DESCRIPTION
With scala code moved to morpheus, developer commands for our scala code is no longer relevant.
This PR removes the corresponding code. 