### PR TITLE
Normalize the configured object names to lowercase

### DIFF
--- a/src/databricks/labs/remorph/config.py
+++ b/src/databricks/labs/remorph/config.py
@@ -131,6 +131,12 @@ class DatabaseConfig:
     target_schema: str
     source_catalog: str | None = None
 
+    def __post_init__(self):
+        self.source_schema = self.source_schema.lower()
+        self.target_schema = self.target_schema.lower()
+        self.target_catalog = self.target_catalog.lower()
+        self.source_catalog = self.source_catalog.lower() if self.source_catalog else self.source_catalog
+
 
 @dataclass
 class TranspileResult:


### PR DESCRIPTION
Normalize the configured object names to lowercase.

Fixes #1567 
