### PR TITLE
Improve `Makefile` project setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ setup_python:
 
 
 dev:
-	pip install hatch
+	which hatch > /dev/null || pip3 install hatch
 	hatch env create
-	hatch run pip install --upgrade pip
-	hatch run pip install -e '.[test]'
+	hatch run pip3 install --upgrade pip
+	hatch run pip3 install -e '.[test]'
 	hatch run which python
 	@echo "Hatch has created the above virtual environment. Please activate it using 'source .venv/bin/activate' and also select the .venv/bin/python interpreter in your IDE."
 


### PR DESCRIPTION
This PR updates the `dev` target in our `Makefile`:

 - It no longer tries to install hatch if it's already installed.
 - When invoking pip, it uses `pip3` instead of `pip`: the latter is more reliably available than `pip`, which is often skipped.

Tested with:

 - dash
 - bash
 - zsh
