### PR TITLE
Improve CLI 'transpile' UX

### DIFF
--- a/labs.yml
+++ b/labs.yml
@@ -13,26 +13,28 @@ commands:
     flags:
       - name: transpiler-config-path
         description: Path to the transpiler configuration file
+        default: null
       - name: source-dialect
         description: Dialect name
         default: null
       - name: input-source
         description: Input SQL Folder or File
+        default: null
       - name: output-folder
-        default: null
         description: Output Location For Storing Transpiled Code, defaults to input-source folder
+        default: null
       - name: error-file-path
-        default: null
         description: Output Location For Storing Errors, defaults to input-source folder
+        default: null
       - name: skip-validation
-        default: true
         description: Validate Transpiled Code, default True validation skipped, False validate
+        default: true
       - name: catalog-name
-        default: null
         description: Catalog Name Applicable only when Validation Mode is DATABRICKS
-      - name: schema-name
         default: null
+      - name: schema-name
         description: Schema Name Applicable only when Validation Mode is DATABRICKS
+        default: null
 
     table_template: |-
       total_files_processed\ttotal_queries_processed\tanalysis_error_count\tparsing_error_count\tvalidation_error_count\tgeneration_error_count\terror_log_file

--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -5,19 +5,20 @@ import os
 import time
 import sys
 from pathlib import Path
+from typing import cast
 
 from databricks.labs.blueprint.cli import App
 from databricks.labs.blueprint.entrypoint import get_logger
 
 from databricks.labs.remorph.assessments.configure_assessment import ConfigureAssessment
-from databricks.labs.remorph.config import TranspileConfig
+from databricks.labs.remorph.config import TranspileConfig, LSPConfigOptionV1, JsonType
 from databricks.labs.remorph.connections.credential_manager import create_credential_manager
 from databricks.labs.remorph.connections.env_getter import EnvGetter
 from databricks.labs.remorph.contexts.application import ApplicationContext
 from databricks.labs.blueprint.tui import Prompts
 from databricks.labs.remorph.helpers.recon_config_utils import ReconConfigPrompts
 from databricks.labs.remorph.__about__ import __version__
-from databricks.labs.remorph.install import WorkspaceInstaller
+from databricks.labs.remorph.install import WorkspaceInstaller, TranspilerInstaller
 from databricks.labs.remorph.reconcile.runner import ReconcileRunner
 from databricks.labs.remorph.lineage import lineage_generator
 from databricks.labs.remorph.transpiler.execute import transpile as do_transpile
@@ -27,6 +28,7 @@ from databricks.sdk.service.sql import CreateWarehouseRequestWarehouseType
 
 from databricks.sdk import WorkspaceClient
 
+from databricks.labs.remorph.transpiler.lsp.lsp_engine import LSPConfig
 from databricks.labs.remorph.transpiler.sqlglot.sqlglot_engine import SqlglotEngine
 from databricks.labs.remorph.transpiler.transpile_engine import TranspileEngine
 
@@ -90,81 +92,176 @@ def _verify_workspace_client(ws: WorkspaceClient) -> WorkspaceClient:
 @remorph.command
 def transpile(
     w: WorkspaceClient,
-    transpiler_config_path: str | None = None,
-    source_dialect: str | None = None,
-    input_source: str | None = None,
-    output_folder: str | None = None,
-    error_file_path: str | None = None,
-    skip_validation: str | None = None,
-    catalog_name: str | None = None,
-    schema_name: str | None = None,
+    transpiler_config_path: str,
+    source_dialect: str,
+    input_source: str,
+    output_folder: str | None,
+    error_file_path: str | None,
+    skip_validation: str,
+    catalog_name: str,
+    schema_name: str,
 ):
     """Transpiles source dialect to databricks dialect"""
     ctx = ApplicationContext(w)
     print(f"{ctx.transpile_config!s}")
-    checker = _TranspileConfigChecker(ctx.transpile_config)
-    checker.use_transpiler_config_path(transpiler_config_path)
-    checker.use_source_dialect(source_dialect)
-    checker.use_input_source(input_source)
-    checker.use_output_folder(output_folder)
-    checker.use_error_file_path(error_file_path)
-    checker.use_skip_validation(skip_validation)
-    checker.use_catalog_name(catalog_name)
-    checker.use_schema_name(schema_name)
+    checker = _TranspileConfigChecker(ctx.transpile_config, ctx.prompts)
+    checker.check_input_source(input_source)
+    checker.check_source_dialect(source_dialect)
+    checker.check_transpiler_config_path(transpiler_config_path)
+    checker.check_transpiler_config_options()
+    checker.check_output_folder(output_folder)
+    checker.check_error_file_path(error_file_path)
+    checker.check_skip_validation(skip_validation)
+    checker.check_catalog_name(catalog_name)
+    checker.check_schema_name(schema_name)
     config, engine = checker.check()
     asyncio.run(_transpile(ctx, config, engine))
 
 
 class _TranspileConfigChecker:
 
