### PR TITLE
Make transpiler configuration path optional in the workspace transpile configuration

### DIFF
--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -176,11 +176,12 @@ class _TranspileConfigChecker:
     def check(self) -> tuple[TranspileConfig, TranspileEngine]:
         logger.debug(f"Checking config: {self!s}")
         # not using os.path.exists because it sometimes fails mysteriously...
-        if not self._config.transpiler_config_path or not Path(self._config.transpiler_config_path).exists():
+        transpiler_path = self._config.transpiler_path
+        if not transpiler_path or not transpiler_path.exists():
             raise_validation_exception(
                 f"Invalid value for '--transpiler-config-path': Path '{self._config.transpiler_config_path}' does not exist."
             )
-        engine = TranspileEngine.load_engine(Path(self._config.transpiler_config_path))
+        engine = TranspileEngine.load_engine(transpiler_path)
         engine.check_source_dialect(self._config.source_dialect)
         if not self._config.input_source or not os.path.exists(self._config.input_source):
             raise_validation_exception(

--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -4,6 +4,7 @@ import json
 import os
 import time
 from pathlib import Path
+from typing import NoReturn
 
 from databricks.sdk.core import with_user_agent_extra
 from databricks.sdk.service.sql import CreateWarehouseRequestWarehouseType
@@ -40,7 +41,7 @@ remorph = App(__file__)
 logger = get_logger(__file__)
 
 
-def raise_validation_exception(msg: str) -> Exception:
+def raise_validation_exception(msg: str) -> NoReturn:
     raise ValueError(msg)
 
 

--- a/src/databricks/labs/remorph/config.py
+++ b/src/databricks/labs/remorph/config.py
@@ -101,7 +101,6 @@ class TranspileConfig:
         key_mapping = {"input_sql": "input_source", "output_folder": "output_path", "source": "source_dialect"}
         raw["version"] = 3
         raw["error_file_path"] = "error_log.txt"
-        raw["transpiler_config_path"] = "remorph_transpiler_config.yml"
         return {key_mapping.get(key, key): value for key, value in raw.items()}
 
 

--- a/src/databricks/labs/remorph/config.py
+++ b/src/databricks/labs/remorph/config.py
@@ -57,7 +57,7 @@ class TranspileConfig:
     __file__ = "config.yml"
     __version__ = 3
 
-    transpiler_config_path: str
+    transpiler_config_path: str | None = None
     source_dialect: str | None = None
     input_source: str | None = None
     output_folder: str | None = None
@@ -69,8 +69,8 @@ class TranspileConfig:
     transpiler_options: JsonValue = None
 
     @property
-    def transpiler_path(self):
-        return Path(self.transpiler_config_path)
+    def transpiler_path(self) -> Path | None:
+        return Path(self.transpiler_config_path) if self.transpiler_config_path is not None else None
 
     @property
     def input_path(self):

--- a/src/databricks/labs/remorph/install.py
+++ b/src/databricks/labs/remorph/install.py
@@ -696,7 +696,7 @@ class WorkspaceInstaller:
         )
 
         return TranspileConfig(
-            transpiler_config_path=str(transpiler_config_path),
+            transpiler_config_path=str(transpiler_config_path) if transpiler_config_path is not None else None,
             transpiler_options=transpiler_options,
             source_dialect=source_dialect,
             skip_validation=(not run_validation),

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -323,7 +323,7 @@ def test_configure_transpile_installation_no_override(mock_install_morpheus, moc
 def test_configure_transpile_installation_config_error_continue_install(ws_installer, ws):
     prompts = MockPrompts(
         {
-            r"Do you want to override the existing installation?": "no",
+            r"Do you want to override the existing installation?": "yes",
             r"Select the source dialect": ALL_INSTALLED_DIALECTS.index("snowflake"),
             r"Select the transpiler": TRANSPILERS_FOR_SNOWFLAKE.index("Morpheus"),
             r"Enter input SQL path.*": "/tmp/queries/snow",


### PR DESCRIPTION
## Changes

### What does this PR do? 

This PR makes the `transpiler_path_config` setting optional in `TranspilerConfig`, normally set during the post-install configuration questionnaire as part of the `install-transpile` subcommand.

This is in turn means we don't need to store `"None"` (the string) as a value in the file, in turn meaning we don't need downstream workarounds when reading the configuration.

### Relevant implementation details

In addition, when upgrading a v2 configuration we no longer need to set a value that will fail: we can just leave it out. Even though this is uncommon, leaving it unfilled rules out a source of issues downstream.

### Caveats/things to watch out for when reviewing:

Making an existing field optional is forward-compatible, so we don't need to introduce a new version of the configuration.

### Linked issues

Resolves #1640.

Relates to #1637.

### Functionality

- modified existing command: `databricks labs remorph install-transpile`

### Tests

- manually tested
- existing tests