### PR TITLE
Drop post-install support for Java-based transpilers

### DIFF
--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -613,10 +613,10 @@ class WorkspaceInstaller:
         self._save_config(config)
         return config
 
-    def _all_installed_dialects(self):
+    def _all_installed_dialects(self) -> list[str]:
         return sorted(TranspilerInstaller.all_dialects())
 
-    def _transpilers_with_dialect(self, dialect: str):
+    def _transpilers_with_dialect(self, dialect: str) -> list[str]:
         return sorted(TranspilerInstaller.transpilers_with_dialect(dialect))
 
     def _transpiler_config_path(self, transpiler: str) -> Path:

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -409,7 +409,7 @@ class MavenInstaller(TranspilerInstaller):
         self._install_path = self._product_path / "lib"
         self._install_path.mkdir()
         try:
-            result = self._unsafe_install_latest_version(version)
+            result = self._unsafe_install_version(version)
             logger.info(f"Successfully installed {self._product_name} v{version}")
             if backup_path.exists():
                 rmtree(backup_path)
@@ -421,7 +421,7 @@ class MavenInstaller(TranspilerInstaller):
                 os.rename(backup_path, self._product_path)
             return None
 
-    def _unsafe_install_latest_version(self, version: str) -> Path | None:
+    def _unsafe_install_version(self, version: str) -> Path | None:
         jar_file_path = self._install_path / f"{self._artifact_id}.jar"
         success = self.download_artifact_from_maven(self._group_id, self._artifact_id, version, jar_file_path)
         if not success:

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -171,7 +171,7 @@ class PypiInstaller(TranspilerInstaller):
             logger.info(f"Successfully downloaded {path}")
             if not target.exists():
                 logger.info(f"Moving {path} to {target!s}")
-                move(path, str(target))
+                move(path, target)
             return 0
         except URLError as e:
             logger.error("While downloading from pypi", exc_info=e)
@@ -412,11 +412,11 @@ class MavenInstaller(TranspilerInstaller):
             result = self._unsafe_install_latest_version(version)
             logger.info(f"Successfully installed {self._product_name} v{version}")
             if backup_path.exists():
-                rmtree(str(backup_path))
+                rmtree(backup_path)
             return result
         except (CalledProcessError, ValueError) as e:
             logger.error(f"Failed to install {self._product_name} v{version}", exc_info=e)
-            rmtree(str(self._product_path))
+            rmtree(self._product_path)
             if backup_path.exists():
                 os.rename(backup_path, self._product_path)
             return None

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -401,6 +401,8 @@ class MavenInstaller(TranspilerInstaller):
         # use type(self) to workaround a mock bug on class methods
         self._product_path = type(self).transpilers_path() / self._product_name
         backup_path = Path(f"{self._product_path!s}-saved")
+        if backup_path.exists():
+            rmtree(backup_path)
         if self._product_path.exists():
             os.rename(self._product_path, backup_path)
         self._product_path.mkdir(parents=True)

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -394,9 +394,9 @@ class MavenInstaller(TranspilerInstaller):
         if installed_version == latest_version:
             logger.info(f"Databricks {self._product_name} transpiler v{latest_version} already installed")
             return None
-        return self._install_latest_version(latest_version)
+        return self._install_version(latest_version)
 
-    def _install_latest_version(self, version: str) -> Path | None:
+    def _install_version(self, version: str) -> Path | None:
         logger.info(f"Installing Databricks {self._product_name} transpiler v{version}")
         # use type(self) to workaround a mock bug on class methods
         self._product_path = type(self).transpilers_path() / self._product_name

--- a/tests/integration/install/test_install.py
+++ b/tests/integration/install/test_install.py
@@ -28,10 +28,10 @@ def test_gets_maven_artifact_version() -> None:
 def test_downloads_from_maven():
     with TemporaryDirectory() as parent:
         path = Path(parent) / "pom.xml"
-        result = MavenInstaller.download_artifact_from_maven(
+        success = MavenInstaller.download_artifact_from_maven(
             "com.databricks", "databricks-connect", "16.0.0", path, extension="pom"
         )
-        assert result == 0
+        assert success
         assert path.exists()
         assert path.stat().st_size == 5_684
 
@@ -222,7 +222,7 @@ class PatchedMavenInstaller(MavenInstaller):
         target: Path,
         classifier: str | None = None,
         extension: str = "jar",
-    ) -> int:
+    ) -> bool:
         sample_jar = (
             Path(__file__).parent.parent.parent
             / "resources"
@@ -233,7 +233,7 @@ class PatchedMavenInstaller(MavenInstaller):
         )
         assert sample_jar.exists()
         shutil.copyfile(sample_jar, target)
-        return 0
+        return True
 
 
 async def test_installs_and_runs_morpheus(patched_transpiler_installer):


### PR DESCRIPTION
## Changes

### What does this PR do? 

This PR updates the maven-based installer so that:

1. It no longer copies all `lsp/` resources from the JAR into the transpiler directory;
2. It no longer supports running `lsp/install.sh` after the install.
3. It fails immediately instead of proceeding if the `config.yml` file is missing from the JAR.

This PR does not affect the PyPi-based installer for BB.

### Caveats/things to watch out for when reviewing:

Aside from the above behaviour changes, some type-related changes are present:

 - Additional type-hints in a few places.
 - Paths are passed around as-is for longer, with conversion to string only when necessary.
 - Some methods now indicate success with a boolean rather than using an integer.

### Linked issues

This is stacked on top of #1615, which should be dealt with first.

### Functionality

- modified existing command: `databricks labs remorph install-transpiler`

### Tests

- manually tested
- existing unit tests
- existing integration tests
