### PR TITLE
do not shallow clone in CI to detect local versions correctly

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Install Python
         uses: actions/setup-python@v6

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,8 +8,9 @@ from databricks.labs.lakebridge.__about__ import __version__
 from databricks.labs.lakebridge.connections.database_manager import DatabaseManager
 from tests.integration.debug_envgetter import TestEnvGetter
 
-logging.getLogger("tests").setLevel("DEBUG")
-logging.getLogger("databricks.labs.lakebridge").setLevel("DEBUG")
+logging.getLogger("tests").setLevel(logging.DEBUG)
+logging.getLogger("databricks.labs.lakebridge").setLevel(logging.DEBUG)
+logging.getLogger("databricks.labs.pytester").setLevel(logging.DEBUG)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary, they're helpful to illustrate the before and after state -->
### What does this PR do?
CI runs observed the error
```
12:02 WARNING [databricks.labs.blueprint.wheels] Cannot determine unreleased version. This can be fixed by adding `git fetch --prune --unshallow` to your CI configuration.
Traceback (most recent call last):
File "/home/runner/work/lakebridge/lakebridge/.venv/lib/python3.10/site-packages/databricks/labs/blueprint/wheels.py", line 115, in unreleased_version
out = subprocess.run(
File "/opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/subprocess.py", line 526, in run
raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'describe', '--tags']' returned non-zero exit status 128.
```

this happened because we switched to shallow fetching and tags were not fetched. this has to be reverted so databricks sdk works as expected

