### PR TITLE
Fix Missing Spark Pool Identifiers for the Synapse Profiler

### DIFF
--- a/src/databricks/labs/lakebridge/resources/assessments/synapse/monitoring_metrics_extract.py
+++ b/src/databricks/labs/lakebridge/resources/assessments/synapse/monitoring_metrics_extract.py
@@ -133,8 +133,12 @@ def execute():
                 logger.info(f"   Resource id: {pool_resoure_id}")
 
                 step_name = "metrics_spark_pool_metrics"
-
                 spark_pool_metrics_df = synapse_metrics.get_spark_pool_metrics(pool_resoure_id)
+
+                # Add pool name and resource id columns
+                spark_pool_metrics_df.insert(loc=0, column="pool_name", value=pool_name)
+                spark_pool_metrics_df.insert(loc=1, column="resource_id", value=pool_resoure_id)
+
                 if idx == 0:
                     spark_pools_df = spark_pool_metrics_df
                 else:


### PR DESCRIPTION
## Changes

### What does this PR do?

Currently, the Synapse profiler will extract CPU metrics for Spark pools, such as min, max, and total aggregates. However, these metrics are all stored under the metric name, making it impossible to discern which Spark pool they are associated with. This PR adds the pool name and resource id during metrics collection, making it possible to associate CPU usage and calculated project costs per Spark pool.

### Relevant implementation details

This PR uses Pandas `insert()` operation to prepend the pool name and resource id as the first and second columns of the `metrics_spark_pool_metrics` table.

### Caveats/things to watch out for when reviewing:

### Linked issues

Resolves a bug in how Spark pool metrics are collected in the Synapse profiler.

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [ X] Fix missing pool name and resource id 

### Tests

- [X] manually tested
- [ ] added unit tests
- [X] added integration tests
