### PR TITLE
fix

### DIFF
--- a/src/databricks/labs/lakebridge/reconcile/query_builder/expression_generator.py
+++ b/src/databricks/labs/lakebridge/reconcile/query_builder/expression_generator.py
@@ -265,10 +265,14 @@ DataType_transform_mapping: dict[str, dict[str, list[partial[exp.Expression]]]] 
     },
     "tsql": {
         "default": [partial(anonymous, func="COALESCE(TRIM(CAST({} AS VARCHAR(MAX))), '_null_recon_')")],
-        exp.DataType.Type.DATE.value: [partial(anonymous, func="COALESCE(CONVERT(DATE, {0}, 101), '1900-01-01')")],
-        exp.DataType.Type.TIME.value: [partial(anonymous, func="COALESCE(CONVERT(TIME, {0}, 108), '00:00:00')")],
+        exp.DataType.Type.DATE.value: [
+            partial(anonymous, func="COALESCE(CONVERT(VARCHAR(MAX), {0}, 101), '1900-01-01')")
+        ],
+        exp.DataType.Type.TIME.value: [
+            partial(anonymous, func="COALESCE(CONVERT(VARCHAR(MAX), {0}, 108), '00:00:00')")
+        ],
         exp.DataType.Type.DATETIME.value: [
-            partial(anonymous, func="COALESCE(CONVERT(DATETIME, {0}, 120), '1900-01-01 00:00:00')")
+            partial(anonymous, func="COALESCE(CONVERT(VARCHAR(MAX), {0}, 120), '1900-01-01 00:00:00')")
         ],
     },
 }

--- a/tests/unit/reconcile/query_builder/test_hash_query.py
+++ b/tests/unit/reconcile/query_builder/test_hash_query.py
@@ -379,3 +379,60 @@ def test_hash_query_builder_sort_column(
 
     assert src_actual == src_expected
     assert tgt_actual == tgt_expected
+
+
+def test_hash_query_builder_tsql_date_time_columns(
+    fake_tsql_datasource,
+    fake_databricks_datasource,
+):
+    """Test that TSQL date/time/datetime columns are converted to VARCHAR for concatenation compatibility."""
+    src_schema = [
+        tsql_schema_fixture_factory("id", "number"),
+        tsql_schema_fixture_factory("birth_date", "date"),
+        tsql_schema_fixture_factory("created_time", "time"),
+        tsql_schema_fixture_factory("created_date", "datetime"),
+        tsql_schema_fixture_factory("name", "varchar"),
+    ]
+
+    tgt_schema = [
+        ansi_schema_fixture_factory("id", "number"),
+        ansi_schema_fixture_factory("birth_date", "date"),
+        ansi_schema_fixture_factory("created_time", "timestamp"),
+        ansi_schema_fixture_factory("created_date", "timestamp"),
+        ansi_schema_fixture_factory("name", "string"),
+    ]
+
+    table_conf = Table(
+        source_name="customer",
+        target_name="customer",
+        join_columns=["id"],
+        select_columns=["id", "birth_date", "created_time", "created_date", "name"],
+    )
+
+    normalize_service = NormalizeReconConfigService(fake_tsql_datasource, fake_databricks_datasource)
+    normalized_conf = normalize_service.normalize_recon_table_config(table_conf)
+
+    src_actual = HashQueryBuilder(
+        normalized_conf,
+        src_schema,
+        "source",
+        get_dialect("tsql"),
+        fake_tsql_datasource,
+    ).build_query(report_type="data")
+
+    # Verify that date/time/datetime columns use CONVERT(VARCHAR(MAX), ...) not CONVERT(DATE/TIME/DATETIME, ...)
+    assert "CONVERT(DATE," not in src_actual
+    assert "CONVERT(TIME," not in src_actual
+    assert "CONVERT(DATETIME," not in src_actual
+
+    src_expected = (
+        "SELECT LOWER(CONVERT(VARCHAR(64), HASHBYTES('SHA2_256', "
+        "CONVERT(VARCHAR(MAX),COALESCE(CONVERT(VARCHAR(MAX), [birth_date], 101), '1900-01-01') + "
+        "COALESCE(CONVERT(VARCHAR(MAX), [created_date], 120), '1900-01-01 00:00:00') + "
+        "COALESCE(CONVERT(VARCHAR(MAX), [created_time], 108), '00:00:00') + "
+        "COALESCE(TRIM(CAST([id] AS VARCHAR(MAX))), '_null_recon_') + "
+        "COALESCE(TRIM(CAST([name] AS VARCHAR(MAX))), '_null_recon_'))), 2)) AS "
+        "hash_value_recon, [id] AS [id] FROM :tbl"
+    )
+
+    assert src_actual == src_expected


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary, they're helpful to illustrate the before and after state -->
### What does this PR do?
Fixes MSSQL reconciliation failing at runtime when the source table contains DATE, TIME, or DATETIME columns. The generated hash query was producing expressions like COALESCE(CONVERT(DATE, [birth_date], 101), '1900-01-01') which return a DATE-typed value. When these were concatenated with VARCHAR values using the T-SQL + operator, SQL Server raised:
> The data types varchar and date are incompatible in the add operator.

### Relevant implementation details

The `DataType_transform_mapping` for `tsql` in `expression_generator.py` previously converted date/time columns **to their native types** (`DATE`, `TIME`, `DATETIME`) via `CONVERT`. Since T-SQL's `+` operator does not support implicit casting between `VARCHAR` and date/time types, concatenation in the hash expression failed.

The fix changes the `CONVERT` target type from `DATE`/`TIME`/`DATETIME` to `VARCHAR(MAX)` for all three entries. The CONVERT style codes (101, 108, 120) are preserved, so the string representation of each value remains identical — only the output type changes to `VARCHAR`, which is compatible with `+` concatenation.

| Column Type | Before (broken) | After (fixed) |
|---|---|---|
| `DATE` | `CONVERT(DATE, {0}, 101)` | `CONVERT(VARCHAR(MAX), {0}, 101)` |
| `TIME` | `CONVERT(TIME, {0}, 108)` | `CONVERT(VARCHAR(MAX), {0}, 108)` |
| `DATETIME` | `CONVERT(DATETIME, {0}, 120)` | `CONVERT(VARCHAR(MAX), {0}, 120)` |

### Caveats/things to watch out for when reviewing:

The existing TSQL hash query tests (`test_hash_query_builder_for_tsql_src`, `test_hash_query_builder_sort_column`) only used `number` and `varchar` column types, so they did not catch this bug. The new test explicitly covers `DATE`, `TIME`, and `DATETIME` columns.


### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #2314 

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [ ] ... +add your own

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
