### PR TITLE
Fix spark version detection in CI integration 

### DIFF
--- a/.github/scripts/setup_spark_remote.sh
+++ b/.github/scripts/setup_spark_remote.sh
@@ -5,7 +5,7 @@ set -xve
 mkdir -p "$HOME"/spark
 cd "$HOME"/spark || exit 1
 
-version=$(wget -O - https://dlcdn.apache.org/spark/ | grep 'href="spark' | grep -v 'preview' | sed 's:</a>:\n:g' | sed -n 's/.*>//p' | tr -d spark- | tr -d / | sort -r --version-sort | head -1)
+version=$(wget -O - https://dlcdn.apache.org/spark/ | grep 'href="spark' | grep -v 'preview' | sed 's:</a>:\n:g' | sed -n 's/.*>//p' | rev | cut -d - -f 1 - | tr -d / | rev | sort -r --version-sort | head -1)
 if [ -z "$version" ]; then
   echo "Failed to extract Spark version"
    exit 1

--- a/.github/scripts/setup_spark_remote.sh
+++ b/.github/scripts/setup_spark_remote.sh
@@ -5,7 +5,7 @@ set -xve
 mkdir -p "$HOME"/spark
 cd "$HOME"/spark || exit 1
 
-version=$(wget -O - https://dlcdn.apache.org/spark/ | grep 'href="spark-[0-9.]*/"'  | sed 's:</a>:\n:g' | sed -n 's/.*>//p' | tr -d spark-/ | sort -r --version-sort | head -1)
+version=$(wget -O - https://dlcdn.apache.org/spark/ | grep 'href="spark-[0-9.]*/"' | sed 's:</a>:\n:g' | sed -n 's/.*>//p' | tr -d spark/- | sort -r --version-sort | head -1)
 if [ -z "$version" ]; then
   echo "Failed to extract Spark version"
    exit 1

--- a/.github/scripts/setup_spark_remote.sh
+++ b/.github/scripts/setup_spark_remote.sh
@@ -5,7 +5,7 @@ set -xve
 mkdir -p "$HOME"/spark
 cd "$HOME"/spark || exit 1
 
-version=$(wget -O - https://dlcdn.apache.org/spark/ | grep 'href="spark' | grep -v 'preview' | sed 's:</a>:\n:g' | sed -n 's/.*>//p' | rev | cut -d - -f 1 - | tr -d / | rev | sort -r --version-sort | head -1)
+version=$(wget -O - https://dlcdn.apache.org/spark/ | grep 'href="spark-[0-9.]*/"'  | sed 's:</a>:\n:g' | sed -n 's/.*>//p' | tr -d spark-/ | sort -r --version-sort | head -1)
 if [ -z "$version" ]; then
   echo "Failed to extract Spark version"
    exit 1


### PR DESCRIPTION
Our CI suddenly fails because the spark download page has new entries that our version extractor does not properly parse.
See https://github.com/databrickslabs/remorph/actions/runs/14901901650/job/41855507048
This PR fixes that.