### PR TITLE
Properly pin the Databricks SDK.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "databricks-sdk~=0.51",
+  "databricks-sdk~=0.51.0",
   "standard-distutils~=3.11.9; python_version>='3.11'",
   "databricks-bb-analyzer~=0.1.4",
   "sqlglot==26.1.3",


### PR DESCRIPTION
## Changes
### What does this PR do? 

This PR properly pins the project to a release of the Databricks SDK (or patch releases), which happens to resolve a linting error on `main` due to a breaking change in a later SDK release.

### Caveats/things to watch out for when reviewing:

The `~=` syntax means the _last_ digit can be incremented safely. Because the `.0` was missing, were allowing `0.51+` instead of `0.51.x`.