-    def __init__(self, config: TranspileConfig | None):
+    def __init__(self, config: TranspileConfig | None, prompts: Prompts):
         if not config:
             raise SystemExit("Installed transpile config not found. Please install Remorph transpile first.")
         self._config: TranspileConfig = config
+        self._prompts = prompts
 
-    def use_transpiler_config_path(self, transpiler_config_path: str | None):
-        if transpiler_config_path and transpiler_config_path != "None":
-            logger.debug(f"Setting transpiler_config_path to '{transpiler_config_path}'")
-            self._config = dataclasses.replace(self._config, transpiler_config_path=transpiler_config_path)
+    def check_input_source(self, input_source: str | None):
+        if input_source == "None":
+            input_source = None
+        if not input_source:
+            input_source = self._config.input_source
+        if not input_source:
+            input_source = self._prompts.question("Enter input SQL path (directory/file)")
+        if not input_source:
+            raise_validation_exception("Missing '--input-source'")
+        if not os.path.exists(input_source):
+            raise_validation_exception(f"Invalid value for '--input-source': Path '{input_source}' does not exist.")
+        logger.debug(f"Setting input_source to '{input_source}'")
+        self._config = dataclasses.replace(self._config, input_source=input_source)
 
-    def use_source_dialect(self, source_dialect: str | None):
-        if source_dialect and source_dialect != "None":
-            logger.debug(f"Setting source_dialect to '{source_dialect}'")
-            self._config = dataclasses.replace(self._config, source_dialect=source_dialect)
+    def check_source_dialect(self, source_dialect: str | None):
+        if source_dialect == "None":
+            source_dialect = None
+        if not source_dialect:
+            source_dialect = self._config.source_dialect
+        if not source_dialect:
+            all_dialects = sorted(TranspilerInstaller.all_dialects())
+            source_dialect = self._prompts.choice("Select the source dialect:", all_dialects)
+        if not source_dialect:
+            raise_validation_exception("Missing '--source-dialect'")
+        logger.debug(f"Setting source_dialect to '{source_dialect}'")
+        self._config = dataclasses.replace(self._config, source_dialect=source_dialect)
 
-    def use_input_source(self, input_source: str | None):
-        if input_source and input_source != "None":
-            logger.debug(f"Setting input_source to '{input_source}'")
-            self._config = dataclasses.replace(self._config, input_source=input_source)
+    def check_transpiler_config_path(self, transpiler_config_path: str | None):
+        transpiler_names = TranspilerInstaller.transpilers_with_dialect(cast(str, self._config.source_dialect))
+        valid_paths = set(TranspilerInstaller.transpiler_config_path(name) for name in transpiler_names)
+        if transpiler_config_path == "None":
+            transpiler_config_path = None
+        if not transpiler_config_path:
+            transpiler_config_path = self._config.transpiler_config_path
+        if transpiler_config_path not in valid_paths:
+            if transpiler_config_path:
+                logger.error(f"The configured transpiler does not support dialect '{self._config.source_dialect}.")
+            if len(transpiler_names) > 1:
+                transpiler_name = self._prompts.choice("Select the transpiler:", list(transpiler_names))
+            else:
+                transpiler_name = next(name for name in transpiler_names)
+                logger.info(f"Remorph will use the {transpiler_name} transpiler")
+            transpiler_config_path = TranspilerInstaller.transpiler_config_path(transpiler_name)
+        logger.debug(f"Setting transpiler_config_path to '{transpiler_config_path}'")
+        self._config = dataclasses.replace(self._config, transpiler_config_path=cast(str, transpiler_config_path))
 
-    def use_output_folder(self, output_folder: str | None):
-        if output_folder and output_folder != "None":
-            logger.debug(f"Setting output_folder to '{output_folder}'")
-            self._config = dataclasses.replace(self._config, output_folder=output_folder)
+    def check_transpiler_config_options(self):
+        lsp_config = LSPConfig.load(Path(self._config.transpiler_config_path))
+        options_to_configure = lsp_config.options_for_dialect(self._config.source_dialect) or []
+        transpiler_options = self._config.transpiler_options or {}
+        if len(options_to_configure) == 0:
+            transpiler_options = None
+        else:
+            # TODO delete stale options ?
+            for option in options_to_configure:
+                self._check_transpiler_config_option(option, transpiler_options)
+        logger.debug(f"Setting transpiler_options to {transpiler_options}")
+        self._config = dataclasses.replace(self._config, transpiler_options=transpiler_options)
 
-    def use_error_file_path(self, error_file_path: str | None):
-        if error_file_path and error_file_path != "None":
-            logger.debug(f"Setting error_file_path to '{error_file_path}'")
-            self._config = dataclasses.replace(self._config, error_file_path=error_file_path)
+    def _check_transpiler_config_option(self, option: LSPConfigOptionV1, values: dict[str, JsonType]):
+        if option.flag in values.keys():
+            return
+        values[option.flag] = option.prompt_for_value(self._prompts)
 
