### PR TITLE
Wait for transpile capability during LSP initialisation

### DIFF
--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -204,6 +204,18 @@ class _LanguageClient(BaseLanguageClient):
             logger.debug(f"Unknown capability: {registration.method}")
 
     async def transpile_document_async(self, params: TranspileDocumentParams) -> TranspileDocumentResult:
+        """Transpile a document to Databricks SQL.
+
+        The caller is responsible for ensuring that the LSP server is capable of handling this request.
+
+        Args:
+            params: The parameters for the transpile request to forward to the LSP server.
+        Returns:
+            The result of the transpile request, from the LSP server.
+        Raises:
+            IllegalStateException: If the client has been stopped or the server hasn't (yet) signalled that it is
+                capable of transpiling documents to Databricks SQL.
+        """
         if self.stopped:
             raise IllegalStateException("Client has been stopped.")
         if not self.transpile_to_databricks_capability:

--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -206,10 +206,10 @@ class _LanguageClient(BaseLanguageClient):
     async def transpile_document_async(self, params: TranspileDocumentParams) -> TranspileDocumentResult:
         if self.stopped:
             raise RuntimeError("Client has been stopped.")
-        await self._await_for_transpile_capability()
+        await self.await_for_transpile_capability()
         return await self.protocol.send_request_async(TRANSPILE_TO_DATABRICKS_METHOD, params)
 
-    async def _await_for_transpile_capability(self):
+    async def await_for_transpile_capability(self):
         for _ in range(1, 100):
             if self.transpile_to_databricks_capability:
                 return
@@ -391,6 +391,7 @@ class LSPEngine(TranspileEngine):
         try:
             os.chdir(self._workdir)
             await self._do_initialize(config)
+            await self._client.await_for_transpile_capability()
         # it is good practice to catch broad exceptions raised by launching a child process
         except Exception as e:  # pylint: disable=broad-exception-caught
             logger.error("LSP initialization failed", exc_info=e)

--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -205,8 +205,9 @@ class _LanguageClient(BaseLanguageClient):
 
     async def transpile_document_async(self, params: TranspileDocumentParams) -> TranspileDocumentResult:
         if self.stopped:
-            raise RuntimeError("Client has been stopped.")
-        await self.await_for_transpile_capability()
+            raise IllegalStateException("Client has been stopped.")
+        if not self.transpile_to_databricks_capability:
+            raise IllegalStateException("Client has not yet registered its transpile capability.")
         return await self.protocol.send_request_async(TRANSPILE_TO_DATABRICKS_METHOD, params)
 
     async def await_for_transpile_capability(self):

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -82,11 +82,6 @@ async def test_receives_config(lsp_engine, transpile_config):
 
 async def test_server_has_transpile_capability(lsp_engine, transpile_config):
     await lsp_engine.initialize(transpile_config)
-    # need to give time to child process and client listener
-    for _ in range(1, 10):
-        await asyncio.sleep(0.1)
-        if lsp_engine.server_has_transpile_capability:
-            break
     assert lsp_engine.server_has_transpile_capability
     await lsp_engine.shutdown()
 


### PR DESCRIPTION
## Changes

This PR updates the initialisation sequence when starting up the LSP server: initialisation now waits until it knows the transpiler capability is available before returning.

### Relevant implementation details

Currently we are using LSPs dynamic registration mechanism for the server (=transpiler plugin), after the initialisation sequence, to notify the client (=remorph CLI) that transpilation is supported. This normally happens quickly, but previously the first call to transpile would wait up to 10 seconds for the capability to be declared. As noted on #1542, this meant that a failure that prevented it from arriving would be noted on the call to transpile, which is a little misleading because something has really gone wrong during startup.

### Caveats/things to watch out for when reviewing:

We don't currently have any way to verify the sequence of LSP interactions at a fine-grained level: this would require mocking the LSP part of the stack, and be a significant amount of work. Instead the approach until now is to use a small test LSP server. Testing for this PR is therefore a little racy: we can't strictly verify that initialisation waits for the capability, because it might occur after initialisation but before the test performs its check. A passing test therefore doesn't _prove_ that it works in the strict sense, although a failure (including flakiness) would demonstrate that it's not working as intended.

### Linked issues

Resolves #1542.

### Tests

- update tests
