### PR TITLE
patch cluster creation test

### DIFF
--- a/tests/integration/reconcile/test_recon_databricks.py
+++ b/tests/integration/reconcile/test_recon_databricks.py
@@ -56,7 +56,7 @@ def recon_config(make_cluster, watchdog_remove_after: str, recon_schema: SchemaI
         .result()
         .cluster_id
     )
-    deployment_overrides = ReconcileJobConfig(existing_cluster_id=cluster)
+    deployment_overrides = ReconcileJobConfig(existing_cluster_id=cluster, tags={"lakebridge": "reconcile_test"})
     logger.info(f"Using recon job overrides: {deployment_overrides}")
 
     assert recon_schema.catalog_name


### PR DESCRIPTION
  ## Summary
  Removed custom cluster naming and tagging from reconciliation E2E tests to simplify test setup and enable parallel ci execution by letting pytester manage the cluster creation.

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [ ] ... +add your own

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
