### PR TITLE
Fix MSSQL profiler extract path, credential manager init, and query/cert handling

### DIFF
--- a/src/databricks/labs/lakebridge/assessments/configure_assessment.py
+++ b/src/databricks/labs/lakebridge/assessments/configure_assessment.py
@@ -137,6 +137,7 @@ class ConfigureSqlServerAssessment(AssessmentConfigurator):
                 "driver": self.prompts.question(
                     "Enter the ODBC driver installed locally", default="ODBC Driver 18 for SQL Server"
                 ),
+                "trust_server_certificate": "yes",
             },
         }
 

--- a/src/databricks/labs/lakebridge/connections/database_manager.py
+++ b/src/databricks/labs/lakebridge/connections/database_manager.py
@@ -88,11 +88,12 @@ class MSSQLConnector(_BaseConnector):
     def _connect(self) -> Engine:
         auth_type = self.config.get('auth_type', 'sql_authentication')
         db_value = self.config.get('database')
-        db_name = str(db_value) if db_value else None
+        db_name = str(db_value) if db_value else 'master'
 
         query_params: dict[str, str] = {
             "driver": str(self.config['driver']),
             "loginTimeout": "30",
+            "TrustServerCertificate": str(self.config.get('trust_server_certificate', 'no')),
         }
 
         if auth_type == "ad_passwd_authentication":

--- a/src/databricks/labs/lakebridge/resources/assessments/mssql/activity_extract.py
+++ b/src/databricks/labs/lakebridge/resources/assessments/mssql/activity_extract.py
@@ -8,7 +8,10 @@ from databricks.labs.lakebridge.connections.env_getter import EnvGetter
 from databricks.labs.lakebridge.assessments import PRODUCT_NAME
 from databricks.labs.lakebridge.resources.assessments.common.cli import arguments_loader
 from databricks.labs.lakebridge.resources.assessments.common.duckdb_helpers import save_to_duckdb
-from databricks.labs.lakebridge.resources.assessments.mssql.common.connector import get_sqlserver_reader, get_query_class
+from databricks.labs.lakebridge.resources.assessments.mssql.common.connector import (
+    get_sqlserver_reader,
+    get_query_class,
+)
 from databricks.labs.lakebridge.resources.assessments.mssql.common.schemas import MSSQL_SCHEMAS
 
 logger = get_logger(__file__)

--- a/src/databricks/labs/lakebridge/resources/assessments/mssql/activity_extract.py
+++ b/src/databricks/labs/lakebridge/resources/assessments/mssql/activity_extract.py
@@ -4,6 +4,7 @@ import sys
 from databricks.labs.blueprint.entrypoint import get_logger
 
 from databricks.labs.lakebridge.connections.credential_manager import create_credential_manager
+from databricks.labs.lakebridge.connections.env_getter import EnvGetter
 from databricks.labs.lakebridge.assessments import PRODUCT_NAME
 from databricks.labs.lakebridge.resources.assessments.common.cli import arguments_loader
 from databricks.labs.lakebridge.resources.assessments.common.duckdb_helpers import save_to_duckdb
@@ -17,7 +18,7 @@ logger = get_logger(__file__)
 def execute():
 
     db_path, creds_file = arguments_loader(desc="MSSQL Server Activity Extract Script")
-    cred_manager = create_credential_manager(PRODUCT_NAME, creds_file)
+    cred_manager = create_credential_manager(PRODUCT_NAME, EnvGetter())
     mssql_settings = cred_manager.get_credentials("mssql")
     auth_type = mssql_settings.get("auth_type", "sql_authentication")
     server_name = mssql_settings.get("server", "")

--- a/src/databricks/labs/lakebridge/resources/assessments/mssql/activity_extract.py
+++ b/src/databricks/labs/lakebridge/resources/assessments/mssql/activity_extract.py
@@ -8,8 +8,7 @@ from databricks.labs.lakebridge.connections.env_getter import EnvGetter
 from databricks.labs.lakebridge.assessments import PRODUCT_NAME
 from databricks.labs.lakebridge.resources.assessments.common.cli import arguments_loader
 from databricks.labs.lakebridge.resources.assessments.common.duckdb_helpers import save_to_duckdb
