### PR TITLE
LSP: include the client's process ID during the initialisation sequence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "databricks-sdk~=0.44.0",
+  "databricks-sdk~=0.51",
   "standard-distutils~=3.11.9; python_version>='3.11'",
   "sqlglot==26.1.3",
   "databricks-labs-blueprint[yaml]>=0.10.1",

--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -388,6 +388,7 @@ class LSPEngine(TranspileEngine):
         root_path = input_path if input_path.is_dir() else input_path.parent
         params = InitializeParams(
             capabilities=self._client_capabilities(),
+            client_info=ClientInfo(name=self._client.name, version=self._client.version),
             root_uri=str(root_path.absolute().as_uri()),
             workspace_folders=None,  # for now, we only support a single workspace = root_uri
             initialization_options=self._initialization_options(config),

--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -414,6 +414,7 @@ class LSPEngine(TranspileEngine):
         params = InitializeParams(
             capabilities=self._client_capabilities(),
             client_info=ClientInfo(name=self._client.name, version=self._client.version),
+            process_id=os.getpid(),
             root_uri=str(root_path.absolute().as_uri()),
             workspace_folders=None,  # for now, we only support a single workspace = root_uri
             initialization_options=self._initialization_options(config),

--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -11,41 +11,36 @@ from typing import Any, Literal
 
 import attrs
 import yaml
-
 from lsprotocol import types as types_module
 from lsprotocol.types import (
-    InitializeParams,
-    ClientCapabilities,
-    InitializeResult,
     CLIENT_REGISTER_CAPABILITY,
-    RegistrationParams,
-    Registration,
-    TextEdit,
-    Diagnostic,
-    DidOpenTextDocumentParams,
-    TextDocumentItem,
-    DidCloseTextDocumentParams,
-    TextDocumentIdentifier,
     METHOD_TO_TYPES,
-    LanguageKind,
-    Range as LSPRange,
-    Position as LSPPosition,
+    ClientCapabilities,
+    ClientInfo,
+    Diagnostic,
     DiagnosticSeverity,
+    DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams,
+    InitializeParams,
+    InitializeResult,
+    LanguageKind,
 )
-from pygls.lsp.client import BaseLanguageClient
+from lsprotocol.types import Position as LSPPosition
+from lsprotocol.types import Range as LSPRange
+from lsprotocol.types import Registration, RegistrationParams, TextDocumentIdentifier, TextDocumentItem, TextEdit
 from pygls.exceptions import FeatureRequestError
+from pygls.lsp.client import BaseLanguageClient
 
 from databricks.labs.blueprint.wheels import ProductInfo
-
-from databricks.labs.remorph.config import TranspileConfig, TranspileResult, LSPConfigOptionV1
+from databricks.labs.remorph.config import LSPConfigOptionV1, TranspileConfig, TranspileResult
 from databricks.labs.remorph.errors.exceptions import IllegalStateException
 from databricks.labs.remorph.transpiler.transpile_engine import TranspileEngine
 from databricks.labs.remorph.transpiler.transpile_status import (
-    TranspileError,
+    CodePosition,
+    CodeRange,
     ErrorKind,
     ErrorSeverity,
-    CodeRange,
-    CodePosition,
+    TranspileError,
 )
 
 logger = logging.getLogger(__name__)
@@ -180,9 +175,8 @@ METHOD_TO_TYPES[TRANSPILE_TO_DATABRICKS_METHOD] = (
 # subclass BaseLanguageClient so we can override stuff when required
 class _LanguageClient(BaseLanguageClient):
 
-    def __init__(self):
-        version = ProductInfo.from_class(type(self)).version()
-        super().__init__("Remorph", version)
+    def __init__(self, name: str, version: str) -> None:
+        super().__init__(name, version)
         self._transpile_to_databricks_capability: Registration | None = None
         self._register_lsp_features()
 
@@ -345,10 +339,17 @@ class LSPEngine(TranspileEngine):
         config = LSPConfig.load(config_path)
         return LSPEngine(config_path.parent, config)
 
-    def __init__(self, workdir: Path, config: LSPConfig):
+    @classmethod
+    def client_metadata(cls) -> tuple[str, str]:
+        """Obtain the name and version for this LSP client, respectively in a tuple."""
+        product_info = ProductInfo.from_class(cls)
+        return product_info.product_name(), product_info.version()
+
+    def __init__(self, workdir: Path, config: LSPConfig) -> None:
         self._workdir = workdir
         self._config = config
-        self._client = _LanguageClient()
+        name, version = self.client_metadata()
+        self._client = _LanguageClient(name, version)
         self._init_response: InitializeResult | None = None
 
     @property

--- a/tests/resources/lsp_transpiler/lsp_server.py
+++ b/tests/resources/lsp_transpiler/lsp_server.py
@@ -116,6 +116,8 @@ class TestLspServer(LanguageServer):
         client_info = init_params.client_info
         if client_info:
             logger.debug(f"client-info={client_info.name}/{client_info.version}")
+        if init_params.process_id:
+            logger.debug(f"client-process-id={init_params.process_id}")
         logger.debug(f"dialect={self.dialect}")
         logger.debug(f"whatever={self.whatever}")
         logger.debug(f"experimental={self.experimental}")

--- a/tests/resources/lsp_transpiler/lsp_server.py
+++ b/tests/resources/lsp_transpiler/lsp_server.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 from collections.abc import Sequence
@@ -6,29 +7,25 @@ from typing import Any, Literal
 from uuid import uuid4
 
 import attrs
-
 from lsprotocol import types as types_module
 from lsprotocol.types import (
-    InitializeParams,
     INITIALIZE,
-    RegistrationParams,
-    Registration,
-    TextEdit,
-    Diagnostic,
-    TEXT_DOCUMENT_DID_OPEN,
-    DidOpenTextDocumentParams,
-    TEXT_DOCUMENT_DID_CLOSE,
-    DidCloseTextDocumentParams,
-    Range,
-    Position,
     METHOD_TO_TYPES,
+    TEXT_DOCUMENT_DID_CLOSE,
+    TEXT_DOCUMENT_DID_OPEN,
+    Diagnostic,
     DiagnosticSeverity,
+    DidCloseTextDocumentParams,
+    DidOpenTextDocumentParams,
+    InitializeParams,
     LanguageKind,
+    Position,
+    Range,
+    Registration,
+    RegistrationParams,
+    TextEdit,
 )
 from pygls.lsp.server import LanguageServer
-
-import logging
-
 
 logging.basicConfig(filename='test-lsp-server.log', filemode='w', level=logging.DEBUG)
 
@@ -116,6 +113,9 @@ class TestLspServer(LanguageServer):
 
     async def did_initialize(self, init_params: InitializeParams) -> None:
         self.initialization_options = init_params.initialization_options or {}
+        client_info = init_params.client_info
+        if client_info:
+            logger.debug(f"client-info={client_info.name}/{client_info.version}")
         logger.debug(f"dialect={self.dialect}")
         logger.debug(f"whatever={self.whatever}")
         logger.debug(f"experimental={self.experimental}")

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -5,14 +5,12 @@ from pathlib import Path
 from time import sleep
 
 import pytest
-from lsprotocol.types import TextEdit, Range, Position
+from lsprotocol.types import Position, Range, TextEdit
 
+from databricks.labs.blueprint.wheels import ProductInfo
 from databricks.labs.remorph.errors.exceptions import IllegalStateException
-from databricks.labs.remorph.transpiler.lsp.lsp_engine import (
-    LSPEngine,
-    ChangeManager,
-)
-from databricks.labs.remorph.transpiler.transpile_status import TranspileError, ErrorSeverity, ErrorKind
+from databricks.labs.remorph.transpiler.lsp.lsp_engine import ChangeManager, LSPEngine
+from databricks.labs.remorph.transpiler.transpile_status import ErrorKind, ErrorSeverity, TranspileError
 from tests.unit.conftest import path_to_resource
 
 
@@ -78,6 +76,14 @@ async def test_receives_config(lsp_engine, transpile_config):
     log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
     assert "dialect=snowflake" in log
     await lsp_engine.shutdown()
+
+
+async def test_receives_client_info(lsp_engine, transpile_config):
+    await lsp_engine.initialize(transpile_config)
+    log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
+    product_info = ProductInfo.from_class(type(lsp_engine))
+    expected_client_info = f"client_info={product_info.product_name}/{product_info.version}]"
+    assert expected_client_info in log
 
 
 async def test_server_has_transpile_capability(lsp_engine, transpile_config):

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -1,6 +1,7 @@
 import asyncio
 import dataclasses
 import logging
+import os
 from pathlib import Path
 from time import sleep
 
@@ -85,6 +86,13 @@ async def test_receives_client_info(lsp_engine, transpile_config):
     expected_client_info = f"client-info={product_info.product_name()}/{product_info.version()}"
     assert expected_client_info in log
     await lsp_engine.shutdown()
+
+
+async def test_receives_process_id(lsp_engine, transpile_config):
+    await lsp_engine.initialize(transpile_config)
+    log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
+    expected_process_id = f"client-process-id={os.getpid()}"
+    assert expected_process_id in log
 
 
 async def test_server_has_transpile_capability(lsp_engine, transpile_config):

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -82,7 +82,7 @@ async def test_receives_client_info(lsp_engine, transpile_config):
     await lsp_engine.initialize(transpile_config)
     log = Path(path_to_resource("lsp_transpiler", "test-lsp-server.log")).read_text("utf-8")
     product_info = ProductInfo.from_class(type(lsp_engine))
-    expected_client_info = f"client_info={product_info.product_name}/{product_info.version}]"
+    expected_client_info = f"client-info={product_info.product_name()}/{product_info.version()}"
     assert expected_client_info in log
     await lsp_engine.shutdown()
 

--- a/tests/unit/transpiler/test_lsp_engine.py
+++ b/tests/unit/transpiler/test_lsp_engine.py
@@ -84,6 +84,7 @@ async def test_receives_client_info(lsp_engine, transpile_config):
     product_info = ProductInfo.from_class(type(lsp_engine))
     expected_client_info = f"client_info={product_info.product_name}/{product_info.version}]"
     assert expected_client_info in log
+    await lsp_engine.shutdown()
 
 
 async def test_server_has_transpile_capability(lsp_engine, transpile_config):


### PR DESCRIPTION
## Changes

This PR updates the LSP initialisation sequence for pluggable transpilers so that the client (=Remorph CLI) notifies the server (=pluggable transpiler) of its process ID. The [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize) mentions this:
```typescript
/**
 * The process Id of the parent process that started the server. Is null if
 * the process has not been started by another process. If the parent
 * process is not alive then the server should exit (see exit notification)
 * its process.
 */
```

The intent here is that sometimes a server cannot rely on orderly shutdown of the LSP server (including the LSP messages or stdin/stdout being closed) to detect a client that has crashed, and a mitigation here is that the server should periodically check that this process is still present.

### Caveats/things to watch out for when reviewing:

There's a line from another test removed: this is from a test added in #1571, and #1569 would have removed the line but both of those PRs were merged in parallel.

### Functionality

 - updated initialisation sequence during transpile requests.

### Tests

 - added tests
