### PR TITLE
Ensure the Remorph CLI provides product information to the pluggable transpilers during initialisation.

### DIFF
--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -388,6 +388,7 @@ class LSPEngine(TranspileEngine):
         root_path = input_path if input_path.is_dir() else input_path.parent
         params = InitializeParams(
             capabilities=self._client_capabilities(),
+            client_info=ClientInfo(name=self._client.name, version=self._client.version),
             root_uri=str(root_path.absolute().as_uri()),
             workspace_folders=None,  # for now, we only support a single workspace = root_uri
             initialization_options=self._initialization_options(config),

--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -11,41 +11,36 @@ from typing import Any, Literal
 
 import attrs
 import yaml
-
 from lsprotocol import types as types_module
 from lsprotocol.types import (
-    InitializeParams,
-    ClientCapabilities,
-    InitializeResult,
     CLIENT_REGISTER_CAPABILITY,
-    RegistrationParams,
-    Registration,
-    TextEdit,
-    Diagnostic,
-    DidOpenTextDocumentParams,
-    TextDocumentItem,
-    DidCloseTextDocumentParams,
-    TextDocumentIdentifier,
     METHOD_TO_TYPES,
-    LanguageKind,
-    Range as LSPRange,
-    Position as LSPPosition,
+    ClientCapabilities,
+    ClientInfo,
+    Diagnostic,
     DiagnosticSeverity,
+    DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams,
+    InitializeParams,
+    InitializeResult,
+    LanguageKind,
 )
-from pygls.lsp.client import BaseLanguageClient
+from lsprotocol.types import Position as LSPPosition
+from lsprotocol.types import Range as LSPRange
+from lsprotocol.types import Registration, RegistrationParams, TextDocumentIdentifier, TextDocumentItem, TextEdit
 from pygls.exceptions import FeatureRequestError
+from pygls.lsp.client import BaseLanguageClient
 
 from databricks.labs.blueprint.wheels import ProductInfo
-
-from databricks.labs.remorph.config import TranspileConfig, TranspileResult, LSPConfigOptionV1
+from databricks.labs.remorph.config import LSPConfigOptionV1, TranspileConfig, TranspileResult
 from databricks.labs.remorph.errors.exceptions import IllegalStateException
 from databricks.labs.remorph.transpiler.transpile_engine import TranspileEngine
 from databricks.labs.remorph.transpiler.transpile_status import (
-    TranspileError,
+    CodePosition,
+    CodeRange,
     ErrorKind,
     ErrorSeverity,
-    CodeRange,
-    CodePosition,
+    TranspileError,
 )
 
 logger = logging.getLogger(__name__)
@@ -180,9 +175,8 @@ METHOD_TO_TYPES[TRANSPILE_TO_DATABRICKS_METHOD] = (
 # subclass BaseLanguageClient so we can override stuff when required
 class _LanguageClient(BaseLanguageClient):
 
-    def __init__(self):
-        version = ProductInfo.from_class(type(self)).version()
-        super().__init__("Remorph", version)
+    def __init__(self, name: str, version: str) -> None:
+        super().__init__(name, version)
         self._transpile_to_databricks_capability: Registration | None = None
         self._register_lsp_features()
 
@@ -345,10 +339,17 @@ class LSPEngine(TranspileEngine):
         config = LSPConfig.load(config_path)
         return LSPEngine(config_path.parent, config)
 
-    def __init__(self, workdir: Path, config: LSPConfig):
+    @classmethod
+    def client_metadata(cls) -> tuple[str, str]:
+        """Obtain the name and version for this LSP client, respectively in a tuple."""
+        product_info = ProductInfo.from_class(cls)
+        return product_info.product_name(), product_info.version()
+
+    def __init__(self, workdir: Path, config: LSPConfig) -> None:
         self._workdir = workdir
         self._config = config
-        self._client = _LanguageClient()
+        name, version = self.client_metadata()
+        self._client = _LanguageClient(name, version)
         self._init_response: InitializeResult | None = None
 
     @property

--- a/tests/resources/lsp_transpiler/lsp_server.py
+++ b/tests/resources/lsp_transpiler/lsp_server.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 from collections.abc import Sequence
@@ -6,29 +7,25 @@ from typing import Any, Literal
 from uuid import uuid4
 
 import attrs
-
 from lsprotocol import types as types_module
 from lsprotocol.types import (
-    InitializeParams,
     INITIALIZE,
-    RegistrationParams,
-    Registration,
-    TextEdit,
-    Diagnostic,
-    TEXT_DOCUMENT_DID_OPEN,
-    DidOpenTextDocumentParams,
-    TEXT_DOCUMENT_DID_CLOSE,
-    DidCloseTextDocumentParams,
-    Range,
-    Position,
     METHOD_TO_TYPES,
+    TEXT_DOCUMENT_DID_CLOSE,
+    TEXT_DOCUMENT_DID_OPEN,
+    Diagnostic,
     DiagnosticSeverity,
+    DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams,
+    InitializeParams,
     LanguageKind,
+    Position,
+    Range,
+    Registration,
+    RegistrationParams,
+    TextEdit,
 )
 from pygls.lsp.server import LanguageServer
-
-import logging
-
 
 logging.basicConfig(filename='test-lsp-server.log', filemode='w', level=logging.DEBUG)
 
@@ -116,6 +113,9 @@ class TestLspServer(LanguageServer):
 
     async def did_initialize(self, init_params: InitializeParams) -> None:
         self.initialization_options = init_params.initialization_options or {}
+        client_info = init_params.client_info
+        if client_info:
+            logger.debug(f"client-info={client_info.name}/{client_info.version}")
         logger.debug(f"dialect={self.dialect}")
         logger.debug(f"whatever={self.whatever}")
         logger.debug(f"experimental={self.experimental}")

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -5,14 +5,12 @@ from pathlib import Path
 from time import sleep
 
 import pytest
-from lsprotocol.types import TextEdit, Range, Position
+from lsprotocol.types import Position, Range, TextEdit
 
+from databricks.labs.blueprint.wheels import ProductInfo
 from databricks.labs.remorph.errors.exceptions import IllegalStateException
-from databricks.labs.remorph.transpiler.lsp.lsp_engine import (
-    LSPEngine,
-    ChangeManager,
-)
-from databricks.labs.remorph.transpiler.transpile_status import TranspileError, ErrorSeverity, ErrorKind
+from databricks.labs.remorph.transpiler.lsp.lsp_engine import ChangeManager, LSPEngine
+from databricks.labs.remorph.transpiler.transpile_status import ErrorKind, ErrorSeverity, TranspileError
 from tests.unit.conftest import path_to_resource
 
 
@@ -78,6 +76,14 @@ async def test_receives_config(lsp_engine, transpile_config):
     log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
     assert "dialect=snowflake" in log
     await lsp_engine.shutdown()
+
+
+async def test_receives_client_info(lsp_engine, transpile_config):
+    await lsp_engine.initialize(transpile_config)
+    log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
+    product_info = ProductInfo.from_class(type(lsp_engine))
+    expected_client_info = f"client_info={product_info.product_name}/{product_info.version}]"
+    assert expected_client_info in log
 
 
 async def test_server_has_transpile_capability(lsp_engine, transpile_config):

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -82,7 +82,7 @@ async def test_receives_client_info(lsp_engine, transpile_config):
     await lsp_engine.initialize(transpile_config)
     log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
     product_info = ProductInfo.from_class(type(lsp_engine))
-    expected_client_info = f"client_info={product_info.product_name}/{product_info.version}]"
+    expected_client_info = f"client-info={product_info.product_name()}/{product_info.version()}"
     assert expected_client_info in log
     await lsp_engine.shutdown()
 

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -84,6 +84,7 @@ async def test_receives_client_info(lsp_engine, transpile_config):
     product_info = ProductInfo.from_class(type(lsp_engine))
     expected_client_info = f"client_info={product_info.product_name}/{product_info.version}]"
     assert expected_client_info in log
+    await lsp_engine.shutdown()
 
 
 async def test_server_has_transpile_capability(lsp_engine, transpile_config):


### PR DESCRIPTION
This PR updates the LSP engine so that the product information is supplied to the pluggable transpilers during initialisation.

Name and version information are provided using the normal blueprint manner, and are currently `remorph` and `0.9.0` respectively.

Resolves #1553.
