### PR TITLE
Reduce logging noise during normal transpiler processing.

### DIFF
--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -93,8 +93,8 @@ async def _process_many_files(
     all_errors: list[TranspileError] = []
 
     for file in files:
-        logger.info(f"Processing file: {file}")
         if not is_sql_file(file) and not is_dbt_project_file(file):
+            logger.debug(f"Ignored file: {file}")
             continue
         output_file_name = output_folder / file.name
         success_count, error_list = await _process_one_file(config, validator, transpiler, file, output_file_name)
@@ -121,7 +121,7 @@ async def _process_input_dir(config: TranspileConfig, validator: Validator | Non
     for source_dir, _, files in dir_walk(input_path):
         relative_path = cast(Path, source_dir).relative_to(input_path)
         transpiled_dir = output_folder / relative_path
-        logger.info(f"Transpiling sql files from folder: {source_dir!s} into {transpiled_dir!s}")
+        logger.debug(f"Transpiling sql files from folder: {source_dir!s} into {transpiled_dir!s}")
         file_list.extend(files)
         no_of_sqls, errors = await _process_many_files(config, validator, transpiler, transpiled_dir, files)
         counter = counter + no_of_sqls


### PR DESCRIPTION
## Changes

This PR updates the logging during transpiling to be less noisy. See below for the logs before and after.

### Linked issues

Resolves #1539.

### Functionality

- modified existing command: `databricks labs remorph transpile`

### Tests

- manually tested (against the development morpheus transpiler)

### Example Logs

Before:
```
14:57:51  INFO [d.l.r.t.lsp.lsp_engine] INFO [c.d.l.m.l.Main$] - Starting LSP server...
14:57:52  INFO [d.l.r.transpiler.execute] Transpiling sql files from folder: /tmp/tsql into /tmp/foo
14:57:52  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/verify.log
14:57:52  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/README.md
14:57:52  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/verify.py
14:57:52  INFO [d.l.r.transpiler.execute] Transpiling sql files from folder: /tmp/tsql/xxx into /tmp/foo/xxx
14:57:52  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/README.md
14:57:52  INFO [d.l.r.transpiler.execute] Transpiling sql files from folder: /tmp/tsql/xxx/queries into /tmp/foo/xxx/queries
14:57:52  INFO [d.l.r.transpiler.execute] Transpiling sql files from folder: /tmp/tsql/xxx/queries/03 into /tmp/foo/xxx/queries/03
14:57:52  INFO [d.l.r.transpiler.execute] Transpiling sql files from folder: /tmp/tsql/xxx/queries/03/038 into /tmp/foo/xxx/queries/03/038
14:57:52  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/038/0386.sql
14:57:53  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0386.sql (errors: 1)
14:57:53  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/038/0387.sql
14:57:53  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0387.sql (errors: 0)
14:57:53  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/038/0385.sql
14:57:53  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0385.sql (errors: 1)
14:57:53  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/038/0384.sql
14:57:53  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0384.sql (errors: 1)
14:57:53  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/038/0380.sql
14:57:54  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0380.sql (errors: 0)
14:57:54  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/038/0381.sql
14:57:54  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0381.sql (errors: 0)
14:57:54  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/038/0383.sql
14:57:54  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0383.sql (errors: 1)
14:57:54  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/038/0382.sql
14:57:54  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0382.sql (errors: 0)
14:57:54  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/038/0389.sql
14:57:54  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0389.sql (errors: 1)
14:57:54  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/038/0388.sql
14:57:54  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0388.sql (errors: 1)
14:57:54  INFO [d.l.r.transpiler.execute] Transpiling sql files from folder: /tmp/tsql/xxx/queries/03/036 into /tmp/foo/xxx/queries/03/036
14:57:54  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/036/0368.sql
14:57:54  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0368.sql (errors: 1)
14:57:54  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/036/0369.sql
14:57:54  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0369.sql (errors: 1)
14:57:54  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/036/0364.sql
14:57:54  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0364.sql (errors: 2)
14:57:54  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/036/0365.sql
14:57:54  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0365.sql (errors: 2)
14:57:54  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/036/0367.sql
14:57:54  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0367.sql (errors: 2)
14:57:54  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/036/0366.sql
14:57:54  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0366.sql (errors: 2)
14:57:54  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/036/0362.sql
14:57:54  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0362.sql (errors: 0)
14:57:54  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/036/0363.sql
14:57:54  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0363.sql (errors: 2)
14:57:54  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/036/0361.sql
14:57:54  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0361.sql (errors: 0)
14:57:54  INFO [d.l.r.transpiler.execute] Processing file: /tmp/tsql/xxx/queries/03/036/0360.sql
14:57:54  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0360.sql (errors: 2)
14:57:54  INFO [d.l.r.transpiler.execute] Transpiling sql files from folder: /tmp/tsql/xxx/queries/03/031 into /tmp/foo/xxx/queries/03/031
```

After:
```
15:02:35  INFO [d.l.r.t.lsp.lsp_engine] INFO [c.d.l.m.l.Main$] - Starting LSP server...
15:02:37  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0386.sql (errors: 1)
15:02:37  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0387.sql (errors: 0)
15:02:37  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0385.sql (errors: 1)
15:02:37  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0384.sql (errors: 1)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0380.sql (errors: 0)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0381.sql (errors: 0)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0383.sql (errors: 1)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0382.sql (errors: 0)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0389.sql (errors: 1)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/038/0388.sql (errors: 1)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0368.sql (errors: 1)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0369.sql (errors: 1)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0364.sql (errors: 2)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0365.sql (errors: 2)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0367.sql (errors: 2)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0366.sql (errors: 2)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0362.sql (errors: 0)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0363.sql (errors: 2)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0361.sql (errors: 0)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/036/0360.sql (errors: 2)
15:02:38  INFO [d.l.r.transpiler.execute] Processed file: /tmp/tsql/xxx/queries/03/031/0319.sql (errors: 0)
```