### PR TITLE
Fix accidental `${}` instead of `{}`

### DIFF
--- a/src/databricks/labs/lakebridge/analyzer/lakebridge_analyzer.py
+++ b/src/databricks/labs/lakebridge/analyzer/lakebridge_analyzer.py
@@ -67,7 +67,7 @@ class AnalyzerRunner:
         return cls(Analyzer.analyze, move_tmp_file, is_debug)
 
     def run(self, source_dir: Path, results_dir: Path, platform: str) -> AnalyzerResult:
-        logger.debug(f"Starting analyzer execution in ${source_dir} for ${platform}")
+        logger.debug(f"Starting analyzer execution in {source_dir} for {platform}")
 
         if not check_path(source_dir) or not check_path(results_dir):
             raise ValueError(f"Invalid path(s) provided: source_dir={source_dir}, results_dir={results_dir}")
@@ -75,7 +75,7 @@ class AnalyzerRunner:
         tmp_dir = self._temp_xlsx_path(results_dir)
         self._runnable(source_dir, tmp_dir, platform, self._is_debug)
         self._move_file(tmp_dir, Path(results_dir))
-        logger.info(f"Successfully Analyzed files in ${source_dir} for ${platform} and saved report to {results_dir}")
+        logger.info(f"Successfully Analyzed files in {source_dir} for {platform} and saved report to {results_dir}")
         return AnalyzerResult(Path(source_dir), Path(results_dir), platform)
 
     @staticmethod

--- a/src/databricks/labs/lakebridge/reconcile/connectors/oracle.py
+++ b/src/databricks/labs/lakebridge/reconcile/connectors/oracle.py
@@ -94,7 +94,7 @@ class OracleDataSource(DataSource, SecretsMixin, JDBCReaderMixin):
             df = self.reader(schema_query).load()
             schema_metadata = df.select([col(c).alias(c.lower()) for c in df.columns]).collect()
             logger.info(f"Schema fetched successfully. Completed at: {datetime.now()}")
-            logger.debug(f"schema_metadata: ${schema_metadata}")
+            logger.debug(f"schema_metadata: {schema_metadata}")
             return [self._map_meta_column(field, normalize) for field in schema_metadata]
         except (RuntimeError, PySparkException) as e:
             return self.log_and_throw_exception(e, "schema", schema_query)


### PR DESCRIPTION
## Changes

This PR fixes some logging that accidentally used `${...}` for f-string interpolation instead of `{...}`, leading to spurious `$` in the logging statements. For example:
```console
16:00:40    DEBUG [d.l.l.analyzer.lakebridge_analyzer] Starting analyzer execution in $/xxxx/tests/resources/functional/informatica for $Informatica - PC
```

### Functionality

- modified existing commands:

   -  `databricks labs lakebridge analyze`
   -  `databricks labs lakebridge reconcile`

### Tests

- manually tested
