### PR TITLE
Update transpiler configurations to use a dictionary to specify the environment

### DIFF
--- a/docs/remorph/docs/transpile_guide/pluggable_transpilers.mdx
+++ b/docs/remorph/docs/transpile_guide/pluggable_transpilers.mdx
@@ -50,10 +50,10 @@ remorph:
     - ...
     - <sql dialect _n_>
   environment: # this section is optional, variables are set prior to launching the transpiler
-    - <name 1>: <value 1>
-    - <name 2>: <value 2>
-    - ...
-    - <name _n_>: <value _n_>
+    <name 1>: <value 1>
+    <name 2>: <value 2>
+    ...
+    <name _n_>: <value _n_>
   command_line: # this section is mandatory and cannot be empty, it is used to launch the transpiler
     - <executable> # such as 'java', or 'python'
     - <argument 1> # such as '-jar'

--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -5,7 +5,6 @@ import asyncio
 import logging
 import os
 from collections.abc import Callable, Sequence
-from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
@@ -70,10 +69,7 @@ class _LSPRemorphConfigV1:
         dialects = data.get("dialects", [])
         if len(dialects) == 0:
             raise ValueError("Missing 'dialects' entry")
-        env_list = data.get("environment", [])
-        env_vars: dict[str, str] = {}
-        for env_var in env_list:
-            env_vars = env_vars | env_var
+        env_vars = data.get("environment", {})
         command_line = data.get("command_line", [])
         if len(command_line) == 0:
             raise ValueError("Missing 'command_line' entry")
@@ -377,9 +373,7 @@ class LSPEngine(TranspileEngine):
 
     async def _do_initialize(self, config: TranspileConfig) -> None:
         executable = self._config.remorph.command_line[0]
-        env = deepcopy(os.environ)
-        for name, value in self._config.remorph.env_vars.items():
-            env[name] = value
+        env: dict[str, str] = os.environ | self._config.remorph.env_vars
         # ensure modules are searched locally before being searched in remorph
         if "PYTHONPATH" in env.keys():
             env["PYTHONPATH"] = str(self._workdir) + os.pathsep + env["PYTHONPATH"]

--- a/tests/resources/lsp_transpiler/lsp_config.yml
+++ b/tests/resources/lsp_transpiler/lsp_config.yml
@@ -4,7 +4,7 @@ remorph:
   dialects:
     - snowflake
   environment:
-    - SOME_ENV: abc
+    SOME_ENV: abc
   command_line:
     - python
     - lsp_server.py


### PR DESCRIPTION
This PR updates the way environment variables are specified in our transpiler configurations. Specifically the configuration now takes a mapping of environment variables, rather than a list of mappings that are merged during load.

Although an incompatible change:

 - Our transpiler configurations don't use this part of the configuration file;
 - We haven't yet released.

As such I think it's worth the benefit of tidying this up before we make a release.