### PR TITLE
 Pin virtualenv<21 to fix hatch CI incompatibility

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -38,7 +38,8 @@ jobs:
           python-version: '3.10'
 
       - name: Install hatch
-        run: pip install hatch==1.14.2
+        # see here for more details https://github.com/pypa/hatch/issues/2193
+        run: pip install hatch==1.14.2 "virtualenv<21"
 
       - name: Install MSSQL ODBC Driver
         run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -34,7 +34,8 @@ jobs:
           python-version: '3.10'
 
       - name: Install hatch
-        run: pip install hatch==$HATCH_VERSION
+        # see here for more details https://github.com/pypa/hatch/issues/2193
+        run: pip install hatch==$HATCH_VERSION "virtualenv<21"
 
       - name: Run unit tests
         run: hatch run test
@@ -61,7 +62,8 @@ jobs:
           python-version: 3.10.x
 
       - name: Install hatch
-        run: pip install hatch==$HATCH_VERSION
+        # https://github.com/pypa/hatch/issues/2193
+        run: pip install hatch==$HATCH_VERSION "virtualenv<21"
 
       - name: Reformat code
         run: make fmt
@@ -114,7 +116,8 @@ jobs:
           python-version: 3.10.x
 
       - name: Install hatch
-        run: pip install hatch==$HATCH_VERSION
+        # https://github.com/pypa/hatch/issues/2193
+        run: pip install hatch==$HATCH_VERSION "virtualenv<21"
 
       - name: Install Databricks CLI
         uses: databricks/setup-cli@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,8 @@ jobs:
 
       - name: Build wheels
         run: |
-          pip install hatch==1.14.2
+          # see here for more details https://github.com/pypa/hatch/issues/2193
+          pip install hatch==1.14.2 "virtualenv<21"
           hatch build
 
       - name: Draft release


### PR DESCRIPTION
## Summary
Pins `virtualenv<21` alongside `hatch` installs across all CI workflows to prevent breakage from `virtualenv 21.0.0` removing the `propose_interpreters` API that hatch depends on.

  - **CI Stability: Dependency Pinning**
    - Add `"virtualenv<21"` to all `pip install hatch` steps in `push.yml`, `acceptance.yml`, and `release.yml`


### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
