### PR TITLE
CI/CD: JFrog/Maven integration

### DIFF
--- a/.github/actions/jfrog-auth/action.yml
+++ b/.github/actions/jfrog-auth/action.yml
@@ -18,7 +18,7 @@ runs:
       name: Detecting python package/project managers.
       shell: bash
       run: |
-        for cmd in pip3 uv
+        for cmd in mvn pip3 uv
         do
           command -v "${cmd}" > /dev/null && found=true || found=false
           printf '::debug::%s\n' "Found ${cmd}: ${found}"
@@ -37,6 +37,34 @@ runs:
         index-url = https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple
         EOF
         printf '%s=%s\n' 'PIP_CONFIG_FILE' "${RUNNER_TEMP}/.pip.conf" >> "${GITHUB_ENV}"
+
+    - name: Configure Maven for JFrog
+      if: "${{ steps.detect-cmds.outputs.command_uv == 'true' }}"
+      shell: bash
+      env:
+        JFROG_ACCESS_TOKEN: "${{ steps.jfrog-auth.outputs.jfrog-access-token }}"
+      run: |
+        umask 077
+        mkdir -p ~/.m2
+        cat > ~/.m2/settings.xml << EOF
+        <settings>
+          <mirrors>
+            <mirror>
+              <id>jfrog-central</id>
+              <mirrorOf>*</mirrorOf>
+              <url>https://databricks.jfrog.io/artifactory/db-maven/</url>
+            </mirror>
+          </mirrors>
+          <servers>
+            <server>
+              <id>jfrog-central</id>
+              <username>gha-service-account</username>
+              <password>${JFROG_ACCESS_TOKEN}</password>
+            </server>
+          </servers>
+        </settings>
+        EOF
+        printf '::debug::%s\n' 'Configured JFrog access for maven.'
 
     - name: Configure uv for JFrog
       if: "${{ steps.detect-cmds.outputs.command_uv == 'true' }}"

--- a/.github/actions/jfrog-auth/action.yml
+++ b/.github/actions/jfrog-auth/action.yml
@@ -46,5 +46,5 @@ runs:
         UV_INDEX_URL: 'https://databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple'
       run: |
         uv auth login "${UV_INDEX_URL}" --username gha-service-account --password "${JFROG_ACCESS_TOKEN}"
-        printf "%s=%s\n" 'UV_INDEX_URL' "${UV_INDEX_URL}" >> "${GITHUB_ENV}"
-        printf "%s=%s\n" 'UV_FROZEN' '1' >> "${GITHUB_ENV}"
+        printf '%s=%s\n' 'UV_INDEX_URL' "${UV_INDEX_URL}" >> "${GITHUB_ENV}"
+        printf '%s=%s\n' 'UV_FROZEN' '1' >> "${GITHUB_ENV}"

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -48,7 +48,9 @@ jobs:
           $GITHUB_WORKSPACE/.github/scripts/setup_mssql_odbc.sh
 
       # TODO: Migrate tests to use Databricks clusters instead of Spark local mode
+      # Currently disabled because archive.apache.org is blocked on runners; need an alternative source for Spark 3.5.5.
       - name: Setup spark
+        if: false
         run: |
           chmod +x $GITHUB_WORKSPACE/.github/scripts/setup_spark_remote.sh
           $GITHUB_WORKSPACE/.github/scripts/setup_spark_remote.sh


### PR DESCRIPTION
## Changes

### What does this PR do?

This PR adds support for setting up Maven during CI/CD to work with JFrog.

### Caveats/things to watch out for when reviewing:

The integration/acceptance tests should use maven to download various resources they need, but the relevant script is currently disabled because it fails at any earlier point. This PR is merely intended to checkpoint the support for maven, which is general in nature.