### PR TITLE
Add Pipeline and Step Comments

### DIFF
--- a/src/databricks/labs/remorph/assessments/profiler_config.py
+++ b/src/databricks/labs/remorph/assessments/profiler_config.py
@@ -9,6 +9,7 @@ class Step:
     mode: str | None
     frequency: str | None
     flag: str | None
+    comment: str | None = None
 
     def __post_init__(self):
         if self.frequency is None:
@@ -24,4 +25,5 @@ class PipelineConfig:
     name: str
     version: str
     extract_folder: str
+    comment: str | None = None
     steps: list[Step] = field(default_factory=list)

--- a/tests/integration/assessments/test_pipeline.py
+++ b/tests/integration/assessments/test_pipeline.py
@@ -3,6 +3,7 @@ import duckdb
 import pytest
 
 from databricks.labs.remorph.assessments.pipeline import PipelineClass, DB_NAME
+from databricks.labs.remorph.assessments.profiler_config import PipelineConfig, Step
 from ..connections.helpers import get_db_manager
 
 
@@ -79,3 +80,39 @@ def verify_output(get_logger, path):
     conn.close()
     logger.info("All expected tables exist and are not empty")
     return True
+
+
+def test_pipeline_config_comments():
+    pipeline_w_comments = PipelineConfig(
+        name="warehouse_profiler",
+        version="1.0",
+        extract_folder="/tmp/extracts",
+        comment="A pipeline for extracting warehouse usage.",
+    )
+    pipeline_wo_comments = PipelineConfig(
+        name="another_warehouse_profiler", version="1.0", extract_folder="/tmp/extracts"
+    )
+    assert pipeline_w_comments.comment == "A pipeline for extracting warehouse usage."
+    assert pipeline_wo_comments.comment is None
+
+
+def test_pipeline_step_comments():
+    step_w_comment = Step(
+        name="step_w_comment",
+        type="sql",
+        extract_source="path/to/extract/source.sql",
+        mode="append",
+        frequency="once",
+        flag="active",
+        comment="This is a step comment.",
+    )
+    step_wo_comment = Step(
+        name="step_wo_comment",
+        type="python",
+        extract_source="path/to/extract/source.py",
+        mode="overwrite",
+        frequency="daily",
+        flag="inactive",
+    )
+    assert step_w_comment.comment == "This is a step comment."
+    assert step_wo_comment.comment is None


### PR DESCRIPTION
## Changes

This PR adds a `comment` attribute to the `PipelineConfig` and `Step` classes.

### What does this PR do? 

Adds the ability for pipeline authors to document what a pipeline and/or step does for future maintainers (including themselves). 

### Relevant implementation details

For pipelines containing many steps, it becomes unclear what effect a pipeline or step has. To discern what a step does, for example, a pipeline maintainer must look at the extract_source attribute, navigate to the Python or SQL file, and then read through the file to determine what a step does.

### Caveats/things to watch out for when reviewing:

### Linked issues

Resolves #1470. 

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs remorph ...`
- [X] Augments the `PipelineConfig` and `Step` classes with a metadata attribute.

### Tests

- [ ] manually tested
- [ ] added unit tests
- [X] added integration tests
