### PR TITLE
Fix reconcile notebook docs: update TableRecon API for v2

### DIFF
--- a/docs/lakebridge/docs/reconcile/recon_notebook.mdx
+++ b/docs/lakebridge/docs/reconcile/recon_notebook.mdx
@@ -132,17 +132,19 @@ reconcile_config = ReconcileConfig(
 
 ## Configure Table Properties
 
-We use the class `TableRecon` to configure the properties of the source & target tables to be reconciled.
+We use the class `TableRecon` to configure the list of tables to be reconciled. Schema and catalog information
+is provided via `DatabaseConfig` inside `ReconcileConfig` (see above).
 
 ```python
 @dataclass
 class TableRecon:
-    source_schema: str
-    target_catalog: str
-    target_schema: str
     tables: list[Table]
-    source_catalog: str | None = None
 ```
+
+:::note
+The `source_schema`, `target_catalog`, `target_schema`, and `source_catalog` fields were removed from `TableRecon`
+in Lakebridge v2. They are now configured in `DatabaseConfig` inside `ReconcileConfig`.
+:::
 
 An Example Table properties for reconciliation:
 
@@ -160,9 +162,6 @@ from databricks.labs.lakebridge.reconcile.recon_config import (
 )
 
 table_recon = TableRecon(
-    source_schema="source_sf_schema",
-    target_catalog="target_databricks_catalog",
-    target_schema="target_databricks_schema",
     tables=[
         Table(
             source_name="source_table_name",

--- a/docs/lakebridge/docs/reconcile/reconcile_configuration.mdx
+++ b/docs/lakebridge/docs/reconcile/reconcile_configuration.mdx
@@ -297,7 +297,7 @@ using this config, you can specify the columns that you want to exclude from the
 <Tabs>
   <TabItem value="python" label="Python" default>
     ```python
-    TableRecon(
+    Table(
       drop_columns = ["column_name1", "column_name2"]
       )
     ```


### PR DESCRIPTION
## Summary

Fixes #2232.

Users following the [Running Reconcile on Notebook](https://databrickslabs.github.io/lakebridge/docs/reconcile/recon_notebook) guide hit this error immediately:

```
TypeError: TableRecon.__init__() got an unexpected keyword argument 'source_schema'
```

## Root cause

`TableRecon` was refactored in v2 (PR #2150) to remove the schema/catalog fields — `source_schema`, `target_catalog`, `target_schema`, `source_catalog` — which moved to `DatabaseConfig` inside `ReconcileConfig`. A `v1_migrate()` method was added to handle old YAML config files, but the **notebook documentation was never updated**, so users copy-pasting the examples get an immediate crash.

## Changes

**`recon_notebook.mdx`**
- Update the `TableRecon` dataclass signature to show only `tables: list[Table]` (the current v2 API)
- Remove the old schema fields (`source_schema`, `target_catalog`, `target_schema`) from the `TableRecon(...)` usage example
- Add a `:::note` callout explaining the migration so users upgrading from v1 understand what changed and where to put those values now

**`reconcile_configuration.mdx`**
- Fix a secondary bug: the `drop_columns` example was shown inside `TableRecon(...)` but `drop_columns` is actually a field on `Table`, not `TableRecon`

## Before / After

**Before** (causes crash):
```python
table_recon = TableRecon(
    source_schema="source_sf_schema",        # ← does not exist in v2
    target_catalog="target_databricks_catalog",  # ← does not exist in v2
    target_schema="target_databricks_schema",    # ← does not exist in v2
    tables=[...]
)
```

**After** (correct v2 API):
```python
# Schema/catalog go in ReconcileConfig → DatabaseConfig
reconcile_config = ReconcileConfig(
    ...
    database_config=DatabaseConfig(
        source_schema="source_sf_schema",
        target_catalog="target_databricks_catalog",
        target_schema="target_databricks_schema",
    ),
)

# TableRecon only holds the table list
table_recon = TableRecon(tables=[...])
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)