### PR TITLE
Drop unused test fixture: `switch_artefact`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -312,21 +312,6 @@ def morpheus_artifact() -> Path:
     return artifact
 
 
-@pytest.fixture
-def switch_artifact() -> Path:
-    """Get Switch wheel for testing."""
-    artifact = (
-        Path(__file__).parent
-        / "resources"
-        / "transpiler_configs"
-        / "switch"
-        / "wheel"
-        / "databricks_switch_plugin-0.1.2-py3-none-any.whl"
-    )
-    assert artifact.exists(), f"Switch artifact not found: {artifact}"
-    return artifact
-
-
 class FakeDataSource(DataSource):
 
     def __init__(self, start_delimiter: str, end_delimiter: str):


### PR DESCRIPTION
## Changes

This is a trivial PR that drops an unused fixture, accidentally left over from #2078.
