### PR TITLE
Change error-reporting during `transpile`

### DIFF
--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -1,5 +1,4 @@
 import asyncio
-import datetime
 import logging
 import math
 from pathlib import Path

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -260,7 +260,7 @@ async def _do_transpile(
 
     if result.error_list and config.error_path is not None:
         with config.error_path.open("a", encoding="utf-8") as e:
-            e.writelines(f"{err!s}\n" for err in result.error_list)
+            e.writelines(f"{err}\n" for err in result.error_list)
         error_log_file = str(config.error_path)
     else:
         error_log_file = None

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -257,7 +257,7 @@ async def _do_transpile(
     if not config.skip_validation:
         logger.info(f"SQL validation errors: {result.validation_error_count}")
 
-    # TODO: Refactor this so that errors are written while processing files instead of waiting until the end.
+    # TODO: Refactor this so that errors are written while transpiling instead of waiting until the end.
     if result.error_list and config.error_path is not None:
         with config.error_path.open("a", encoding="utf-8") as e:
             e.writelines(f"{err}\n" for err in result.error_list)

--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -258,6 +258,7 @@ async def _do_transpile(
     if not config.skip_validation:
         logger.info(f"SQL validation errors: {result.validation_error_count}")
 
+    # TODO: Refactor this so that errors are written while processing files instead of waiting until the end.
     if result.error_list and config.error_path is not None:
         with config.error_path.open("a", encoding="utf-8") as e:
             e.writelines(f"{err}\n" for err in result.error_list)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,7 +2,7 @@ import io
 import re
 import shutil
 from pathlib import Path
-from collections.abc import Sequence
+from collections.abc import Sequence, Generator
 from unittest.mock import create_autospec
 
 import pytest
@@ -292,7 +292,7 @@ def write_data_to_file(path: Path, content: str):
 
 
 @pytest.fixture
-def input_source(tmp_path: Path):
+def input_source(tmp_path: Path) -> Generator[Path, None, None]:
     source_dir = tmp_path / "remorph_source"
     safe_remove_dir(source_dir)  # should never be required but harmless
     make_dir(source_dir)
@@ -406,14 +406,14 @@ def input_source(tmp_path: Path):
 
 
 @pytest.fixture
-def output_folder(tmp_path: Path):
+def output_folder(tmp_path: Path) -> Generator[Path, None, None]:
     output_dir = tmp_path / "remorph_transpiled"
     yield output_dir
     safe_remove_dir(output_dir)
 
 
 @pytest.fixture
-def error_file(tmp_path: Path):
+def error_file(tmp_path: Path) -> Generator[Path, None, None]:
     file_path = tmp_path / "transpile_errors.lst"
     yield file_path
     safe_remove_file(file_path)


### PR DESCRIPTION
## Changes

### What does this PR do? 

This PR updates the handling of accumulated errors while transpiling:

 - If an error file has not been specified, we no longer make one up anyway.
 - Status reporting no longer uses `"None"` (a string) to indicate that no error file was written.

### Relevant implementation details

In addition to this change, I've added some type-hints in a few places.

### Caveats/things to watch out for when reviewing:

Errors are not just written to the log-file: they are also logged (at `ERROR`-level) by the CLI at the end of the `transpile` run.

### Functionality

- modified existing command: `databricks labs remorph transpile`

### Tests

- manually tested
- existing unit tests

Previously when no error-file was written the final status would be reported like this (scroll to the right):
```
10:34:39     INFO [d.l.r.transpiler.execute] Done transpiling.
total_files_processed  total_queries_processed  analysis_error_count  parsing_error_count  validation_error_count  generation_error_count  error_log_file
99                     99                       0                     0                    0                       0                       None
```

With this PR, it now looks like this:
```
10:28:54     INFO [d.l.r.transpiler.execute] Done transpiling.
total_files_processed  total_queries_processed  analysis_error_count  parsing_error_count  validation_error_count  generation_error_count  error_log_file
99                     99                       0                     0                    0                       0                       <no value>
```