### PR TITLE
Update cryptography requirement (via dependabot)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
   "sqlglot==26.1.3",
   "databricks-labs-blueprint[yaml]>=0.10.1",
   "databricks-labs-lsql==0.16.0",
-  "cryptography~=44.0.2",
+  "cryptography>=44.0.2,<45.1.0",
   "pyodbc~=5.2.0",
   "SQLAlchemy~=2.0.40",
   "pygls~=2.0.0a2",


### PR DESCRIPTION
This PR is the same as #1589, which doesn't build because actions from dependabot-submitted PRs don't seem to have access to the credentials they need to run tests against the acceptance environment.

(When merged, this will close the upstream PR as well.)