### PR TITLE
Hotfix: increase the maximum line-size that can be handled when process stderr from LSP servers

### DIFF
--- a/src/databricks/labs/lakebridge/transpiler/lsp/lsp_engine.py
+++ b/src/databricks/labs/lakebridge/transpiler/lsp/lsp_engine.py
@@ -551,7 +551,7 @@ class LSPEngine(TranspileEngine):
         args = [*args, f"--log_level={log_level}"]
         env = {**env, "DATABRICKS_LAKEBRIDGE_LOG_LEVEL": log_level}
         logger.debug(f"Starting LSP engine: {executable} {args} (cwd={self._workdir})")
-        # Increase limit to 256MB to handle large lines on stderr from LSP servers
+        # Increase limit to 64MiB to handle large lines on stderr from LSP servers
         await self._client.start_io(executable, *args, env=env, cwd=self._workdir, limit=64 * 1024 * 1024)
 
     def _client_capabilities(self):


### PR DESCRIPTION
## Changes

### What does this PR do?

During `transpile` anything written by the LSP server to stderr is mirrored in the logs. Due to the internal implementation, there's a default maximum size of 64K for each line. Recent versions of BB can output lines that are larger than this limit, which causes a crash or a hang. This PR is a hot fix to increase the limit, pending tests and a proper fix.

### Related Issues

This mitigates the problem reported in #2164 but doesn't deal with it completely; a more rigorous fix is provided by #2163.

### Functionality

- modified existing command: `databricks labs lakebridge transpile`

### Tests

- manually tested
