### PR TITLE
Enabled disabled unit test: `test_complete_transpiler_config`

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,4 +1,3 @@
-
 from databricks.labs.blueprint.installation import MockInstallation
 
 from databricks.labs.lakebridge.config import TranspileConfig


### PR DESCRIPTION
## Changes

This PR enables a test that was disabling pending an upstream release of blueprint, which has in the meantime happened. (The `pyproject.xml` dependencies were already updated.)

### Linked issues

Depends on databrickslabs/blueprint#252.

### Tests

- additional unit test
