### PR TITLE
Improve logging during transpiler installation

### DIFF
--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -123,6 +123,9 @@ class TranspilerInstaller(abc.ABC):
     def install_from_pypi(cls, product_name: str, pypi_name: str) -> Path | None:
         current_version = cls.get_installed_version(product_name)
         latest_version = cls.get_pypi_version(pypi_name)
+        if latest_version is None:
+            logger.warning(f"Could not determine the latest version of {pypi_name}")
+            return None
         if current_version == latest_version:
             logger.info(f"{pypi_name} v{latest_version} already installed")
             return None

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -130,7 +130,7 @@ class TranspilerInstaller(abc.ABC):
         if current_version == latest_version:
             logger.info(f"{pypi_name} v{latest_version} already installed")
             return None
-        logger.info(f"Installing {pypi_name} v{latest_version}")
+        logger.debug(f"Installing {pypi_name} v{latest_version}")
         product_path = cls.transpilers_path() / product_name
         if current_version is not None:
             product_path.rename(f"{product_name}-saved")
@@ -242,7 +242,7 @@ class MorpheusInstaller(TranspilerInstaller):
         if current_version == latest_version:
             logger.info(f"Databricks Morpheus transpiler v{latest_version} already installed")
             return
-        logger.info(f"Installing Databricks Morpheus transpiler v{latest_version}")
+        logger.debug(f"Installing Databricks Morpheus transpiler v{latest_version}")
         product_path = cls.transpilers_path() / cls.MORPHEUS_TRANSPILER_NAME
         if current_version is not None:
             product_path.rename(f"{cls.MORPHEUS_TRANSPILER_NAME}-saved")

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -115,7 +115,8 @@ class TranspilerInstaller(abc.ABC):
                 text: bytes = server.read()
             data: dict[str, Any] = loads(text)
             return data.get("info", {}).get('version', None)
-        except HTTPError:
+        except HTTPError as e:
+            logger.error(f"Error while fetching PyPI metadata: {product_name}", exc_info=e)
             return None
 
     @classmethod

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -126,6 +126,7 @@ class TranspilerInstaller(abc.ABC):
         latest_version = cls.get_pypi_version(pypi_name)
         if latest_version is None:
             logger.warning(f"Could not determine the latest version of {pypi_name}")
+            logger.error(f"Failed to install transpiler: {product_name}")
             return None
         if current_version == latest_version:
             logger.info(f"{pypi_name} v{latest_version} already installed")
@@ -149,7 +150,7 @@ class TranspilerInstaller(abc.ABC):
                 rmtree(f"{product_path!s}-saved")
             return install_path
         except CalledProcessError as e:
-            logger.info(f"Failed to install {pypi_name} v{latest_version}", exc_info=e)
+            logger.error(f"Failed to install {pypi_name} v{latest_version}", exc_info=e)
             if current_version is not None:
                 rmtree(str(product_path))
                 renamed = Path(f"{product_path!s}-saved")
@@ -238,6 +239,7 @@ class MorpheusInstaller(TranspilerInstaller):
         latest_version = cls.get_maven_version(cls.MORPHEUS_TRANSPILER_GROUP_NAME, cls.MORPHEUS_TRANSPILER_NAME)
         if latest_version is None:
             logger.warning(f"Could not determine the latest version of Databricks Morpheus transpiler ({cls.MORPHEUS_TRANSPILER_GROUP_NAME}:{cls.MORPHEUS_TRANSPILER_NAME})")
+            logger.error(f"Failed to install transpiler: Databricks Morpheus transpiler")
             return
         if current_version == latest_version:
             logger.info(f"Databricks Morpheus transpiler v{latest_version} already installed")
@@ -266,7 +268,7 @@ class MorpheusInstaller(TranspilerInstaller):
             if current_version is not None:
                 rmtree(f"{product_path!s}-saved")
         else:
-            logger.info(f"Failed to install Databricks Morpheus transpiler v{latest_version}")
+            logger.error(f"Failed to install Databricks Morpheus transpiler v{latest_version}")
             if current_version is not None:
                 rmtree(str(product_path))
                 renamed = Path(f"{product_path!s}-saved")

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -309,8 +309,7 @@ class WorkspaceInstaller:
         module: str,
         config: RemorphConfigs | None = None,
     ) -> RemorphConfigs:
