### PR TITLE
Fix test temporary resources

### DIFF
--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 from pathlib import Path
-from tempfile import TemporaryFile, TemporaryDirectory
+from tempfile import TemporaryFile
 
 import pytest
 
@@ -30,19 +30,16 @@ def test_downloads_from_maven():
 
 
 @pytest.fixture()
-def mock_transpiler_folder():
-    with TemporaryDirectory() as tmpdir:
-        folder = Path(tmpdir)
-        folder.mkdir(exist_ok=True)
-        for transpiler in ("rct", "morpheus"):
-            target = folder / transpiler
-            target.mkdir(exist_ok=True)
-            target = target / "lib"
-            target.mkdir(exist_ok=True)
-            target = target / "config.yml"
-            source = TranspilerInstaller.resources_folder() / transpiler / "lib" / "config.yml"
-            shutil.copyfile(str(source), str(target))
-        yield folder
+def mock_transpiler_folder(tmp_path):
+    for transpiler in ("rct", "morpheus"):
+        target = tmp_path / transpiler
+        target.mkdir(exist_ok=True)
+        target = target / "lib"
+        target.mkdir(exist_ok=True)
+        target = target / "config.yml"
+        source = TranspilerInstaller.resources_folder() / transpiler / "lib" / "config.yml"
+        shutil.copyfile(str(source), str(target))
+        yield tmp_path
 
 
 def test_lists_all_transpiler_names(mock_transpiler_folder):

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from collections.abc import Iterable
 from pathlib import Path
 
 import pytest
@@ -18,7 +19,7 @@ def test_gets_maven_version():
     check_valid_version(version)
 
 
-def test_downloads_from_maven(tmp_path):
+def test_downloads_from_maven(tmp_path: Path) -> None:
     path = tmp_path / "test-download.pom"
     result = TranspilerInstaller.download_from_maven(
         "com.databricks", "databricks-connect", "16.0.0", path, extension="pom"
@@ -29,7 +30,7 @@ def test_downloads_from_maven(tmp_path):
 
 
 @pytest.fixture()
-def mock_transpiler_folder(tmp_path):
+def mock_transpiler_folder(tmp_path: Path) -> Iterable[Path]:
     for transpiler in ("rct", "morpheus"):
         target = tmp_path / transpiler
         target.mkdir()

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -38,7 +38,7 @@ def mock_transpiler_folder(tmp_path):
         target.mkdir()
         target = target / "config.yml"
         source = TranspilerInstaller.resources_folder() / transpiler / "lib" / "config.yml"
-        shutil.copyfile(str(source), str(target))
+        shutil.copyfile(source, target)
         yield tmp_path
 
 

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -39,7 +39,7 @@ def mock_transpiler_folder(tmp_path: Path) -> Iterable[Path]:
         target = target / "config.yml"
         source = TranspilerInstaller.resources_folder() / transpiler / "lib" / "config.yml"
         shutil.copyfile(source, target)
-        yield tmp_path
+    yield tmp_path
 
 
 def test_lists_all_transpiler_names(mock_transpiler_folder):

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 from pathlib import Path
-from tempfile import TemporaryFile
 
 import pytest
 
@@ -19,8 +18,8 @@ def test_gets_maven_version():
     check_valid_version(version)
 
 
-def test_downloads_from_maven():
-    path = Path(str(TemporaryFile()))
+def test_downloads_from_maven(tmp_path):
+    path = tmp_path / "test-download.pom"
     result = TranspilerInstaller.download_from_maven(
         "com.databricks", "databricks-connect", "16.0.0", path, extension="pom"
     )

--- a/tests/integration/test_install.py
+++ b/tests/integration/test_install.py
@@ -33,9 +33,9 @@ def test_downloads_from_maven():
 def mock_transpiler_folder(tmp_path):
     for transpiler in ("rct", "morpheus"):
         target = tmp_path / transpiler
-        target.mkdir(exist_ok=True)
+        target.mkdir()
         target = target / "lib"
-        target.mkdir(exist_ok=True)
+        target.mkdir()
         target = target / "config.yml"
         source = TranspilerInstaller.resources_folder() / transpiler / "lib" / "config.yml"
         shutil.copyfile(str(source), str(target))

--- a/tests/unit/helpers/test_file_utils.py
+++ b/tests/unit/helpers/test_file_utils.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -28,18 +27,17 @@ def test_is_sql_file():
     assert is_sql_file("test") is False
 
 
-def test_make_dir():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        new_dir_path = temp_dir.join("new_dir")
+def test_make_dir(tmp_path):
+    new_dir_path = tmp_path.join("new_dir")
 
-        # Ensure the directory does not exist
-        assert os.path.exists(new_dir_path) is False
+    # Ensure the directory does not exist
+    assert os.path.exists(new_dir_path) is False
 
-        # Call the function to create the directory
-        make_dir(new_dir_path)
+    # Call the function to create the directory
+    make_dir(new_dir_path)
 
-        # Check if the directory now exists
-        assert os.path.exists(new_dir_path) is True
+    # Check if the directory now exists
+    assert os.path.exists(new_dir_path) is True
 
 
 def safe_remove_file(file_path: Path):

--- a/tests/unit/helpers/test_file_utils.py
+++ b/tests/unit/helpers/test_file_utils.py
@@ -31,13 +31,13 @@ def test_make_dir(tmp_path):
     new_dir_path = tmp_path.join("new_dir")
 
     # Ensure the directory does not exist
-    assert os.path.exists(new_dir_path) is False
+    assert not os.path.exists(new_dir_path)
 
     # Call the function to create the directory
     make_dir(new_dir_path)
 
     # Check if the directory now exists
-    assert os.path.exists(new_dir_path) is True
+    assert os.path.exists(new_dir_path)
 
 
 def safe_remove_file(file_path: Path):

--- a/tests/unit/helpers/test_file_utils.py
+++ b/tests/unit/helpers/test_file_utils.py
@@ -28,7 +28,7 @@ def test_is_sql_file():
 
 
 def test_make_dir(tmp_path):
-    new_dir_path = tmp_path.join("new_dir")
+    new_dir_path = tmp_path / "new_dir"
 
     # Ensure the directory does not exist
     assert not os.path.exists(new_dir_path)

--- a/tests/unit/helpers/test_file_utils.py
+++ b/tests/unit/helpers/test_file_utils.py
@@ -27,7 +27,7 @@ def test_is_sql_file():
     assert is_sql_file("test") is False
 
 
-def test_make_dir(tmp_path):
+def test_make_dir(tmp_path: Path) -> None:
     new_dir_path = tmp_path / "new_dir"
 
     # Ensure the directory does not exist


### PR DESCRIPTION
This PR updates our tests to use the [pytest facility](https://docs.pytest.org/en/6.2.x/tmpdir.html#the-tmp-path-fixture) for creating temporary directories which tests can use. The primary purpose of this change is to resolve #1547: something in the way the existing code worked was (on macOS) creating a spurious `n` folder in the root of the project.

Some incidental changes in this PR include:

 - Type annotations for the updated tests.
 - Avoiding unnecessary conversion of paths to strings.
 - Failing if for some reason one of the temporary paths being created already exists.
