### PR TITLE
Update telemetry submitted during uninstall hook

### DIFF
--- a/src/databricks/labs/lakebridge/uninstall.py
+++ b/src/databricks/labs/lakebridge/uninstall.py
@@ -1,6 +1,7 @@
 import logging
 
 from databricks.labs.blueprint.entrypoint import is_in_debug
+from databricks.sdk.core import with_user_agent_extra
 
 from databricks.labs.lakebridge.cli import lakebridge
 from databricks.labs.lakebridge.contexts.application import ApplicationContext
@@ -13,6 +14,8 @@ def run(context: ApplicationContext):
 
 
 if __name__ == "__main__":
+    with_user_agent_extra("cmd", "uninstall")
+
     logger.setLevel("INFO")
     if is_in_debug():
         logging.getLogger("databricks").setLevel(logging.DEBUG)


### PR DESCRIPTION
## Changes
### What does this PR do?

This PR updates the user-agent based telemetry that is collected when the uninstall hook runs so that it's clear the API calls are associated with the application being uninstalled.

### Relevant implementation details

Prior to this PR the user-agent for API calls during uninstall is associated with Lakebridge but not with any particular entry-point.

### Functionality

- modified existing command: `databricks labs uninstall lakebridge`