-        if module == "all":
-            logger.info(f"Installing Remorph v{self._product_info.version()}")
+        logger.debug(f"Initializing workspace installation for module: {module} (config: {config})")
         if module in {"transpile", "all"}:
             self.install_rct()
             self.install_morpheus()

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -232,7 +232,7 @@ class MorpheusInstaller(TranspilerInstaller):
     MORPHEUS_TRANSPILER_GROUP_NAME = "com.databricks.labs"
 
     @classmethod
-    def install(cls):
+    def install(cls) -> None:
         current_version = cls.get_installed_version(cls.MORPHEUS_TRANSPILER_NAME)
         latest_version = cls.get_maven_version(cls.MORPHEUS_TRANSPILER_GROUP_NAME, cls.MORPHEUS_TRANSPILER_NAME)
         if current_version == latest_version:

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -112,14 +112,14 @@ class TranspilerInstaller(abc.ABC):
     def get_pypi_version(cls, product_name: str) -> str | None:
         try:
             with request.urlopen(f"https://pypi.org/pypi/{product_name}/json") as server:
-                text = server.read()
+                text: bytes = server.read()
             data: dict[str, Any] = loads(text)
             return data.get("info", {}).get('version', None)
         except HTTPError:
             return None
 
     @classmethod
-    def install_from_pypi(cls, product_name: str, pypi_name: str):
+    def install_from_pypi(cls, product_name: str, pypi_name: str) -> Path | None:
         current_version = cls.get_installed_version(product_name)
         latest_version = cls.get_pypi_version(pypi_name)
         if current_version == latest_version:

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -79,7 +79,8 @@ class TranspilerInstaller(abc.ABC):
             with request.urlopen(url) as server:
                 text = server.read()
                 return cls._get_maven_version(text)
-        except HTTPError:
+        except HTTPError as e:
+            logger.error(f"Error while fetching maven metadata: {group_id}:{artifact_id}", exc_info=e)
             return None
 
     @classmethod

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -238,8 +238,10 @@ class MorpheusInstaller(TranspilerInstaller):
         current_version = cls.get_installed_version(cls.MORPHEUS_TRANSPILER_NAME)
         latest_version = cls.get_maven_version(cls.MORPHEUS_TRANSPILER_GROUP_NAME, cls.MORPHEUS_TRANSPILER_NAME)
         if latest_version is None:
-            logger.warning(f"Could not determine the latest version of Databricks Morpheus transpiler ({cls.MORPHEUS_TRANSPILER_GROUP_NAME}:{cls.MORPHEUS_TRANSPILER_NAME})")
-            logger.error(f"Failed to install transpiler: Databricks Morpheus transpiler")
+            logger.warning(
+                f"Could not determine the latest version of Databricks Morpheus transpiler ({cls.MORPHEUS_TRANSPILER_GROUP_NAME}:{cls.MORPHEUS_TRANSPILER_NAME})"
+            )
+            logger.error("Failed to install transpiler: Databricks Morpheus transpiler")
             return
         if current_version == latest_version:
             logger.info(f"Databricks Morpheus transpiler v{latest_version} already installed")

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -236,10 +236,11 @@ class MorpheusInstaller(TranspilerInstaller):
     def install(cls) -> None:
         current_version = cls.get_installed_version(cls.MORPHEUS_TRANSPILER_NAME)
         latest_version = cls.get_maven_version(cls.MORPHEUS_TRANSPILER_GROUP_NAME, cls.MORPHEUS_TRANSPILER_NAME)
+        if latest_version is None:
+            logger.warning(f"Could not determine the latest version of Databricks Morpheus transpiler ({cls.MORPHEUS_TRANSPILER_GROUP_NAME}:{cls.MORPHEUS_TRANSPILER_NAME})")
+            return
         if current_version == latest_version:
             logger.info(f"Databricks Morpheus transpiler v{latest_version} already installed")
