### PR TITLE
Ci/fix scope of integration tests

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -23,8 +23,8 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     environment: tool
     runs-on:
-      group: databrickslabs-protected-runner-group
-      labels: linux-ubuntu-latest
+      group: larger-runners
+      labels: larger
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -32,9 +32,10 @@ def pytest_collection_modifyitems(config, items):
     if os.getenv('TEST_ENV') == 'ACCEPTANCE':
         selected_items = []
         deselected_items = []
-        # Added only specific tests to run from acceptance.yml
+        # Add only specific tests to run from acceptance.yml
+        inclusions = { 'assessments', 'connections', 'discovery', 'transpile' }
         for item in items:
-            if 'tests/integration/reconcile' not in str(item.fspath) and 'tests/unit/' not in str(item.fspath):
+            if any(f"tests/integration/{inclusion}" in str(item.fspath) for inclusion in inclusions):
                 selected_items.append(item)
             else:
                 deselected_items.append(item)


### PR DESCRIPTION
Our integration tests are ran from 2 workflows: push and acceptance (with DB platform access)
However, which specific integration tests are ran depends on a pytest hook.
This PR adjusts this hook such that only tests requiring DB platform access are ran as part of acceptance.
It also moves them to larger runners.