### PR TITLE
Add Profiler Installer/Uninstaller

### DIFF
--- a/docs/remorph/docs/scheduler/index.mdx
+++ b/docs/remorph/docs/scheduler/index.mdx
@@ -1,0 +1,36 @@
+---
+sidebar_position: 1
+---
+
+# Installing the Profiler Scheduler
+
+## What is the profiler scheduler?
+
+- The profiler scheduler collects usage and performance metrics from a source warehouse
+- It leverages built-in scheduling components of the host operating system to execute usage collection queries
+
+## Why is profiler scheduler needed?
+
+- Some data warehouses do not preserve query history for longer than a few days or are limited to only a few rows. As an example, Amazon Redshift only preserves usage history for around 2-5 days
+- Having adequate usage history is critical in providing an _accurate_ Total Cost of Ownership (TCO) estimate
+- Having too little history could produce an inaccurate representation of data warehouse query patterns and system utilization
+
+## Supported operating systems
+
+The usage collection scheduler can be installed on the following operating systems:
+
+1. MacOS
+2. Linux
+3. Windows
+
+## Local vs. Remote Deployments
+
+The usage collection scheduler can be executed in the following deployments:
+
+1. **Local scheduler** - Scheduler is installed on a local laptop or workstation, provided that the local system can connect to a bastion host and forward connectivity to the data warehouse
+2. **Remote scheduler** - Scheduler is installed directly on a bastion host in a separate subnet or a compute instance deployed within the data warehouse's subnet
+
+
+## Automatic restart
+
+The usage collection scheduler utilizes the host operating system to run as a background process. As a result, the process will automatically resume processing after a system restart; no intervention is needed during a host system restart. The scheduler will automatically detect usage history gaps and proactively backfill when possible.

--- a/docs/remorph/docs/scheduler/linux/linux_installation.mdx
+++ b/docs/remorph/docs/scheduler/linux/linux_installation.mdx
@@ -1,0 +1,83 @@
+---
+sidebar_position: 2
+title: Linux Installation
+---
+
+# (Linux) Installing the Profiler Scheduler
+
+## Prerequisites
+
+The following requirements must be met before running the profiler scheduler installer:
+1. Python 3.10 (or higher)
+2. systemd
+3. Super user access to a Terminal window
+4. Cloned copy of the `remorph` project
+
+## Running the installer
+
+The installer will create and schedule a new system service using the built-in `systemctl` command. The installer will create 2 new system files:
+
+- **remorph_usage_collection.service** - A unit file that describes the remorph profiler as a system service (see **Description of the Unit File Elements** section below)
+- **remorph_usage_collection.timer** - A timer file for executing the usage collection service
+
+### Installation steps:
+
+1. Open a new Terminal window and navigate to the scheduler directory:
+
+```bash
+$ cd $HOME/.databricks/labs/remorph/assessments/scheduler/install/
+```
+
+2. Run the installer script:
+
+```bash
+$ sudo ./install.py
+```
+
+### Un-installation steps:
+
+1. Open a new Terminal window and navigate to the scheduler directory:
+
+```bash
+$ cd $HOME/.databricks/labs/remorph/assessments/scheduler/install/
+```
+
+2. Run the uninstaller script:
+
+```bash
+$ sudo ./uninstall.py
+```
+
+## Description of the unit file elements
+
+
+1. **Description**: A description of the service
+
+2. **After**: Ensures the service starts only after the specified system service is up (network in this case)
+
+3. **ExecStart**: Specifies the command and arguments (python3 interpreter and the script path)
+
+4. **WorkingDirectory**: The directory where the script should run
+
+5. **StandardOutput**: Redirects the standard out to the system logs
+
+6. **StandardError**: Redirects the error out to the system logs
+
+7. **Restart**: Restarts the script if the system reboots
+
+8. **User**: Runs the script as the specified user
+
+9. **WantedBy**: Ensures the service starts when the system reaches multi-user mode
+
+
+## Description of the timer file elements
+
+1. **Description**:  A description of the timer
+
+2. **Persistent** : Ensures the script runs after reboots
+
+3. **OnBootSec**: Ensures the script runs 1 min after bootin
+
+4. **OnUnitActiveSec**: Runs the script every 15 minutes
+
+5. **WantedBy**: Ensures the timer is activated when the system is running timers