-            return
-        if latest_version is None:
             return
         logger.info(f"Installing Databricks Morpheus transpiler v{latest_version}")
         product_path = cls.transpilers_path() / cls.MORPHEUS_TRANSPILER_NAME

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -309,10 +309,11 @@ class WorkspaceInstaller:
         module: str,
         config: RemorphConfigs | None = None,
     ) -> RemorphConfigs:
+        if module == "all":
+            logger.info(f"Installing Remorph v{self._product_info.version()}")
         if module in {"transpile", "all"}:
             self.install_rct()
             self.install_morpheus()
-        logger.info(f"Installing Remorph v{self._product_info.version()}")
         if not config:
             config = self.configure(module)
         if self._is_testing():


### PR DESCRIPTION
## Changes

This PR updates the logging while installing the transpilers. The goals of these changes are:

 - Less logging during normal routine installation.
 - Correct some misleading logging.
 - Improve the information available when things go wrong, to help users understand the cause of a problem and our ability to help them.

### Relevant implementation details

Technical changes include:

 - Removing a confusing message when installing the components:
   ```
   INFO: Installing Remorph v0.9.0
   ```
   Remorph is already installed at this point, so it made no sense.
 - Downgrading some logging from `INFO` to `DEBUG`. The goal here is reduce the normal logging so that there is less noise during routine progress. If we log before and after something that might fail, I have chosen to log at `DEBUG` before and `INFO` upon completion although either would be fine. (If you object, please say so.)
 - Ensuring that failures to contact PyPi or Maven Central are logged. These are early in the process, and will be a common source of failure. To support users (and let them help themselves) it is important that the reason for the failure be available.
 - Ensuring that an `ERROR` is logged on all the paths whereby we wanted to install a transpiler but this didn't happen.
 - Improved logging during the initial install if the component metadata can't be downloaded. This is really a failure, but previously we would log:
   ```
   INFO: databricks-labs-remorph-community-transpiler vNone is already installed.
   ```
   or
   ```
   INFO: Databricks Morpheus transpiler vNone already installed
   ```
   Now we instead log:
   ```
   WARN: Could not determine the latest version of: databricks-labs-remorph-community-transpiler
   ```
   and
   ```
   WARN: Could not determine the latest version of Databricks Morpheus transpiler (com.databricks.labs:morpheus)
   ```
   respectively. Both warnings are now also followed by an `ERROR` indicating that installation failed.
 - Some type hints have been added in a few places; this was purely opportunistic.

### Caveats/things to watch out for when reviewing:

The PyPi and Maven installation code isn't symmetrical, so the logging needs to be changed in multiple places.

To run the installer:

1. Wipe your remorph installation:
   ```sh
   rm -fr ~/.databricks/labs/remorph*
   ```
2. Install this branch:
   ```sh
   databricks labs install remorph@improve-install-logging
   ```
3. Work around an installer issue:
   ```sh
   mkdir -p ~/.databricks/labs/remorph-transpilers/remorph-community-transpiler
   ```
4. Install the components:
   ```sh
   databricks labs remorph install-transpile
   ```

### Functionality

- modified existing command: `databricks labs remorph install-transpile`

### Tests

- [X] manually tested
- [ ] added unit tests
- [ ] added integration tests

Some example logs from a clean install:
```
17:30:04  INFO [d.l.remorph.install] Successfully installed databricks-labs-remorph-community-transpiler v0.0.1
17:30:04  WARN [d.l.remorph.install] Could not determine the latest version of Databricks Morpheus transpiler (com.databricks.labs:morpheus)
17:30:04 ERROR [d.l.remorph.install] Failed to install transpiler: Databricks Morpheus transpiler
17:30:04  INFO [d.l.remorph.install] Configuring remorph `transpile`.
```

And a second run with the components already installed:
```
17:31:59  INFO [d.l.remorph.install] databricks-labs-remorph-community-transpiler v0.0.1 already installed
17:31:59  WARN [d.l.remorph.install] Could not determine the latest version of Databricks Morpheus transpiler (com.databricks.labs:morpheus)
17:31:59 ERROR [d.l.remorph.install] Failed to install transpiler: Databricks Morpheus transpiler
```