### PR TITLE
Revert some changes accidentally included in #1582

### DIFF
--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -113,7 +113,7 @@ def transpile(
 ):
     """Transpiles source dialect to databricks dialect"""
     ctx = ApplicationContext(w)
-    print(f"{ctx.transpile_config!s}")
+    logger.debug(f"Application transpiler config: {ctx.transpile_config}")
     checker = _TranspileConfigChecker(ctx.transpile_config, ctx.prompts)
     checker.check_input_source(input_source)
     checker.check_source_dialect(source_dialect)

--- a/src/databricks/labs/remorph/cli.py
+++ b/src/databricks/labs/remorph/cli.py
@@ -3,7 +3,6 @@ import dataclasses
 import json
 import os
 import time
-import sys
 from pathlib import Path
 from typing import cast
 
@@ -447,6 +446,4 @@ def analyze(w: WorkspaceClient, source_directory: str, report_file: str):
 
 
 if __name__ == "__main__":
-    if "--debug" in sys.argv:
-        logger.setLevel("DEBUG")
     remorph()


### PR DESCRIPTION
## Changes

### What does this PR do? 

This PR reverts some changes accidentally included in #1582:

 - A `print()` that replaced a debug-logging statement. This is restored.
 - A workaround for `--debug` logging not working that was fixed upstream in blueprint.

### Functionality

- modified existing command: `databricks labs remorph transpile`
