### PR TITLE
Constrain the Databricks SDK to a single version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "databricks-sdk~=0.44.0",
+  "databricks-sdk>=0.44,<0.52",
   "standard-distutils~=3.11.9; python_version>='3.11'",
   "sqlglot==26.1.3",
   "databricks-labs-blueprint[yaml]>=0.10.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "databricks-sdk>=0.44,<0.52",
+  "databricks-sdk~=0.51",
   "standard-distutils~=3.11.9; python_version>='3.11'",
   "sqlglot==26.1.3",
   "databricks-labs-blueprint[yaml]>=0.10.1",


### PR DESCRIPTION
As part of #1523 most dependencies were constrained to the specific version currently in use. Unfortunately I overlooked the version for `databricks-sdk` and left it as a wide range rather than pinning it to the latest release (or a patch-release thereof).

This PR fixes this by pinning the `databricks-sdk` to a single version, plus any patch releases that are made for it.