-from databricks.labs.lakebridge.resources.assessments.mssql.common.connector import get_sqlserver_reader
-from databricks.labs.lakebridge.resources.assessments.mssql.common.queries import MSSQLQueries
+from databricks.labs.lakebridge.resources.assessments.mssql.common.connector import get_sqlserver_reader, get_query_class
 from databricks.labs.lakebridge.resources.assessments.mssql.common.schemas import MSSQL_SCHEMAS
 
 logger = get_logger(__file__)
@@ -37,9 +36,11 @@ def execute():
             mssql_settings, db_name="master", server_name=server_name, auth_type=auth_type
         )
 
+        queries = get_query_class(connection)
+
         # Query stats
         table_name = "query_stats"
-        table_query = MSSQLQueries.get_query_stats(last_execution_time)
+        table_query = queries.get_query_stats(last_execution_time)
         logger.info(f"Loading '{table_name}' for SQL server: {server_name}")
         result = connection.fetch(table_query)
         save_to_duckdb(
@@ -48,7 +49,7 @@ def execute():
 
         # Stored procedure stats
         table_name = "proc_stats"
-        table_query = MSSQLQueries.get_procedure_stats(last_execution_time)
+        table_query = queries.get_procedure_stats(last_execution_time)
         logger.info(f"Loading '{table_name}' for SQL server: {server_name}")
         result = connection.fetch(table_query)
         save_to_duckdb(
@@ -57,7 +58,7 @@ def execute():
 
         # Session info
         table_name = "sessions"
-        table_query = MSSQLQueries.get_sessions(last_execution_time)
+        table_query = queries.get_sessions(last_execution_time)
         logger.info(f"Loading '{table_name}' for SQL server: {server_name}")
         result = connection.fetch(table_query)
         save_to_duckdb(
@@ -66,7 +67,7 @@ def execute():
 
         # CPU Utilization
         table_name = "cpu_utilization"
-        table_query = MSSQLQueries.get_cpu_utilization(last_execution_time)
+        table_query = queries.get_cpu_utilization(last_execution_time)
         logger.info(f"Loading '{table_name}' for SQL server: {server_name}")
         result = connection.fetch(table_query)
         save_to_duckdb(

--- a/src/databricks/labs/lakebridge/resources/assessments/mssql/common/connector.py
+++ b/src/databricks/labs/lakebridge/resources/assessments/mssql/common/connector.py
@@ -40,6 +40,7 @@ def get_sqlserver_reader(
         "password": input_cred['password'],
         "port": input_cred.get('port', 1433),
         "auth_type": auth_type,
+        "trust_server_certificate": input_cred.get('trust_server_certificate', 'no'),
     }
     source = "mssql"
 

--- a/src/databricks/labs/lakebridge/resources/assessments/mssql/common/connector.py
+++ b/src/databricks/labs/lakebridge/resources/assessments/mssql/common/connector.py
@@ -1,4 +1,28 @@
+import logging
+
 from databricks.labs.lakebridge.connections.database_manager import DatabaseManager
+from databricks.labs.lakebridge.resources.assessments.mssql.common.queries import (
+    AzureSQLDetect,
+    AzureSQLQueries,
+    MSSQLQueries,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_query_class(connection: DatabaseManager):
+    """Return AzureSQLQueries if connected to Azure SQL DB (EngineEdition 5), else MSSQLQueries."""
+    try:
+        result = connection.fetch(AzureSQLDetect.is_azure_sql_db())
+        if result.rows:
+            engine_edition = result.rows[0][0]
+            logger.info(f"Detected SQL Server EngineEdition: {engine_edition}")
+            if engine_edition == 5:
+                logger.info("Using Azure SQL Database compatible queries")
+                return AzureSQLQueries
+    except Exception as e:
+        logger.warning(f"Could not detect engine edition, assuming on-prem: {e}")
+    return MSSQLQueries
 
 
 def get_sqlserver_reader(

--- a/src/databricks/labs/lakebridge/resources/assessments/mssql/common/queries.py
+++ b/src/databricks/labs/lakebridge/resources/assessments/mssql/common/queries.py
@@ -1,3 +1,11 @@
+class AzureSQLDetect:
+    """Detect whether the target is Azure SQL Database vs on-prem / VM SQL Server."""
+
+    @staticmethod
+    def is_azure_sql_db() -> str:
+        return "SELECT CAST(SERVERPROPERTY('EngineEdition') AS INT) AS engine_edition"
+
+
 class MSSQLQueries:
 
     @staticmethod
@@ -382,4 +390,166 @@ class MSSQLQueries:
           JOIN  sys.objects AS o ON ps.object_id = o.object_id
           WHERE o.type = 'U'
           GROUP BY schema_name(o.schema_id), o.name
+        """
+
+
+class AzureSQLQueries(MSSQLQueries):
+    """Azure SQL Database compatible overrides for DMVs not available in Azure SQL DB.
+
+    Azure SQL DB (EngineEdition = 5) does not support:
+      - sys.dm_os_ring_buffers
+      - Server-scoped DMVs (VIEW SERVER PERFORMANCE STATE)
+      - Cross-database name resolution via DB_NAME(database_id)
+
+    Only overrides methods that differ from MSSQLQueries. Inherits:
+      get_sys_info, get_databases, get_tables, get_views, get_columns,
+      get_indexed_views, get_routines, get_db_sizes, get_table_sizes
+    """
+
+    @staticmethod
+    def get_query_stats(last_execution_time: str | None) -> str:
+        """Uses DB_ID() instead of st.dbid (cross-db resolution unavailable on Azure SQL DB)."""
+        predicate = (
+            f"WHERE qs.last_execution_time > CAST('{last_execution_time}' AS DATETIME2(6))"
+            if last_execution_time
+            else ""
+        )
+
+        return f"""
+          with query_stats as (
+            SELECT
+                CONVERT(VARCHAR(64), HASHBYTES('SHA2_256', qs.sql_handle), 1) as sql_handle,
+                DB_ID() as dbid,
+                qs.creation_time,
+                qs.last_execution_time,
+                qs.execution_count,
+                qs.total_worker_time,
+                qs.total_elapsed_time,
+                qs.total_rows,
+                SUBSTRING(st.text, (qs.statement_start_offset/2) + 1,
+                    ((CASE statement_end_offset
+                        WHEN -1 THEN DATALENGTH(st.text)
+                        ELSE qs.statement_end_offset END
+                        - qs.statement_start_offset)/2) + 1) AS statement_text
+            FROM sys.dm_exec_query_stats AS qs
+            CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) AS st
+            {predicate}
+          ),
+          query_stats_ex as (
+            select
+              dbid,
+              creation_time,
+              last_execution_time,
+              execution_count,
+              total_worker_time,
+              total_elapsed_time,
+              total_rows,
+              UPPER(SUBSTRING(LTRIM(RTRIM(statement_text)), 1, 40)) as command
+            from query_stats
+          )
+          SELECT
+            *,
+            CASE
+              WHEN command like 'SELECT%' THEN 'QUERY'
+              WHEN command like 'WITH%' THEN 'QUERY'
+              WHEN command like 'INSERT%' THEN 'DML'
+              WHEN command like 'UPDATE%' THEN 'DML'
+              WHEN command like 'MERGE%' THEN 'DML'
+              WHEN command like 'DELETE%' THEN 'DML'
+              WHEN command like 'TRUNCATE%' THEN 'DML'
+              WHEN command like 'COPY%' THEN 'DML'
+              WHEN command like 'IF%' THEN 'DML'
+              WHEN command like 'BEGIN%' THEN 'DML'
+              WHEN command like 'DECLARE%' THEN 'DML'
+              WHEN command like 'BUILDREPLICATEDTABLECACHE%' THEN 'DML'
+              WHEN command like 'CREATE%' THEN 'DDL'
+              WHEN command like 'DROP%' THEN 'DDL'
+              WHEN command like 'ALTER%' THEN 'DDL'
+              WHEN command like 'EXEC%' THEN 'ROUTINE'
+              WHEN command like 'EXECUTE %' THEN 'ROUTINE'
+              WHEN command like 'BEGIN%TRAN%' THEN 'TRANSACTION_CONTROL'
+              WHEN command like 'END%TRAN%' THEN 'TRANSACTION_CONTROL'
+              WHEN command like 'COMMIT%' THEN 'TRANSACTION_CONTROL'
+              WHEN command like 'ROLLBACK%' THEN 'TRANSACTION_CONTROL'
+              ELSE 'OTHER'
+            END as command_type,
+            SYSDATETIME() as extract_ts
+          FROM query_stats_ex
+          ORDER BY last_execution_time
+        """
+
+    @staticmethod
+    def get_procedure_stats(last_execution_time: str | None):
+        """Uses DB_NAME() and OBJECT_NAME() without cross-db params."""
+        predicate = (
+            f"WHERE last_execution_time > CAST('{last_execution_time}' AS DATETIME2(6))" if last_execution_time else ""
+        )
+        return f"""
+            SELECT
+              database_id,
+              DB_NAME() AS db_name,
+              object_id,
+              OBJECT_NAME(object_id) AS object_name,
+              type,
+              last_execution_time,
+              execution_count,
+              total_worker_time,
+              total_elapsed_time,
+              SYSDATETIME() as extract_ts
+            FROM
+              sys.dm_exec_procedure_stats
+            {predicate}
+            ORDER BY
+              last_execution_time
+        """
+
+    @staticmethod
+    def get_sessions(last_execution_time: str | None):
+        """Uses DB_NAME() instead of DB_NAME(database_id) for current database context."""
+        predicate = (
+            f"AND last_request_end_time > CAST('{last_execution_time}' AS DATETIME2(6))" if last_execution_time else ""
+        )
+        return f"""
+        SELECT
+          session_id,
+          login_time,
+          program_name,
+          client_interface_name,
+          CONVERT(VARCHAR(64), HASHBYTES('SHA2_256', login_name), 1) as login_name,
+          status,
+          cpu_time,
+          memory_usage,
+          total_scheduled_time,
+          total_elapsed_time,
+          last_request_start_time,
+          last_request_end_time,
+          is_user_process,
+          row_count,
+          database_id,
+          DB_NAME() AS db_name,
+          SYSDATETIME() as extract_ts
+        FROM
+          sys.dm_exec_sessions
+        WHERE
+          is_user_process <> 0 {predicate}
+        ORDER BY
+          last_request_end_time
+        """
+
+    @staticmethod
+    def get_cpu_utilization(last_execution_time: str | None):
+        """Uses sys.dm_db_resource_stats instead of dm_os_ring_buffers (unavailable on Azure SQL DB)."""
+        predicate = (
+            f"WHERE end_time > CAST('{last_execution_time}' AS DATETIME2(6))" if last_execution_time else ""
+        )
+        return f"""
+            SELECT
+                NULL AS record_id,
+                end_time AS EventTime,
+                CAST(100 - avg_cpu_percent AS INT) AS SystemIdle,
+                CAST(avg_cpu_percent AS INT) AS SQLProcessUtilization,
+                SYSDATETIME() AS extract_ts
+            FROM sys.dm_db_resource_stats
+            {predicate}
+            ORDER BY end_time
         """

--- a/src/databricks/labs/lakebridge/resources/assessments/mssql/common/queries.py
+++ b/src/databricks/labs/lakebridge/resources/assessments/mssql/common/queries.py
@@ -539,9 +539,7 @@ class AzureSQLQueries(MSSQLQueries):
     @staticmethod
     def get_cpu_utilization(last_execution_time: str | None):
         """Uses sys.dm_db_resource_stats instead of dm_os_ring_buffers (unavailable on Azure SQL DB)."""
-        predicate = (
-            f"WHERE end_time > CAST('{last_execution_time}' AS DATETIME2(6))" if last_execution_time else ""
-        )
+        predicate = f"WHERE end_time > CAST('{last_execution_time}' AS DATETIME2(6))" if last_execution_time else ""
         return f"""
             SELECT
                 NULL AS record_id,

--- a/src/databricks/labs/lakebridge/resources/assessments/mssql/info_extract.py
+++ b/src/databricks/labs/lakebridge/resources/assessments/mssql/info_extract.py
@@ -4,6 +4,7 @@ import sys
 from databricks.labs.blueprint.entrypoint import get_logger
 
 from databricks.labs.lakebridge.connections.credential_manager import create_credential_manager
+from databricks.labs.lakebridge.connections.env_getter import EnvGetter
 from databricks.labs.lakebridge.assessments import PRODUCT_NAME
 from databricks.labs.lakebridge.resources.assessments.common.cli import arguments_loader
 from databricks.labs.lakebridge.resources.assessments.common.duckdb_helpers import save_to_duckdb
@@ -16,7 +17,7 @@ logger = get_logger(__file__)
 
 def execute():
     db_path, creds_file = arguments_loader(desc="MSSQL Server Info Extract Script")
-    cred_manager = create_credential_manager(PRODUCT_NAME, creds_file)
+    cred_manager = create_credential_manager(PRODUCT_NAME, EnvGetter())
     mssql_settings = cred_manager.get_credentials("mssql")
     auth_type = mssql_settings.get("auth_type", "sql_authentication")
     server_name = mssql_settings.get("server", "")

--- a/src/databricks/labs/lakebridge/resources/assessments/mssql/info_extract.py
+++ b/src/databricks/labs/lakebridge/resources/assessments/mssql/info_extract.py
@@ -8,8 +8,7 @@ from databricks.labs.lakebridge.connections.env_getter import EnvGetter
 from databricks.labs.lakebridge.assessments import PRODUCT_NAME
 from databricks.labs.lakebridge.resources.assessments.common.cli import arguments_loader
 from databricks.labs.lakebridge.resources.assessments.common.duckdb_helpers import save_to_duckdb
-from databricks.labs.lakebridge.resources.assessments.mssql.common.connector import get_sqlserver_reader
-from databricks.labs.lakebridge.resources.assessments.mssql.common.queries import MSSQLQueries
+from databricks.labs.lakebridge.resources.assessments.mssql.common.connector import get_sqlserver_reader, get_query_class
 from databricks.labs.lakebridge.resources.assessments.mssql.common.schemas import MSSQL_SCHEMAS
 
 logger = get_logger(__file__)
@@ -35,9 +34,11 @@ def execute():
             mssql_settings, db_name="master", server_name=server_name, auth_type=auth_type
         )
 
+        queries = get_query_class(connection)
+
         # System info
         table_name = "sys_info"
-        table_query = MSSQLQueries.get_sys_info()
+        table_query = queries.get_sys_info()
         logger.info(f"Loading '{table_name}' for SQL server: {server_name}")
         print(f"Loading '{table_name}' for SQL server: {server_name}")
         result = connection.fetch(table_query)
@@ -47,7 +48,7 @@ def execute():
 
         # Databases
         table_name = "databases"
-        table_query = MSSQLQueries.get_databases()
+        table_query = queries.get_databases()
         logger.info(f"Loading '{table_name}' for SQL server: {server_name}")
         result = connection.fetch(table_query)
         save_to_duckdb(
@@ -56,7 +57,7 @@ def execute():
 
         # Tables
         table_name = "tables"
-        table_query = MSSQLQueries.get_tables()
+        table_query = queries.get_tables()
         logger.info(f"Loading '{table_name}' for SQL server: {server_name}")
         result = connection.fetch(table_query)
         save_to_duckdb(
@@ -65,7 +66,7 @@ def execute():
 
         # Views
         table_name = "views"
-        table_query = MSSQLQueries.get_views()
+        table_query = queries.get_views()
         logger.info(f"Loading '{table_name}' for SQL server: {server_name}")
         result = connection.fetch(table_query)
         save_to_duckdb(
@@ -74,7 +75,7 @@ def execute():
 
         # Columns
         table_name = "columns"
-        table_query = MSSQLQueries.get_columns()
+        table_query = queries.get_columns()
         logger.info(f"Loading '{table_name}' for SQL server: {server_name}")
         result = connection.fetch(table_query)
         save_to_duckdb(
@@ -83,7 +84,7 @@ def execute():
 
         # Indexed views
         table_name = "indexed_views"
-        table_query = MSSQLQueries.get_indexed_views()
+        table_query = queries.get_indexed_views()
         logger.info(f"Loading '{table_name}' for SQL server: {server_name}")
         result = connection.fetch(table_query)
         save_to_duckdb(
@@ -92,7 +93,7 @@ def execute():
 
         # Routines
         table_name = "routines"
-        table_query = MSSQLQueries.get_routines()
+        table_query = queries.get_routines()
         logger.info(f"Loading '{table_name}' for SQL server: {server_name}")
         result = connection.fetch(table_query)
         save_to_duckdb(
@@ -101,7 +102,7 @@ def execute():
 
         # Database sizes
         table_name = "db_sizes"
-        table_query = MSSQLQueries.get_db_sizes()
+        table_query = queries.get_db_sizes()
         logger.info(f"Loading '{table_name}' for SQL server: {server_name}")
         result = connection.fetch(table_query)
         save_to_duckdb(
@@ -110,7 +111,7 @@ def execute():
 
         # Table sizes
         table_name = "table_sizes"
-        table_query = MSSQLQueries.get_table_sizes()
+        table_query = queries.get_table_sizes()
         logger.info(f"Loading '{table_name}' for SQL server: {server_name}")
         result = connection.fetch(table_query)
         save_to_duckdb(

--- a/src/databricks/labs/lakebridge/resources/assessments/mssql/info_extract.py
+++ b/src/databricks/labs/lakebridge/resources/assessments/mssql/info_extract.py
@@ -8,7 +8,10 @@ from databricks.labs.lakebridge.connections.env_getter import EnvGetter
 from databricks.labs.lakebridge.assessments import PRODUCT_NAME
 from databricks.labs.lakebridge.resources.assessments.common.cli import arguments_loader
 from databricks.labs.lakebridge.resources.assessments.common.duckdb_helpers import save_to_duckdb
-from databricks.labs.lakebridge.resources.assessments.mssql.common.connector import get_sqlserver_reader, get_query_class
+from databricks.labs.lakebridge.resources.assessments.mssql.common.connector import (
+    get_sqlserver_reader,
+    get_query_class,
+)
 from databricks.labs.lakebridge.resources.assessments.mssql.common.schemas import MSSQL_SCHEMAS
 
 logger = get_logger(__file__)

--- a/src/databricks/labs/lakebridge/resources/assessments/mssql/pipeline_config.yml
+++ b/src/databricks/labs/lakebridge/resources/assessments/mssql/pipeline_config.yml
@@ -1,6 +1,6 @@
 name: mssql_assessment
 version: "1.0"
-extract_folder: "/tmp/data/mssql_assessment"
+extract_folder: "~/.databricks/labs/lakebridge_profilers/mssql_assessment"
 steps:
   - name: activity_extract
     type: python

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -41,6 +41,7 @@ def test_configure_sqlserver_credentials(tmp_path):
             'password': 'TEST_TSQL_PASS',
             'port': 1433,
             'server': 'URL',
+            'trust_server_certificate': 'yes',
             'tz_info': 'UTC',
             'user': 'TEST_TSQL_USER',
         },

--- a/tests/unit/assessment/test_mssql_connector_helpers.py
+++ b/tests/unit/assessment/test_mssql_connector_helpers.py
@@ -1,0 +1,40 @@
+import logging
+from unittest.mock import MagicMock
+
+from databricks.labs.lakebridge.resources.assessments.mssql.common.connector import get_query_class
+from databricks.labs.lakebridge.resources.assessments.mssql.common.queries import (
+    AzureSQLQueries,
+    MSSQLQueries,
+)
+
+
+def _mock_connection_returning(rows) -> MagicMock:
+    conn = MagicMock()
+    conn.fetch.return_value = MagicMock(rows=rows)
+    return conn
+
+
+def test_get_query_class_returns_azure_for_engine_edition_5() -> None:
+    conn = _mock_connection_returning([[5]])
+    assert get_query_class(conn) is AzureSQLQueries
+
+
+def test_get_query_class_returns_mssql_for_on_prem_edition() -> None:
+    conn = _mock_connection_returning([[3]])
+    assert get_query_class(conn) is MSSQLQueries
+
+
+def test_get_query_class_returns_mssql_when_no_rows() -> None:
+    conn = _mock_connection_returning([])
+    assert get_query_class(conn) is MSSQLQueries
+
+
+def test_get_query_class_falls_back_when_detection_fails(caplog) -> None:
+    conn = MagicMock()
+    conn.fetch.side_effect = RuntimeError("boom")
+
+    with caplog.at_level(logging.WARNING):
+        result = get_query_class(conn)
+
+    assert result is MSSQLQueries
+    assert any("Could not detect engine edition" in r.message for r in caplog.records)

--- a/tests/unit/connections/test_database_manager.py
+++ b/tests/unit/connections/test_database_manager.py
@@ -73,3 +73,39 @@ def test_fetch_commit(mock_mssql_connector) -> None:
 
     assert mutate_result == mock_result
     mock_connector_instance.fetch.assert_called_once_with(mutate_query)
+
+
+def _mssql_config_without(key: str) -> dict:
+    cfg = dict(sample_config)
+    cfg.pop(key, None)
+    return cfg
+
+
+@patch('databricks.labs.lakebridge.connections.database_manager.create_engine')
+def test_mssql_default_database_is_master(mock_create_engine) -> None:
+    DatabaseManager("mssql", _mssql_config_without('database'))
+    url = mock_create_engine.call_args.args[0]
+    assert url.database == 'master'
+
+
+@patch('databricks.labs.lakebridge.connections.database_manager.create_engine')
+def test_mssql_empty_database_falls_back_to_master(mock_create_engine) -> None:
+    cfg = dict(sample_config, database='')
+    DatabaseManager("mssql", cfg)
+    url = mock_create_engine.call_args.args[0]
+    assert url.database == 'master'
+
+
+@patch('databricks.labs.lakebridge.connections.database_manager.create_engine')
+def test_mssql_trust_server_certificate_passed_through(mock_create_engine) -> None:
+    cfg = dict(sample_config, trust_server_certificate='yes')
+    DatabaseManager("mssql", cfg)
+    url = mock_create_engine.call_args.args[0]
+    assert url.query.get('TrustServerCertificate') == 'yes'
+
+
+@patch('databricks.labs.lakebridge.connections.database_manager.create_engine')
+def test_mssql_trust_server_certificate_defaults_to_no(mock_create_engine) -> None:
+    DatabaseManager("mssql", sample_config)
+    url = mock_create_engine.call_args.args[0]
+    assert url.query.get('TrustServerCertificate') == 'no'


### PR DESCRIPTION
## Changes

### What does this PR do?
Makes fixes so the MSSQL profiler runs cleanly on both on-prem SQL Server and Azure SQL Database:                                                                                                     
  
  1. Profiler output path — pipeline_config.yml now extracts to ~/.databricks/labs/lakebridge_profilers/mssql_assessment, matching the path used by the other profilers instead of /tmp/data/....                                                   
  2. Credential manager init — activity_extract.py and info_extract.py now construct the credential manager via EnvGetter instead of a file path, so it works when secrets come from env vars.
  3. TrustServerCertificate support — added in database_manager.py (SQLAlchemy query params), configure_assessment.py (defaults to "yes" during prompts), and propagated through connector.py so subprocess steps see the flag.                     
  4. Default database = master — in database_manager.py, db_name falls back to 'master' when not provided.                                                                                                                                          
  5. Engine-edition-aware query selection — new get_query_class(connection) helper in mssql/common/connector.py runs AzureSQLDetect.is_azure_sql_db() and returns AzureSQLQueries when EngineEdition == 5, otherwise MSSQLQueries. Adds an AzureSQLQueries set in common/queries.py.   

### Relevant implementation details
- Engine-edition detection swallows failures and falls back to MSSQLQueries with a warning log, so existing on-prem flows stay unchanged if detection can't run.    

### Caveats/things to watch out for when reviewing:
  - trust_server_certificate defaults to "yes" during interactive prompting in ConfigureSqlServerAssessment. That's a deliberate profiler-UX choice, not a library default — confirm the ergonomics are what reviewers expect.                      
  - pipeline_config.yml path change is a behaviour change for anyone relying on the old /tmp/data/... location.  

### Functionality
- [x] MSSQL profiler now writes to the shared profiler directory                                                                                                                                                                                      
- [x] MSSQL profiler now supports TrustServerCertificate and Azure SQL DB   

### Tests

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
