### PR TITLE
Fix GREATEST with single argument simplified in Databricks SQL output

### DIFF
--- a/src/databricks/labs/lakebridge/transpiler/sqlglot/generator/databricks.py
+++ b/src/databricks/labs/lakebridge/transpiler/sqlglot/generator/databricks.py
@@ -80,6 +80,18 @@ def _curr_time():
     return "date_format(current_timestamp(), 'HH:mm:ss')"
 
 
+def _greatest_sql(self, expression: exp.Greatest) -> str:
+    """Simplify GREATEST with a single argument to just that argument.
+
+    Spark SQL requires GREATEST to have more than one argument. When a source
+    dialect uses GREATEST with a single argument (e.g., Oracle allows it),
+    the wrapper is redundant and must be removed.
+    """
+    if not expression.args.get("expressions"):
+        return self.sql(expression, "this")
+    return self.func("GREATEST", expression.this, *expression.expressions)
+
+
 def _select_contains_index(expression: exp.Select) -> bool:
     for expr in expression.expressions:
         column = expr.unalias() if isinstance(expr, exp.Alias) else expr
@@ -470,6 +482,7 @@ class Databricks(SqlglotDatabricks):  #
             local_expression.ArrayExists: rename_func("EXISTS"),
             exp.GroupConcat: groupconcat_sql_databricks,
             exp.GetExtract: rename_func("GET"),
+            exp.Greatest: _greatest_sql,
         }
 
         def preprocess(self, expression: exp.Expression) -> exp.Expression:

--- a/tests/resources/functional/oracle/functions/test_greatest_1.sql
+++ b/tests/resources/functional/oracle/functions/test_greatest_1.sql
@@ -1,0 +1,11 @@
+-- ##GREATEST with multiple arguments
+--
+-- GREATEST with two or more arguments maps directly to Databricks GREATEST.
+--
+-- oracle sql:
+SELECT GREATEST(a, b) AS result FROM t;
+
+-- databricks sql:
+SELECT
+  GREATEST(a, b) AS result
+FROM t

--- a/tests/resources/functional/oracle/functions/test_greatest_2.sql
+++ b/tests/resources/functional/oracle/functions/test_greatest_2.sql
@@ -1,0 +1,13 @@
+-- ##GREATEST with a single argument is simplified
+--
+-- Spark SQL requires GREATEST to have more than one argument.
+-- When Oracle uses GREATEST with a single argument, it is redundant and
+-- must be simplified to just the inner expression.
+--
+-- oracle sql:
+SELECT GREATEST(NVL(p1_AS_OF, TO_DATE('1000-01-01', 'YYYY-MM-DD'))) AS result FROM t;
+
+-- databricks sql:
+SELECT
+  COALESCE(p1_AS_OF, TO_DATE('1000-01-01')) AS result
+FROM t

--- a/tests/resources/functional/oracle/functions/test_greatest_3.sql
+++ b/tests/resources/functional/oracle/functions/test_greatest_3.sql
@@ -1,0 +1,12 @@
+-- ##GREATEST with a single column argument is simplified
+--
+-- Spark SQL requires GREATEST to have more than one argument.
+-- When Oracle uses GREATEST with a single column, the wrapper is removed.
+--
+-- oracle sql:
+SELECT GREATEST(col1) AS result FROM t;
+
+-- databricks sql:
+SELECT
+  col1 AS result
+FROM t


### PR DESCRIPTION
## Summary

Fixes #2308

Spark SQL requires `GREATEST` to have more than one argument:
```
The `greatest` requires > 1 parameters but the actual number is 1.
```

Oracle (and other dialects) allow `GREATEST(single_expr)` as a redundant no-op wrapper. This PR adds a custom `_greatest_sql` transform in lakebridge's `Databricks` generator that:

- **Single argument**: unwraps `GREATEST(expr)` → `expr`
- **Multiple arguments**: keeps the normal `GREATEST(a, b, ...)` behaviour unchanged

### Example

| Input (Oracle) | Output before | Output after |
|---|---|---|
| `GREATEST(NVL(col, TO_DATE('1000-01-01', 'YYYY-MM-DD')))` | `GREATEST(COALESCE(col, TO_DATE('1000-01-01')))` ❌ | `COALESCE(col, TO_DATE('1000-01-01'))` ✅ |
| `GREATEST(col1)` | `GREATEST(col1)` ❌ | `col1` ✅ |
| `GREATEST(a, b)` | `GREATEST(a, b)` ✅ | `GREATEST(a, b)` ✅ |

## Changes

- `src/databricks/labs/lakebridge/transpiler/sqlglot/generator/databricks.py`: Add `_greatest_sql` function and register it in `TRANSFORMS`
- `tests/resources/functional/oracle/functions/test_greatest_1.sql`: Multi-arg GREATEST (no change)
- `tests/resources/functional/oracle/functions/test_greatest_2.sql`: Single-arg GREATEST with NVL → simplifies
- `tests/resources/functional/oracle/functions/test_greatest_3.sql`: Single-arg GREATEST with column → simplifies

## Test plan

- [x] `tests/unit/transpiler/test_oracle.py` — all 4 cases pass (including 3 new)
- [x] `tests/unit/transpiler/test_snowflake.py::test_snowflake[test_greatest_1]` — multi-arg case unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)