### PR TITLE
Fix schema compare to detect missing columns in both directions

### DIFF
--- a/src/databricks/labs/lakebridge/reconcile/schema_compare.py
+++ b/src/databricks/labs/lakebridge/reconcile/schema_compare.py
@@ -47,6 +47,21 @@ class SchemaCompare:
             SchemaCompare.match_source_target_schemas(s, target_column_map, databricks_types_map) for s in master_schema
         ]
 
+        # Detect target-only columns (missing in source)
+        source_col_names = {m.databricks_column for m in master_schema_match_res}
+        for col in databricks_schema:
+            if col.ansi_normalized_column_name not in source_col_names:
+                master_schema_match_res.append(
+                    SchemaMatchResult(
+                        source_column_normalized="",
+                        source_column_normalized_ansi="",
+                        source_datatype="N/A",
+                        databricks_column=col.ansi_normalized_column_name,
+                        databricks_datatype=col.data_type,
+                        is_valid=False,
+                    )
+                )
+
         return master_schema_match_res
 
     @staticmethod
@@ -163,7 +178,9 @@ class SchemaCompare:
         """
         master_schema = self._build_master_schema(source_schema, databricks_schema, table_conf)
         for master in master_schema:
-            if not isinstance(source, Databricks):
+            if master.databricks_datatype == "Unknown":
+                master.is_valid = False  # Column missing in target
+            elif not isinstance(source, Databricks):
                 self._validate_parsed_query(source, master)
             elif master.source_datatype.lower() != master.databricks_datatype.lower():
                 master.is_valid = False

--- a/tests/integration/reconcile/test_schema_compare.py
+++ b/tests/integration/reconcile/test_schema_compare.py
@@ -427,3 +427,72 @@ def test_schema_compare(mock_spark):
     assert df.count() == 2
     assert df.filter("is_valid = 'true'").count() == 2
     assert df.filter("is_valid = 'false'").count() == 0
+
+
+def test_schema_compare_source_extra_column(mock_spark):
+    """Source has column D missing in target → is_valid=False, datatype='Unknown'."""
+    src_schema = [
+        schema_fixture_factory("col1", "int", "`col1`", "`col1`"),
+        schema_fixture_factory("col2", "string", "`col2`", "`col2`"),
+        schema_fixture_factory("col_d", "double", "`col_d`", "`col_d`"),
+    ]
+    tgt_schema = [
+        schema_fixture_factory("col1", "int", "`col1`", "`col1`"),
+        schema_fixture_factory("col2", "string", "`col2`", "`col2`"),
+    ]
+    table_conf = Table(source_name="t1", target_name="t1")
+
+    output = SchemaCompare(mock_spark).compare(src_schema, tgt_schema, get_dialect("databricks"), table_conf)
+    df = output.compare_df
+
+    assert not output.is_valid
+    assert df.count() == 3
+    assert df.filter("is_valid = 'true'").count() == 2
+    assert df.filter("is_valid = 'false'").count() == 1
+    assert df.filter("databricks_datatype = 'Unknown'").count() == 1
+
+
+def test_schema_compare_target_extra_column(mock_spark):
+    """Target has column D missing in source → is_valid=False, reported in output."""
+    src_schema = [
+        schema_fixture_factory("col1", "int", "`col1`", "`col1`"),
+        schema_fixture_factory("col2", "string", "`col2`", "`col2`"),
+    ]
+    tgt_schema = [
+        schema_fixture_factory("col1", "int", "`col1`", "`col1`"),
+        schema_fixture_factory("col2", "string", "`col2`", "`col2`"),
+        schema_fixture_factory("col_d", "double", "`col_d`", "`col_d`"),
+    ]
+    table_conf = Table(source_name="t1", target_name="t1")
+
+    output = SchemaCompare(mock_spark).compare(src_schema, tgt_schema, get_dialect("databricks"), table_conf)
+    df = output.compare_df
+
+    assert not output.is_valid
+    assert df.count() == 3
+    assert df.filter("is_valid = 'true'").count() == 2
+    assert df.filter("is_valid = 'false'").count() == 1
+    assert df.filter("source_datatype = 'N/A'").count() == 1
+
+
+def test_schema_compare_both_extra_columns(mock_spark):
+    """Source has extra col_s, target has extra col_t → both reported as invalid."""
+    src_schema = [
+        schema_fixture_factory("col1", "int", "`col1`", "`col1`"),
+        schema_fixture_factory("col_s", "string", "`col_s`", "`col_s`"),
+    ]
+    tgt_schema = [
+        schema_fixture_factory("col1", "int", "`col1`", "`col1`"),
+        schema_fixture_factory("col_t", "double", "`col_t`", "`col_t`"),
+    ]
+    table_conf = Table(source_name="t1", target_name="t1")
+
+    output = SchemaCompare(mock_spark).compare(src_schema, tgt_schema, get_dialect("databricks"), table_conf)
+    df = output.compare_df
+
+    assert not output.is_valid
+    assert df.count() == 3
+    assert df.filter("is_valid = 'true'").count() == 1
+    assert df.filter("is_valid = 'false'").count() == 2
+    assert df.filter("databricks_datatype = 'Unknown'").count() == 1
+    assert df.filter("source_datatype = 'N/A'").count() == 1


### PR DESCRIPTION
## Summary
- **Case 1 (source-only columns):** Columns present in source but missing in target are now marked `is_valid = False` instead of silently showing `Unknown` datatype as valid
- **Case 2 (target-only columns):** Columns present in target but missing in source are now detected and reported as `is_valid = False` with `source_datatype = "N/A"`
- Added integration tests for source-only, target-only, and bidirectional missing column scenarios

See [this issue](https://github.com/databrickslabs/lakebridge/issues/1489)

