### PR TITLE
Fix BladeBridge crash on large DataStage XML files (>100MB)

### DIFF
--- a/docs/bladebridge_large_xml_fix.md
+++ b/docs/bladebridge_large_xml_fix.md
@@ -1,0 +1,97 @@
+# Fix: BladeBridge Crash on Large DataStage XML Files
+
+**Issue:** [#2097](https://github.com/databrickslabs/lakebridge/issues/2097)
+**Affects:** BladeBridge plugin (`databricks-bb-plugin`) version 0.3.0 and earlier
+**Symptom:** `OSError: [Errno 63] File name too long` when processing DataStage XML files larger than ~100 MB
+
+---
+
+## Quick Fix
+
+Run the provided patch script after installing Lakebridge and BladeBridge:
+
+```bash
+bash scripts/patch_bladebridge_large_xml.sh
+```
+
+The script is idempotent — it detects if the patch is already applied and skips if so. It creates a backup of the original file before patching.
+
+> **Note:** Re-run this script after upgrading BladeBridge (`databricks labs lakebridge install-transpile`), as upgrades reinstall the plugin from scratch.
+
+---
+
+## Manual Fix
+
+If you prefer to patch manually:
+
+**File:**
+```
+~/.databricks/labs/remorph-transpilers/bladebridge/lib/.venv/lib/python3.10/site-packages/databricks/labs/bladebridge/transpiler.py
+```
+
+**Line 203 — change:**
+```python
+# BEFORE:
+                "-n",
+                str(transpiled_dir.relative_to(workdir)),
+
+# AFTER:
+                "-n",
+                str(transpiled_dir.absolute()),
+```
+
+**Then clear the bytecode cache:**
+```bash
+find ~/.databricks/labs/remorph-transpilers/bladebridge -name "*.pyc" -path "*transpiler*" -delete
+```
+
+---
+
+## Root Cause
+
+BladeBridge's Python wrapper (`transpiler.py`) invokes a compiled binary called `dbxconv` to convert DataStage jobs. The output directory is passed via the `-n` flag as a **relative path** (e.g., `-n transpiled`).
+
+When `dbxconv` processes large XML files containing hundreds of jobs, it internally creates subdirectories using the same name passed to `-n`. Since `-n` receives a relative path, the binary resolves it relative to its own output on every internal write, creating recursive nesting:
+
+```
+transpiled/                  <-- created by Python wrapper
+  transpiled/                <-- created by dbxconv
+    transpiled/              <-- created by dbxconv
+      transpiled/            <-- ...87+ levels deep
+```
+
+The total path length eventually exceeds the OS limit (1024 bytes on macOS), causing the crash.
+
+**The fix** passes an **absolute path** to `-n` instead. When `dbxconv` receives an absolute path, it writes directly to that location without recursive nesting.
+
+---
+
+## Validation
+
+Tested on a real KBTG DataStage export:
+
+| Property | Value |
+|---|---|
+| **File** | `FinancialCredit.xml` |
+| **Size** | 119 MB, 2.2 million lines |
+| **Charset** | CP874 (Thai) |
+| **DataStage version** | 11.5 |
+
+| Metric | Without Patch | With Patch |
+|---|---|---|
+| Result | Crashes after ~69 min | Completes in ~3 hours |
+| Output files | 0 | **425** (379 notebooks + 46 workflow JSONs) |
+| Recursive nesting in logs | 869+ occurrences | 0 |
+| Errors | Fatal `OSError: [Errno 63]` | 0 analysis, 0 parsing, 0 validation, 0 generation |
+
+---
+
+## Lakebridge & Plugin Versions Tested
+
+| Component | Version |
+|---|---|
+| Lakebridge | 0.12.2 |
+| BladeBridge plugin (`databricks-bb-plugin`) | 0.3.0 |
+| Databricks CLI | 0.291.0 |
+| Python | 3.10.13 |
+| macOS | Darwin 25.3.0 (Apple Silicon) |

--- a/scripts/patch_bladebridge_large_xml.sh
+++ b/scripts/patch_bladebridge_large_xml.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# patch_bladebridge_large_xml.sh
+#
+# Fixes BladeBridge crash on DataStage XML files larger than ~100 MB.
+# See: https://github.com/databrickslabs/lakebridge/issues/2097
+#
+# The BladeBridge plugin's dbxconv binary receives the output directory as a
+# relative path via the -n flag. For large XML files, the binary recursively
+# nests that directory name, creating transpiled/transpiled/transpiled/...
+# until the path exceeds the OS limit (errno 63: File name too long).
+#
+# Fix: pass an absolute path to -n instead of a relative path.
+#
+# Usage:
+#   bash scripts/patch_bladebridge_large_xml.sh
+#
+set -euo pipefail
+
+PATCH_FILE="$HOME/.databricks/labs/remorph-transpilers/bladebridge/lib/.venv/lib/python3.10/site-packages/databricks/labs/bladebridge/transpiler.py"
+
+echo "=== BladeBridge Large XML Patch (Issue #2097) ==="
+echo ""
+
+# Step 1: Check if the file exists
+if [ ! -f "$PATCH_FILE" ]; then
+    echo "ERROR: BladeBridge transpiler.py not found at:"
+    echo "  $PATCH_FILE"
+    echo ""
+    echo "Make sure BladeBridge is installed:"
+    echo "  databricks labs lakebridge install-transpile --interactive false"
+    exit 1
+fi
+
+echo "Found: $PATCH_FILE"
+
+# Step 2: Check if the patch is needed
+if grep -q 'str(transpiled_dir\.relative_to(workdir))' "$PATCH_FILE"; then
+    echo "Status: NEEDS PATCHING (relative path found)"
+elif grep -q 'str(transpiled_dir\.absolute())' "$PATCH_FILE"; then
+    echo "Status: ALREADY PATCHED (absolute path found)"
+    echo "No changes needed."
+    exit 0
+else
+    echo "WARNING: Could not find the expected code pattern."
+    echo "The BladeBridge plugin version may be different from what this patch expects."
+    echo "Please check the file manually."
+    exit 1
+fi
+
+# Step 3: Create backup
+cp "$PATCH_FILE" "${PATCH_FILE}.bak"
+echo "Backup: ${PATCH_FILE}.bak"
+
+# Step 4: Apply the patch
+sed -i '' 's/str(transpiled_dir\.relative_to(workdir))/str(transpiled_dir.absolute())/' "$PATCH_FILE"
+
+# Step 5: Verify the patch was applied
+if grep -q 'str(transpiled_dir\.absolute())' "$PATCH_FILE"; then
+    echo "Patch: APPLIED SUCCESSFULLY"
+else
+    echo "ERROR: Patch failed. Restoring backup..."
+    cp "${PATCH_FILE}.bak" "$PATCH_FILE"
+    exit 1
+fi
+
+# Step 6: Clear Python bytecode cache
+find "$HOME/.databricks/labs/remorph-transpilers/bladebridge" -name "*.pyc" -path "*transpiler*" -delete 2>/dev/null
+echo "Cache: CLEARED"
+
+echo ""
+echo "=== Done ==="
+echo "BladeBridge can now process DataStage XML files larger than 100 MB."
+echo "Tested on: FinancialCredit.xml (119 MB, 2.2M lines) -> 425 files, 0 errors."


### PR DESCRIPTION
## Summary

- Add patch script and documentation for BladeBridge crash on large DataStage XML exports
- The `dbxconv` binary receives the output directory as a **relative path** via the `-n` flag. For large XML files with hundreds of jobs, the binary recursively nests that directory name (`transpiled/transpiled/transpiled/...`) until the path exceeds the OS limit (`OSError: [Errno 63] File name too long`)
- **Fix:** pass an **absolute path** to `-n` instead of a relative path

## Files Added

- `scripts/patch_bladebridge_large_xml.sh` — Idempotent patch script that modifies the installed BladeBridge plugin (`transpiler.py` line 203: `str(transpiled_dir.relative_to(workdir))` → `str(transpiled_dir.absolute())`)
- `docs/bladebridge_large_xml_fix.md` — Root cause analysis, manual fix instructions, and validation results

## Why a patch script (not a code change)

The fix is in `databricks/labs/bladebridge/transpiler.py`, which lives in the **BladeBridge plugin** (`databricks-bb-plugin` PyPI package, source: `databrickslabs/bladerunner`). Since that repo is private and the plugin is distributed as a compiled wheel, this PR provides a post-install patch script. The proper fix should be applied in the bladerunner repo.

## Validation

Tested on a real DataStage export (`FinancialCredit.xml`, 119 MB, 2.2M lines, CP874 charset, DataStage 11.5):

| Metric | Without Patch | With Patch |
|---|---|---|
| Result | Crashes after ~69 min | Completes in ~3 hours |
| Output files | 0 | **425** (379 notebooks + 46 workflow JSONs) |
| Recursive nesting | 87+ levels | 0 |
| Errors | Fatal `OSError: [Errno 63]` | 0 |

## Test plan

- [x] Applied patch on macOS (Apple Silicon, Darwin 25.3.0)
- [x] Ran BladeBridge transpile on 119 MB DataStage XML → 425 files, 0 errors
- [x] Verified patch script is idempotent (re-run detects already patched)
- [x] Verified patch script creates backup before modifying

Resolves #2097