--- a/docs/remorph/docs/scheduler/macos/macos_installation.mdx
+++ b/docs/remorph/docs/scheduler/macos/macos_installation.mdx
@@ -1,0 +1,62 @@
+---
+sidebar_position: 1
+title: MacOS Installation
+---
+
+# (MacOS) Installing the Profiler Scheduler
+
+## Prerequisites
+
+The following requirements must be met before running the profiler scheduler installer:
+1. Python 3.10 (or higher)
+2. `launchd`
+3. Super user access to a Terminal window
+4. Cloned copy of the `remorph` project
+
+## Running the installer
+
+The installer will create and a new launch agent using the built-in `launchctl` command. The installer will create 1 new plist files:
+
+- **com.remorph.usagecollection.plist** - A plist file that describes the remorph profiler as a system service (see **Description of the `plist` elements** section below)
+
+### Installation steps:
+
+1. Open a new Terminal window and navigate to the scheduler directory:
+
+```bash
+$ cd $HOME/.databricks/labs/remorph/assessments/scheduler/install/
+```
+
+2. Run the installer script:
+
+```bash
+$ sudo ./install.py
+```
+
+### Un-installation steps:
+
+1. Open a new Terminal window and navigate to the scheduler directory:
+
+```bash
+$ cd $HOME/.databricks/labs/remorph/assessments/scheduler/install/
+```
+
+2. Run the uninstaller script:
+
+```bash
+$ sudo ./uninstall.py
+```
+
+## Description of the `plist` elements
+
+1. **Label**: A unique identifier for the job
+
+2. **ProgramArguments**: Specifies the command and arguments (python3 interpreter and the script path)
+
+3. **StartInterval**: Runs the script every 900 seconds (15 minutes)
+
+4. **RunAtLoad**: Ensures the script runs immediately after loading
+
+5. **StandardOutPath**: Logs output for debugging
+
+6. **StandardErrorPath**: Logs errors to for debugging

--- a/docs/remorph/docs/scheduler/windows/windows_installation.mdx
+++ b/docs/remorph/docs/scheduler/windows/windows_installation.mdx
@@ -1,0 +1,59 @@
+---
+sidebar_position: 1
+title: Windows Installation
+---
+
+# (Windows) Installing the Usage Collection Scheduler
+
+## Prerequisites
+
+The following requirements must be met before running the profiler scheduler installer:
+1. Python 3.10 (or higher)
+3. Administrator access to the Windows Task Manager
+4. Cloned copy of the `remorph` project
+
+## Running the installer
+
+The installer will create and register a new Windows system task:
+
+- **usage_collection_task.xml** - A task file that describes the remorph profiler as a system service (see **Description of the task file elements** section below)
+
+### Installation steps:
+
+1. Open a new CMD window and navigate to the scheduler directory:
+
+```bash
+> cd $HOME\\.databricks\\labs\\remorph\\assessments\\scheduler\\install\\
+```
+
+2. Run the installer script:
+
+```bash
+> python3 install.py
+```
+
+### Un-installation steps:
+
+1. Open a new CMD window and navigate to the scheduler directory:
+
+```bash
+> cd $HOME\\.databricks\\labs\\remorph\\assessments\\scheduler\\install\\
+```
+
+2. Run the uninstaller script:
+
+```bash
+> python3 uninstall.py
+```
+
+## Description of the task file elements
+
+1. **Triggers**: Specifies the frequency for when the profiler should run
+
+2. **StartBoundary**: Defines the initial start time of the profiler scheduler
+
+3. **Principals**: Defines under who's identity the task will execute and with what privileges
+
+4. **Settings**: Specifies the profiler behavior during common system conditions
+
+5. **Actions**: Defines how to execute the profiler program


### PR DESCRIPTION
## Changes

This PR adds an installer and uninstaller for the data warehouse profiler.

### What does this PR do? 

This PR adds an installer/uninstaller for the 3 major operating systems (macOS, Windows, and Linux). This PR includes relevant documentation for installing/uninstalling the profiler. 

### Relevant implementation details

One of the goals of the profiler is to make it easy to install on a local machine without needing a Databricks workspace. Secondly, gathering enough usage data and metrics is critical in calculating an accurate Total Cost of Ownership (TCO). This PR leverages the built-in scheduling components of the host operating system to schedule usage collection so that enough usage information is used in providing a TCO estimate. 

### Caveats/things to watch out for when reviewing:

- (Docs) Are the installation/uninstallation steps clear? Do they make sense? Are they easy to understand even for someone with little experience?
- (Impl) Since this PR leverages the underlying OS to schedule usage collection, the installer must be run under administrative (or super user) privileges. It's assumed that a data warehouse admin will be running the profiler. Do you foresee any challenges/objections to this?

### Linked issues

Resolves #1470.

### Functionality

- [X] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs remorph ...`
- [X] added installer/uninstaller scripts for the profiler
- [X] added profiler installation/uninstallation docs

### Tests

- [X] manually tested
- [ ] added unit tests
- [ ] added integration tests
