### PR TITLE
Document that python 3.14 is not supported

### DIFF
--- a/docs/lakebridge/docs/installation.mdx
+++ b/docs/lakebridge/docs/installation.mdx
@@ -18,55 +18,54 @@ import TabItem from '@theme/TabItem';
 ----
 ## Pre-requisites
 
->1. Install `Databricks CLI` - Ensure that you have the Databricks Command-Line Interface (CLI) installed on your machine. Refer to the installation instructions provided for Linux, MacOS, and Windows, available [here](https://docs.databricks.com/en/dev-tools/cli/install.html#install-or-update-the-databricks-cli).
+1. Install `Databricks CLI` - Ensure that you have the Databricks Command-Line Interface (CLI) installed on your machine. Refer to the installation instructions provided for Linux, MacOS, and Windows, available [here](https://docs.databricks.com/en/dev-tools/cli/install.html#install-or-update-the-databricks-cli).
 
-Installing the Databricks CLI in different OS:
-<Tabs>
-    <TabItem value="macos" label="MacOS & Linux" default>
-        <img src={useBaseUrl('img/macos-databricks-cli-install.gif')} alt="macos-databricks-cli-install" />
-    </TabItem>
-    <TabItem value="windows" label="Windows" default>
-        <img src={useBaseUrl('img/windows-databricks-cli-install.gif')} alt="windows-databricks-cli-install" />
-    </TabItem>
-    <TabItem value="shell" label="Linux without brew" default>
-        ```shell
-        #!/usr/bin/env bash
+   Installing the Databricks CLI in different OS:
+   <Tabs>
+       <TabItem value="macos" label="MacOS & Linux" default>
+           <img src={useBaseUrl('img/macos-databricks-cli-install.gif')} alt="macos-databricks-cli-install" />
+       </TabItem>
+       <TabItem value="windows" label="Windows" default>
+           <img src={useBaseUrl('img/windows-databricks-cli-install.gif')} alt="windows-databricks-cli-install" />
+       </TabItem>
+       <TabItem value="shell" label="Linux without brew" default>
+           ```shell
+           #!/usr/bin/env bash
 
-        #install dependencies
-        apt update && apt install -y curl sudo unzip
+           #install dependencies
+           apt update && apt install -y curl sudo unzip
 
-        #install databricks cli
-        curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/v0.242.0/install.sh | sudo sh
-        ```
-    </TabItem>
-</Tabs>
+           #install databricks cli
+           curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/v0.242.0/install.sh | sudo sh
+           ```
+       </TabItem>
+   </Tabs>
 
->2. Configure `Databricks CLI` - Details can be found [here](https://docs.databricks.com/aws/en/dev-tools/cli/authentication#databricks-personal-access-token-authentication).
-Additionally, Lakebridge requires the profile used for the Databricks CLI to specify a cluster_id, to do this, you can either:
-- Edit your `~/.databrickscfg` file directly and enter a `cluster_id` for the profile you're using or
-- The flag `--configure-cluster` gives you the prompt to select the cluster_id from the available clusters on the workspace
-specified on the selected profile.
-```shell
-databricks configure --host <host> --configure-cluster --profile <profile_name>
-```
-- Alternatively you can use the environment variable `DATABRICKS_CLUSTER_ID` to set the cluster id you would want to use
-for your profile before running the `databricks configure` command.
+2. Configure `Databricks CLI` - Details can be found [here](https://docs.databricks.com/aws/en/dev-tools/cli/authentication#databricks-personal-access-token-authentication). Additionally, Lakebridge requires the profile used for the Databricks CLI to specify a cluster_id, to do this, you can either:
 
-```shell
-export DATABRICKS_CLUSTER_ID=<cluster_id>
-databricks configure --host <host> --profile <profile_name>
-```
+   - Edit your `~/.databrickscfg` file directly and enter a `cluster_id` for the profile you're using or;
+   - The flag `--configure-cluster` gives you the prompt to select the cluster_id from the available clusters on the workspace specified on the selected profile.
+     ```shell
+     databricks configure --host <host> --configure-cluster --profile <profile_name>
+     ```
+   - Alternatively you can use the environment variable `DATABRICKS_CLUSTER_ID` to set the cluster id you would want to use for your profile before running the `databricks configure` command.
 
->3. `Python` - Verify that Python is installed, versions between 3.10 and 3.13 are supported:
-- `Windows` - Install python from [here](https://www.python.org/downloads/). Your Windows computer will need a shell environment ([GitBash](https://www.git-scm.com/downloads) or [WSL](https://learn.microsoft.com/en-us/windows/wsl/about)).
-- `MacOS/Unix` - Use [brew](https://formulae.brew.sh/formula/python@3.13) to install python in macOS/Unix machines.
+     ```shell
+     export DATABRICKS_CLUSTER_ID=<cluster_id>
+     databricks configure --host <host> --profile <profile_name>
+     ```
+
+3. `Python` - Verify that Python is installed, versions between 3.10 and 3.13 are supported:
+
+   - `Windows` - Install python from [here](https://www.python.org/downloads/). Your Windows computer will need a shell environment ([GitBash](https://www.git-scm.com/downloads) or [WSL](https://learn.microsoft.com/en-us/windows/wsl/about)).
+   - `MacOS/Unix` - Use [brew](https://formulae.brew.sh/formula/python@3.13) to install python in macOS/Unix machines.
 
    **Note: Python 3.14 is not currently supported.**
 
-#### Check Python version on Windows, macOS, and Unix
-<img src={useBaseUrl('img/check-python-version.gif')} alt="check-python-version" />
+   Check Python version on Windows, macOS, and Unix:
+   <img src={useBaseUrl('img/check-python-version.gif')} alt="check-python-version" />
 
->4. `Java` - Verify that Java 11 or above is installed. This is required for the Morpheus transpiler.
+4. `Java` - Verify that Java 11 or above is installed. This is required for the Morpheus transpiler.
 
 [[back to top](#table-of-contents)]
 


### PR DESCRIPTION
## Changes

This PR updates the project documentation to mention that Python 3.14 is not currently supported. The instructions for macOS are also updated to install Python 3.13, the latest supported version.

Incidental changes include:

 - Minor punctuation.
 - The formatting of the pre-requisites section has been fixed: the indentation and nesting of the lists was incorrect.

### Linked issues

Relates #2137 

### Functionality

- Updated documentation.

### Tests

- manually tested

<img width="1962" height="1262" alt="image" src="https://github.com/user-attachments/assets/b8f784fa-50fd-4364-bf03-053858c93405" />
