### PR TITLE
Ensure test LSP server is shut down when tests fail

### DIFF
--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -21,11 +21,9 @@ from tests.unit.conftest import path_to_resource
 async def lsp_engine() -> AsyncGenerator[LSPEngine, None]:
     config_path = path_to_resource("lsp_transpiler", "lsp_config.yml")
     engine = LSPEngine.from_config_path(Path(config_path))
-    try:
-        yield engine
-    finally:
-        if engine.is_alive:
-            await engine.shutdown()
+    yield engine
+    if engine.is_alive:
+        await engine.shutdown()
 
 
 async def test_initializes_lsp_server(lsp_engine, transpile_config):

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -1,6 +1,7 @@
 import asyncio
 import dataclasses
 import logging
+from collections.abc import AsyncGenerator
 from pathlib import Path
 from time import sleep
 
@@ -17,10 +18,14 @@ from tests.unit.conftest import path_to_resource
 
 
 @pytest.fixture
-def lsp_engine():
+async def lsp_engine() -> AsyncGenerator[LSPEngine, None]:
     config_path = path_to_resource("lsp_transpiler", "lsp_config.yml")
     engine = LSPEngine.from_config_path(Path(config_path))
-    return engine
+    try:
+        yield engine
+    finally:
+        if engine.is_alive:
+            await engine.shutdown()
 
 
 async def test_initializes_lsp_server(lsp_engine, transpile_config):
@@ -28,14 +33,12 @@ async def test_initializes_lsp_server(lsp_engine, transpile_config):
     await lsp_engine.initialize(transpile_config)
     sleep(3)
     assert lsp_engine.is_alive
-    await lsp_engine.shutdown()
 
 
 async def test_initializes_lsp_server_only_once(lsp_engine, transpile_config):
     await lsp_engine.initialize(transpile_config)
     with pytest.raises(IllegalStateException):
         await lsp_engine.initialize(transpile_config)
-    await lsp_engine.shutdown()
 
 
 async def test_shuts_lsp_server_down(lsp_engine, transpile_config):
@@ -48,21 +51,18 @@ async def test_sets_env_variables(lsp_engine, transpile_config):
     await lsp_engine.initialize(transpile_config)
     log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
     assert "SOME_ENV=abc" in log  # see environment in lsp_transpiler/config.yml
-    await lsp_engine.shutdown()
 
 
 async def test_passes_options(lsp_engine, transpile_config):
     await lsp_engine.initialize(transpile_config)
     log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
     assert "experimental=True" in log  # see environment in lsp_transpiler/config.yml
-    await lsp_engine.shutdown()
 
 
 async def test_passes_extra_args(lsp_engine, transpile_config):
     await lsp_engine.initialize(transpile_config)
     log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
     assert "--stuff=12" in log  # see command_line in lsp_transpiler/config.yml
-    await lsp_engine.shutdown()
 
 
 async def test_passes_log_level(lsp_engine, transpile_config):
@@ -70,14 +70,12 @@ async def test_passes_log_level(lsp_engine, transpile_config):
     await lsp_engine.initialize(transpile_config)
     log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
     assert "--log_level=INFO" in log  # see command_line in lsp_transpiler/config.yml
-    await lsp_engine.shutdown()
 
 
 async def test_receives_config(lsp_engine, transpile_config):
     await lsp_engine.initialize(transpile_config)
     log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
     assert "dialect=snowflake" in log
-    await lsp_engine.shutdown()
 
 
 async def test_server_has_transpile_capability(lsp_engine, transpile_config):
@@ -88,7 +86,6 @@ async def test_server_has_transpile_capability(lsp_engine, transpile_config):
         if lsp_engine.server_has_transpile_capability:
             break
     assert lsp_engine.server_has_transpile_capability
-    await lsp_engine.shutdown()
 
 
 async def read_log(marker: str):
@@ -107,7 +104,6 @@ async def test_server_fetches_workspace_file(lsp_engine, transpile_config):
     await lsp_engine.initialize(transpile_config)
     log = await read_log("fetch-document-uri")
     assert f"fetch-document-uri={sample_path.as_uri()}" in log
-    await lsp_engine.shutdown()
 
 
 async def test_server_loads_document(lsp_engine, transpile_config):
@@ -116,7 +112,6 @@ async def test_server_loads_document(lsp_engine, transpile_config):
     lsp_engine.open_document(sample_path)
     log = await read_log("open-document-uri")
     assert f"open-document-uri={sample_path.as_uri()}" in log
-    await lsp_engine.shutdown()
 
 
 async def test_server_closes_document(lsp_engine, transpile_config):
@@ -126,7 +121,6 @@ async def test_server_closes_document(lsp_engine, transpile_config):
     lsp_engine.close_document(sample_path)
     log = await read_log("close-document-uri")
     assert f"close-document-uri={sample_path.as_uri()}" in log
-    await lsp_engine.shutdown()
 
 
 async def test_server_transpiles_document(lsp_engine, transpile_config):


### PR DESCRIPTION
## Changes

This PR updates the fixture for some of our LSP engine tests to ensure that the underlying LSP server (and its process) is shut down properly even if the test fails.

### Tests

- updated unit tests
