### PR TITLE
Fixed download link in docs (reconcile automation)

### DIFF
--- a/docs/lakebridge/docs/reconcile/reconcile_automation.mdx
+++ b/docs/lakebridge/docs/reconcile/reconcile_automation.mdx
@@ -92,7 +92,7 @@ import LakebridgeTabs from '@site/src/components/ReconcileTabs';
 
 <LakebridgeTabs />
 
-[Link to the notebook](/lakebridge_reconciliation.dbc) - Unzip the downloaded file and upload the notebook file to your Databricks workspace.
+<a href={useBaseUrl('/lakebridge_reconciliation.dbc')} target="_blank" rel="noopener noreferrer">Link to the notebook</a> - Unzip the downloaded file and upload the notebook file to your Databricks workspace.
 
 The utility consists of three key Databricks notebooks:
 


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
Fixed documentation.

### What does this PR do?

I changed the markdown link to use JSX with the useBaseUrl hook:
`<a href={useBaseUrl('/lakebridge_reconciliation.dbc')} target="_blank" rel="noopener noreferrer">Link to the notebook</a>`

### Relevant implementation details

When Docusaurus built the site, it was:
- Moving the file to assets/files/ directory
- Adding a hash suffix for cache busting
- Adding a trailing slash
- This resulted in a broken link: `/lakebridge/assets/files/lakebridge_reconciliation-13ef362ff385092c2af4bd7423976694.dbc/`

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [x] fixed bug

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
