### PR TITLE
Remove line number comments from the decorated output

### DIFF
--- a/src/databricks/labs/remorph/transpiler/execute.py
+++ b/src/databricks/labs/remorph/transpiler/execute.py
@@ -1,7 +1,6 @@
 import asyncio
 import datetime
 import logging
-import math
 from pathlib import Path
 from typing import cast, Any
 import itertools
@@ -112,7 +111,8 @@ def _make_header(file_path: Path, errors: list[TranspileError]) -> str:
         header += f"/*\n    Failed transpilation of {file_path}\n"
         header += "\n    The following errors were found while transpiling:\n"
         for diag in diag_by_severity[ErrorSeverity.ERROR]:
-            line_numbers[diag.range.start.line] = 0
+            if diag.range:
+                line_numbers[diag.range.start.line] = 0
             header += _append_diagnostic(diag)
             failed_producing_output = failed_producing_output or diag.kind == ErrorKind.PARSING
     else:
@@ -121,7 +121,8 @@ def _make_header(file_path: Path, errors: list[TranspileError]) -> str:
     if ErrorSeverity.WARNING in diag_by_severity:
         header += "\n    The following warnings were found while transpiling:\n"
         for diag in diag_by_severity[ErrorSeverity.WARNING]:
-            line_numbers[diag.range.start.line] = 0
+            if diag.range:
+                line_numbers[diag.range.start.line] = 0
             header += _append_diagnostic(diag)
 
     if failed_producing_output:
@@ -135,7 +136,7 @@ def _make_header(file_path: Path, errors: list[TranspileError]) -> str:
     for unshifted in line_numbers:
         line_numbers[unshifted] = header_line_count + unshifted + 1
 
-    return header.format(line_numbers = line_numbers)
+    return header.format(line_numbers=line_numbers)
 
 
 def _append_diagnostic(diag: TranspileError) -> str:


### PR DESCRIPTION
## Changes
### What does this PR do? 

This gets rid of the line number comments that was prepended to the output files contents (and that would have broken the code in the presence of multiline strings). Instead, the positions displayed in the header comment now take the header's height into account:

before: 

```sql=
/*
    Failed transpilation of /tmp/foo.sql

    The following errors were found while transpiling:
      - [1:3] SNOWFLAKE: The transpiler cannnot currently convert SHOW commands, but may be able to do so in the future
*/
/* 1 */  SHOW TABLES LIKE 'CUSTOMER%';
```

now:

```sql=
/*
    Failed transpilation of /tmp/foo.sql

    The following errors were found while transpiling:
      - [7:1] SNOWFLAKE: The transpiler cannnot currently convert SHOW commands, but may be able to do so in the future
*/
SHOW TABLES LIKE 'CUSTOMER%';
```

### Relevant implementation details

### Caveats/things to watch out for when reviewing:

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs remorph ...`
- [ ] ... +add your own

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