-    def use_skip_validation(self, skip_validation: str | None):
-        if skip_validation and skip_validation != "None":
-            if skip_validation.lower() not in {"true", "false"}:
+    def check_output_folder(self, output_folder: str | None):
+        if output_folder == "None":
+            output_folder = None
+        if not output_folder:
+            output_folder = self._config.output_folder
+        if not output_folder:
+            output_folder = self._prompts.question("Enter output directory", default="transpiled")
+        if not output_folder:
+            raise_validation_exception("Missing '--output-folder'")
+        if not os.path.exists(output_folder):
+            raise_validation_exception(f"Invalid value for '--output-folder': Path '{output_folder}' does not exist.")
+        logger.debug(f"Setting output_folder to '{output_folder}'")
+        self._config = dataclasses.replace(self._config, output_folder=output_folder)
+
+    def check_error_file_path(self, error_file_path: str | None):
+        if error_file_path == "None":
+            error_file_path = None
+        if not error_file_path:
+            error_file_path = self._config.error_file_path
+        if not error_file_path:
+            error_file_path = self._prompts.question("Enter error file path", default="errors.log")
+        if not error_file_path:
+            raise_validation_exception("Missing '--error-file-path'")
+        logger.debug(f"Setting error_file_path to '{error_file_path}'")
+        self._config = dataclasses.replace(self._config, error_file_path=error_file_path)
+
+    def check_skip_validation(self, skip_validation_str: str | None):
+        skip_validation: bool | None = None
+        if skip_validation_str == "None":
+            skip_validation_str = None
+        if skip_validation_str is not None:
+            if skip_validation_str.lower() not in {"true", "false"}:
                 raise_validation_exception(
-                    f"Invalid value for '--skip-validation': '{skip_validation}' is not one of 'true', 'false'."
+                    f"Invalid value for '--skip-validation': '{skip_validation_str}' is not one of 'true', 'false'."
                 )
-            logger.debug(f"Setting skip_validation to '{skip_validation}'")
-            self._config = dataclasses.replace(self._config, skip_validation=skip_validation.lower() == "true")
+            skip_validation = skip_validation_str.lower() == "true"
+        if skip_validation is None:
+            skip_validation = self._config.skip_validation
+        if skip_validation is None:
+            skip_validation = self._prompts.confirm(
+                "Would you like to validate the syntax and semantics of the transpiled queries?"
+            )
+        logger.debug(f"Setting skip_validation to '{skip_validation}'")
+        self._config = dataclasses.replace(self._config, skip_validation=skip_validation)
 
-    def use_catalog_name(self, catalog_name: str | None):
-        if catalog_name and catalog_name != "None":
-            logger.debug(f"Setting catalog_name to '{catalog_name}'")
-            self._config = dataclasses.replace(self._config, catalog_name=catalog_name)
+    def check_catalog_name(self, catalog_name: str | None):
+        if not self._config.skip_validation:
+            return
+        if catalog_name == "None":
+            catalog_name = None
+        if not catalog_name:
+            catalog_name = self._config.catalog_name
+        if not catalog_name:
+            raise_validation_exception(
+                "Missing '--catalog-name', please run 'databricks labs remorph install-transpile' to configure one"
+            )
+        logger.debug(f"Setting catalog_name to '{catalog_name}'")
+        self._config = dataclasses.replace(self._config, catalog_name=catalog_name)
 
-    def use_schema_name(self, schema_name: str | None):
-        if schema_name and schema_name != "None":
-            logger.debug(f"Setting schema_name to '{schema_name}'")
-            self._config = dataclasses.replace(self._config, schema_name=schema_name)
+    def check_schema_name(self, schema_name: str | None):
+        if not self._config.skip_validation:
+            return
+        if schema_name == "None":
+            schema_name = None
+        if not schema_name:
+            schema_name = self._config.schema_name
+        if not schema_name:
+            raise_validation_exception(
+                "Missing '--schema-name', please run 'databricks labs remorph install-transpile' to configure one"
+            )
+        logger.debug(f"Setting schema_name to '{schema_name}'")
+        self._config = dataclasses.replace(self._config, schema_name=schema_name)
 
     def check(self) -> tuple[TranspileConfig, TranspileEngine]:
         logger.debug(f"Checking config: {self!s}")

--- a/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/remorph/transpiler/lsp/lsp_engine.py
@@ -82,6 +82,9 @@ class LSPConfig:
     def name(self):
         return self.remorph.name
 
+    def options_for_dialect(self, source_dialect: str) -> list[LSPConfigOptionV1]:
+        return self.options.get("all", []) + self.options.get(source_dialect, [])
+
     @classmethod
     def load(cls, path: Path) -> LSPConfig:
         yaml_text = path.read_text()


### PR DESCRIPTION
In order to transpile code, the user must call:
`databricks labs remorph transpile ...`
Our current implementation requires the user to pass all `transpile` config options as parameters to the above command, which is painful, and leads to wonder what's the point in configuring the transpiler...
PR #1488 makes it less painful by making all parameters optional, and using their configured counterpart if not provided.
However, if the resulting config is inconsistent, it will fail, which can be frustrating.
This PR goes a step further by prompting the user if a config value is missing or inconsistent.

(not tested yet)

Requires #1488 
   