### PR TITLE
CI: verify checksum of Debian package before installing

### DIFF
--- a/.github/scripts/setup_mssql_odbc.sh
+++ b/.github/scripts/setup_mssql_odbc.sh
@@ -3,11 +3,25 @@
 set -xve
 #Repurposed from https://github.com/Yarden-zamir/install-mssql-odbc
 
-curl -sSL -O https://packages.microsoft.com/config/ubuntu/$(grep VERSION_ID /etc/os-release | cut -d '"' -f 2)/packages-microsoft-prod.deb
+VERSION_ID="$(awk -F= '$1=="VERSION_ID"{gsub(/\"/, "", $2); print $2}' /etc/os-release)"
+
+declare -A known_hashes=(
+  [20.04]='3edd2ff1b9e18ca3bc93f46893b755400d1f22f4fb4c077c9d5882cd60d837b8'
+  [22.04]='b8713c36d3e6f6b2520830180cf6b5779e48410ad5d5e1b192635b0c7359fcc6'
+  [24.04]='607d2033f90d1e58ed3cb3593c9b83881f6b3cb3627ab7d00952f1c04199c3a1'
+)
+if [ ! -v "known_hashes[${VERSION_ID}]" ]
+then
+  printf "Unsupported Ubuntu version: %s\n" "${VERSION_ID}"
+  exit 1
+fi
+expected_hash="${known_hashes[${VERSION_ID}]}"
+
+curl -sSL -O "https://packages.microsoft.com/config/ubuntu/${VERSION_ID}/packages-microsoft-prod.deb"
+printf "%s *packages-microsoft-prod.deb\n" "${expected_hash}" | sha256sum -c -
 
 sudo dpkg -i packages-microsoft-prod.deb
 #rm packages-microsoft-prod.deb
 
 sudo apt-get update
 sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
-

--- a/.github/scripts/setup_mssql_odbc.sh
+++ b/.github/scripts/setup_mssql_odbc.sh
@@ -3,7 +3,7 @@
 set -xve
 #Repurposed from https://github.com/Yarden-zamir/install-mssql-odbc
 
-VERSION_ID="$(awk -F= '$1=="VERSION_ID"{gsub(/\"/, "", $2); print $2}' /etc/os-release)"
+VERSION_ID="$(awk -F= '$1=="VERSION_ID"{gsub(/"/, "", $2); print $2}' /etc/os-release)"
 
 declare -A known_hashes=(
   [20.04]='3edd2ff1b9e18ca3bc93f46893b755400d1f22f4fb4c077c9d5882cd60d837b8'


### PR DESCRIPTION
This PR updates the setup for the acceptance tests during CI by verifying the checksum of the downloaded package before we try to install it.

This ensures that we notice if the package is changed instead of just blindly installing something we've downloaded.
