### PR TITLE
[DRAFT] Refactor PyPI packages version query

### DIFF
--- a/src/databricks/labs/lakebridge/transpiler/installers.py
+++ b/src/databricks/labs/lakebridge/transpiler/installers.py
@@ -1,5 +1,6 @@
 import abc
 import datetime as dt
+import json
 import logging
 import os
 import re
@@ -160,24 +161,6 @@ class WheelInstaller(ArtifactInstaller):
     _site_packages: Path
     """Once created, the path to the site-packages directory in the virtual environment."""
 
-    @classmethod
-    def get_latest_artifact_version_from_pypi(cls, artifact_id: str) -> str | None:
-        url = f"https://pypi.org/pypi/{artifact_id}/json"
-        try:
-            # TODO: Use a user-agent that identifies this application.
-            response = requests.get(url, timeout=_DEFAULT_HTTP_TIMEOUT)
-            response.raise_for_status()
-            data: RootJsonValue = response.json()
-        except RequestException as e:
-            logger.error(f"Error while fetching PyPI metadata: {artifact_id}", exc_info=e)
-            return None
-        logger.debug(f"PyPI metadata for {artifact_id}: {data}")
-        match data:
-            case {"info": {"version": str(version), **_ignored}, **_also_ignored}:
-                return version
-            case _:
-                return None
-
     def __init__(
         self,
         repository: TranspilerRepository,
@@ -191,6 +174,26 @@ class WheelInstaller(ArtifactInstaller):
 
     def install(self) -> Path | None:
         return self._install_checking_versions()
+
+    def get_latest_artifact_version_from_pypi(self, artifact_id: str) -> str | None:
+        command: list[Path | str] = [
+            self._venv_exec_cmd,
+            "-m",
+            "pip",
+            "index",
+            "versions",
+            "--json",
+            artifact_id,
+        ]
+        if logger.isEnabledFor(logging.DEBUG):
+            command.append("--verbose")
+        try:
+            result = subprocess.run(command, stdin=sys.stdin, check=True, capture_output=True, text=True)
+            logger.debug(f"PyPI version metadata for {artifact_id}: {result.stdout}")
+            return json.loads(result.stdout)["versions"][0]
+        except (subprocess.CalledProcessError, json.decoder.JSONDecodeError, KeyError, IndexError) as e:
+            logger.error(f"Failed to query PyPi version metadata for {artifact_id}", exc_info=e)
+            return None
 
     def _install_checking_versions(self) -> Path | None:
         latest_version = (


### PR DESCRIPTION
## Changes
### What does this PR do?
Replaces the previous direct `requests.get` call to PyPI for package version lookup with a pip invocation instead. This allows the lookup to automatically respect the existing _pip.conf_ configuration, including custom indexes, mirrors, proxies, and authentication settings.

### Relevant implementation details
Package version resolution now uses `pip index versions --json` and parses the structured output instead of calling the package index directly over HTTP. This makes the behaviour consistent with the user’s configured Python packaging environment and avoids maintaining separate logic for custom PyPI endpoint handling.

### Caveats/things to watch out for when reviewing:

### Linked issues

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [ ] modified existing command: `databricks labs lakebridge ...`
- [ ] ... +add your own

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [X] manually tested
- [ ] added unit tests
- [ ] added integration tests
