### PR TITLE
Update maven installer to not use `search.maven.org`

### DIFF
--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -14,6 +14,7 @@ from urllib.error import URLError, HTTPError
 import webbrowser
 from datetime import datetime, timezone
 from pathlib import Path
+import xml.etree.ElementTree as ET
 from zipfile import ZipFile
 
 from databricks.labs.blueprint.installation import Installation
@@ -298,47 +299,80 @@ class PypiInstaller(TranspilerInstaller):
 
 
 class MavenInstaller(TranspilerInstaller):
+    # Maven Central, base URL.
+    _maven_central_repo: str = "https://repo.maven.apache.org/maven2/"
 
     @classmethod
-    def get_maven_artifact_version(cls, group_id: str, artifact_id: str) -> str | None:
+    def _artifact_base_url(cls, group_id: str, artifact_id: str) -> str:
+        """Construct the base URL for a Maven artifact."""
+        # Reference: https://maven.apache.org/repositories/layout.html
+        group_path = group_id.replace(".", "/")
+        return f"{cls._maven_central_repo}{group_path}/{artifact_id}/"
+
+    @classmethod
+    def artifact_metadata_url(cls, group_id: str, artifact_id: str) -> str:
+        """Get the metadata URL for a Maven artifact."""
+        # TODO: Unit test this method.
+        return f"{cls._artifact_base_url(group_id, artifact_id)}maven-metadata.xml"
+
+    @classmethod
+    def artifact_url(
+        cls, group_id: str, artifact_id: str, version: str, classifier: str | None = None, extension: str = "jar"
+    ) -> str:
+        """Get the URL for a versioned Maven artifact."""
+        # TODO: Unit test this method, including classifier and extension.
+        _classifier = f"-{classifier}" if classifier else ""
+        artifact_base_url = cls._artifact_base_url(group_id, artifact_id)
+        return f"{artifact_base_url}{version}/{artifact_id}-{version}{_classifier}.{extension}"
+
+    @classmethod
+    def get_current_maven_artifact_version(cls, group_id: str, artifact_id: str) -> str | None:
+        url = cls.artifact_metadata_url(group_id, artifact_id)
         try:
-            url = (
-                f"https://search.maven.org/solrsearch/select?q=g:{group_id}+AND+a:{artifact_id}&core=gav&rows=1&wt=json"
-            )
             with request.urlopen(url) as server:
                 text = server.read()
-                return cls._extract_maven_artifact_version(text)
         except HTTPError as e:
             logger.error(f"Error while fetching maven metadata: {group_id}:{artifact_id}", exc_info=e)
             return None
+        logger.debug(f"Maven metadata for {group_id}:{artifact_id}: {text}")
+        return cls._extract_latest_release_version(text)
 
     @classmethod
-    def _extract_maven_artifact_version(cls, text: str) -> str | None:
-        data: dict[str, Any] = loads(text)
-        response: dict[str, Any] | None = data.get("response", None)
-        if not response:
-            return None
-        docs: list[dict[str, Any]] = response.get('docs', None)
-        if not docs or len(docs) < 1:
-            return None
-        return docs[0].get("v", None)
+    def _extract_latest_release_version(cls, maven_metadata: str) -> str | None:
+        """Extract the latest release version from Maven metadata."""
+        # Reference: https://maven.apache.org/repositories/metadata.html#The_A_Level_Metadata
+        # TODO: Unit test this method, to verify the sequence of things it checks for.
+        root = ET.fromstring(maven_metadata)
+        for label in ("release", "latest"):
+            version = root.findtext(f"./versioning/{label}")
+            if version is not None:
+                return version
+        return root.findtext("./versioning/versions/version[last()]")
 
     @classmethod
     def download_artifact_from_maven(
-        cls, group_id: str, artifact_id: str, version: str, target: Path, extension="jar"
+        cls,
+        group_id: str,
+        artifact_id: str,
+        version: str,
+        target: Path,
+        classifier: str | None = None,
+        extension: str = "jar",
     ) -> int:
-        group_id = group_id.replace(".", "/")
-        url = f"https://search.maven.org/remotecontent?filepath={group_id}/{artifact_id}/{version}/{artifact_id}-{version}.{extension}"
+        if target.exists():
+            logger.warning(f"Skipping download of {group_id}:{artifact_id}:{version}; target already exists: {target}")
+            return 0
+        url = cls.artifact_url(group_id, artifact_id, version, classifier, extension)
         try:
             path, _ = request.urlretrieve(url)
