### PR TITLE
Create a pull request template we can use in all Remorph projects

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
+## Changes
+<!-- Summary of your changes that are easy to understand. Add screenshots when necessary, they're helpful to illustrate the before and after state -->
+### What does this PR do? 
+
+### Relevant implementation details
+
+### Caveats/things to watch out for when reviewing:
+
+### Linked issues
+<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
+
+Resolves #..
+
+### Functionality
+
+- [ ] added relevant user documentation
+- [ ] added new CLI command
+- [ ] modified existing command: `databricks labs remorph ...`
+- [ ] ... +add your own
+
+### Tests
+<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->
+
+- [ ] manually tested
+- [ ] added unit tests
+- [ ] added integration tests


### PR DESCRIPTION
As we have discussed before, we want to use a template to help the reviewers of Pull Requests better understand the intent and implementation of a PR.