### PR TITLE
Avoid adding unnecessary semicolons

### DIFF
--- a/src/databricks/labs/remorph/helpers/validation.py
+++ b/src/databricks/labs/remorph/helpers/validation.py
@@ -38,7 +38,7 @@ class Validator:
             config.schema_name,
         )
         if is_valid:
-            result = sql_text + "\n;\n"
+            result = sql_text
             if exception_type is not None:
                 exception_msg = f"[{exception_type.upper()}]: {exception_msg}"
         else:

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -76,7 +76,6 @@ async def _process_one_file(
                 error_list.append(error)
         else:
             w.write(transpile_result.transpiled_code)
-            w.write("\n;\n")
 
     logger.info(f"Processed file: {input_path} (errors: {len(error_list)})")
     return transpile_result.success_count, error_list

--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -315,11 +315,13 @@ class ChangeManager(abc.ABC):
 
     @classmethod
     def _is_full_document_change(cls, lines: list[str], change: TextEdit) -> bool:
+        # A range's end is exclusive. Therefore full document range goes from (0, 0) to (l, 0) where l is the number
+        # of lines in the document.
         return (
-            change.range.start.line <= 0
-            and change.range.start.character <= 0
-            and change.range.end.line >= len(lines) - 1
-            and change.range.end.character >= len(lines[-1])
+            change.range.start.line == 0
+            and change.range.start.character == 0
+            and change.range.end.line >= len(lines)
+            and change.range.end.character >= 0
         )
 
 

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -152,6 +152,7 @@ async def test_server_transpiles_document(lsp_engine, transpile_config):
         ("a\nb\nc\n", [TextEdit(Range(Position(0, 0), Position(1, 1)), "x")], "x\nc\n"),
         ("abc", [TextEdit(Range(Position(0, 1), Position(0, 2)), "x")], "axc"),
         ("abc\ndef\nghi", [TextEdit(Range(Position(0, 2), Position(2, 1)), "x\ny")], "abx\nyhi"),
+        ("abbcccdddd", [TextEdit(Range(Position(0, 0), Position(1, 0)), "1\n22\n333\n4444\n")], "1\n22\n333\n4444\n"),
     ],
 )
 def test_change_mgr_replaces_text(source, changes, expected):


### PR DESCRIPTION
### What does this PR do? 

This PR:

 - Updates transpiling to avoid adding semicolons to transpiled output.
 - Processing of full-document changes is also fixed; there were some off-by-one errors in the existing logic.

### Linked issues
https://github.com/databrickslabs/morpheus/issues/339