-            logger.info(f"Successfully downloaded {path}")
-            if not target.exists():
-                logger.info(f"Moving {path} to {target!s}")
-                move(path, str(target))
-            return 0
+            logger.debug(f"Downloaded maven artefact from {url} to {path}")
         except URLError as e:
-            logger.error("While downloading from maven", exc_info=e)
+            logger.error(f"Unable to download maven artefact: {group_id}:{artifact_id}:{version}", exc_info=e)
             return -1
+        logger.debug(f"Moving {path} to {target}")
+        move(path, target)
+        logger.info(f"Successfully installed: {group_id}:{artifact_id}:{version}")
+        return 0
 
     def __init__(self, product_name: str, group_id: str, artifact_id: str):
         self._product_name = product_name
@@ -349,7 +383,7 @@ class MavenInstaller(TranspilerInstaller):
         return self._install_checking_versions()
 
     def _install_checking_versions(self) -> Path | None:
-        self._latest_version = self.get_maven_artifact_version(self._group_id, self._artifact_id)
+        self._latest_version = self.get_current_maven_artifact_version(self._group_id, self._artifact_id)
         if self._latest_version is None:
             logger.warning(f"Could not determine the latest version of Databricks {self._product_name} transpiler")
             logger.error("Failed to install transpiler: Databricks {self._product_name} transpiler")

--- a/tests/integration/install/test_install.py
+++ b/tests/integration/install/test_install.py
@@ -19,10 +19,9 @@ def test_gets_installed_remorph_version(patched_transpiler_installer):
     check_valid_version(version)
 
 
-@pytest.mark.skip(reason="The search.maven.org service is too unreliable; our dependency on it will be removed.")
-def test_gets_maven_artifact_version():
-    version = MavenInstaller.get_maven_artifact_version("com.databricks", "databricks-connect")
-    assert version, "Maybe maven search is down ? (check https://status.maven.org/)"
+def test_gets_maven_artifact_version() -> None:
+    version = MavenInstaller.get_current_maven_artifact_version("com.databricks", "databricks-connect")
+    assert version
     check_valid_version(version)
 
 
@@ -215,7 +214,15 @@ class PatchedMavenInstaller(MavenInstaller):
         return "0.2.0"
 
     @classmethod
-    def download_artifact_from_maven(cls, group_id: str, artifact_id: str, version: str, target: Path, extension="jar"):
+    def download_artifact_from_maven(
+        cls,
+        group_id: str,
+        artifact_id: str,
+        version: str,
+        target: Path,
+        classifier: str | None = None,
+        extension: str = "jar",
+    ) -> int:
         sample_jar = (
             Path(__file__).parent.parent.parent
             / "resources"

--- a/tests/integration/install/test_install.py
+++ b/tests/integration/install/test_install.py
@@ -210,7 +210,7 @@ async def test_installs_and_runs_bladerunner(patched_transpiler_installer):
 class PatchedMavenInstaller(MavenInstaller):
 
     @classmethod
-    def get_maven_artifact_version(cls, group_id: str, artifact_id: str):
+    def get_current_maven_artifact_version(cls, group_id: str, artifact_id: str):
         return "0.2.0"
 
     @classmethod


### PR DESCRIPTION
## Changes

### What does this PR do?

This PR updates `MavenInstaller` so that it no longer uses `search.maven.org` to either:

 - Locate the current version of an artefact; or
 - Download the actual artefact.

### Relevant implementation details

The installer now fetches the metadata needed for detecting the version, as well as the artefact itself, from the maven central repository directly. This is the CDN-backed service where artefacts are supposed to be fetched from, and it is much more reliable than the search service.

In addition to this, the installer had some logic that could abort the installation if a file already exists at the target location on the local filesystem. This check now happens before the download so that it aborts immediately rather than first performing the (ultimately futile) download.

### Caveats/things to watch out for when reviewing:

In addition to using the repository directly, this PR starts plumbing through support for providing the artefact classifier. ~Another PR will be needed to:~

~1. Expose the classifier as a parameter.~
~2. Update `install_morpheus()` to provide the classifier.~

~(Without these the normal installer will fail even after we publish morpheus because we're not currently specifying the classifier.)~

[It looks like we're not publishing with a classifier, so this isn't needed.]

### Linked issues

Resolves #1602 

### Functionality

- modified existing command: `databricks labs remorph install-transpile`

### Tests

- updated integration tests
