### PR TITLE
Distinguish errors from warnings in the output query header

### DIFF
--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -4,6 +4,7 @@ import logging
 import math
 from pathlib import Path
 from typing import cast, Any
+import itertools
 
 from databricks.labs.remorph.__about__ import __version__
 from databricks.labs.remorph.config import (
@@ -107,26 +108,43 @@ async def _process_one_file(
 
 
 def _make_header(file_path: Path, errors: list[TranspileError]) -> str:
-    header = f"/*\n    Transpiled from {file_path}\n"
+    header = ""
     failed_producing_output = False
-    if errors:
+    diagBySeverity = {}
+
+    for severity, diags in itertools.groupby(errors, key=lambda x: x.severity):
+        diagBySeverity[severity] = list(diags)
+
+    if ErrorSeverity.ERROR in diagBySeverity.keys():
+        header += f"/*\n    Failed transpilation of {file_path}\n"
         header += "\n    The following errors were found while transpiling:\n"
-        for diag in errors:
-            if diag.range:
-                line = diag.range.start.line + 1
-                column = (
-                    diag.range.start.character + 1 + 2
-                )  # + 1 to make it one-based, + 2 to take indentation into account
-                header += f"      - [{line}:{column}] {diag.message}\n"
-            else:
-                header += f"      - {diag.message}\n"
+        for diag in diagBySeverity[ErrorSeverity.ERROR]:
+            header += _append_diagnostic(diag)
             failed_producing_output = failed_producing_output or diag.kind == ErrorKind.PARSING
+    else:
+        header += f"/*\n    Successfully transpiled from {file_path}\n"
+
+    if ErrorSeverity.WARNING in diagBySeverity.keys():
+        header += "\n    The following warnings were found while transpiling:\n"
+        for diag in diagBySeverity[ErrorSeverity.WARNING]:
+            header += _append_diagnostic(diag)
 
     if failed_producing_output:
         header += "\n\n    Parsing errors prevented the converter from translating the input query.\n"
         header += "    We reproduce the input query unchanged below.\n\n"
 
     return header + "*/\n"
+
+
+def _append_diagnostic(diag: TranspileError) -> str:
+    if diag.range:
+        line = diag.range.start.line + 1
+        column = (
+            diag.range.start.character + 1 + 2
+        )  # + 1 to make it one-based, + 2 to take indentation into account
+        return f"      - [{line}:{column}] {diag.message}\n"
+    else:
+        return f"      - {diag.message}\n"
 
 
 async def _process_many_files(

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -115,7 +115,7 @@ def _make_header(file_path: Path, errors: list[TranspileError]) -> str:
     for severity, diags in itertools.groupby(errors, key=lambda x: x.severity):
         diag_by_severity[severity] = list(diags)
 
-    if ErrorSeverity.ERROR in diag_by_severity.keys():
+    if ErrorSeverity.ERROR in diag_by_severity:
         header += f"/*\n    Failed transpilation of {file_path}\n"
         header += "\n    The following errors were found while transpiling:\n"
         for diag in diag_by_severity[ErrorSeverity.ERROR]:
@@ -124,7 +124,7 @@ def _make_header(file_path: Path, errors: list[TranspileError]) -> str:
     else:
         header += f"/*\n    Successfully transpiled from {file_path}\n"
 
-    if ErrorSeverity.WARNING in diag_by_severity.keys():
+    if ErrorSeverity.WARNING in diag_by_severity:
         header += "\n    The following warnings were found while transpiling:\n"
         for diag in diag_by_severity[ErrorSeverity.WARNING]:
             header += _append_diagnostic(diag)

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -110,23 +110,23 @@ async def _process_one_file(
 def _make_header(file_path: Path, errors: list[TranspileError]) -> str:
     header = ""
     failed_producing_output = False
-    diagBySeverity = {}
+    diag_by_severity = {}
 
     for severity, diags in itertools.groupby(errors, key=lambda x: x.severity):
-        diagBySeverity[severity] = list(diags)
+        diag_by_severity[severity] = list(diags)
 
-    if ErrorSeverity.ERROR in diagBySeverity.keys():
+    if ErrorSeverity.ERROR in diag_by_severity.keys():
         header += f"/*\n    Failed transpilation of {file_path}\n"
         header += "\n    The following errors were found while transpiling:\n"
-        for diag in diagBySeverity[ErrorSeverity.ERROR]:
+        for diag in diag_by_severity[ErrorSeverity.ERROR]:
             header += _append_diagnostic(diag)
             failed_producing_output = failed_producing_output or diag.kind == ErrorKind.PARSING
     else:
         header += f"/*\n    Successfully transpiled from {file_path}\n"
 
-    if ErrorSeverity.WARNING in diagBySeverity.keys():
+    if ErrorSeverity.WARNING in diag_by_severity.keys():
         header += "\n    The following warnings were found while transpiling:\n"
-        for diag in diagBySeverity[ErrorSeverity.WARNING]:
+        for diag in diag_by_severity[ErrorSeverity.WARNING]:
             header += _append_diagnostic(diag)
 
     if failed_producing_output:
@@ -139,12 +139,9 @@ def _make_header(file_path: Path, errors: list[TranspileError]) -> str:
 def _append_diagnostic(diag: TranspileError) -> str:
     if diag.range:
         line = diag.range.start.line + 1
-        column = (
-            diag.range.start.character + 1 + 2
-        )  # + 1 to make it one-based, + 2 to take indentation into account
+        column = diag.range.start.character + 1 + 2  # + 1 to make it one-based, + 2 to take indentation into account
         return f"      - [{line}:{column}] {diag.message}\n"
-    else:
-        return f"      - {diag.message}\n"
+    return f"      - {diag.message}\n"
 
 
 async def _process_many_files(


### PR DESCRIPTION

## Changes
### What does this PR do? 

This PR changes the way the header comment above transpiled query is built, by distinguishing `WARNING` and `ERROR` diagnostics. 

When no `ERROR` level diagnostic appears, the query is displayed as successfully transpiled (possibly with a set of warnings).

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs remorph ...`
- [ ] ... +add your own

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
