### PR TITLE
bump various databricks deps to latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
   "pytest-timeout~=2.4.0",
   "black~=25.9.0",
   "ruff~=0.13.2",
-  "databricks-connect==16.1.7",
+  "databricks-connect==15.1",
   "types-requests>=2.28.1,<3",  # Matches the 'requests' above.
   "types-pyYAML~=6.0.12",
   "types-pytz~=2025.2",


### PR DESCRIPTION
### What does this PR do?

bump various databricks deps to latest version on python 3.10


Resolves #..

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [ ] ... +add your own

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [X] manually tested
- [ ] added unit tests
- [ ] added integration tests
