### PR TITLE
Fix CHAR/VARCHAR length overflow when writing reconcile intermediate data

### DIFF
--- a/src/databricks/labs/lakebridge/reconcile/recon_capture.py
+++ b/src/databricks/labs/lakebridge/reconcile/recon_capture.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.functions import col, collect_list, create_map, lit
+from pyspark.sql.types import StringType
 from pyspark.errors import PySparkException
 from sqlglot import Dialect
 
@@ -87,8 +88,23 @@ class ReconIntermediatePersist(AbstractReconIntermediatePersist):
             f"{self._metadata_config.volume}"
         )
 
+    @staticmethod
+    def _strip_char_varchar_constraints(df: DataFrame) -> DataFrame:
+        """Strip CHAR(n)/VARCHAR(n) length constraints from DataFrame columns.
+
+        When reconciling data from external sources (e.g., Teradata via Lakehouse Federation),
+        CHAR columns may contain space-padded values that exceed the declared length limit,
+        causing DELTA_EXCEED_CHAR_VARCHAR_LIMIT errors when writing to Delta.
+
+        Delta enforces length constraints via column metadata (__CHAR_VARCHAR_TYPE_STRING),
+        not just the column type. This method strips all column metadata to remove those
+        constraints.
+        """
+        return df.select(*[col(f.name).alias(f.name, metadata={}) for f in df.schema.fields])
+
     def _write_df_to_volumes(self, df: DataFrame, path: str) -> None:
         logger.debug(f"Writing DF on {self._format} to path: {path}")
+        df = self._strip_char_varchar_constraints(df)
         df.write.format(self._format).save(path)
         logger.info(f"Wrote DF on {self._format}")
 
@@ -114,6 +130,7 @@ class ReconIntermediatePersist(AbstractReconIntermediatePersist):
 
 def _write_df_to_delta(df: DataFrame, table_name: str, mode="append"):
     try:
+        df = ReconIntermediatePersist._strip_char_varchar_constraints(df)
         df.write.mode(mode).saveAsTable(table_name)
         logger.info(f"Data written to {table_name} successfully.")
     except Exception as e:

--- a/tests/unit/reconcile/test_recon_capture.py
+++ b/tests/unit/reconcile/test_recon_capture.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock
+
+from pyspark.sql.types import StructType, StructField, StringType, IntegerType
+
+from databricks.labs.lakebridge.reconcile.recon_capture import ReconIntermediatePersist
+
+
+def _make_df(schema_fields):
+    """Create a mock DataFrame with given schema fields."""
+    schema = StructType(schema_fields)
+    df = MagicMock()
+    df.schema = schema
+    df.columns = [f.name for f in schema_fields]
+
+    def mock_select(*cols):
+        # select with alias strips metadata — return df with empty metadata on all fields
+        stripped_fields = [
+            StructField(f.name, f.dataType, f.nullable, metadata={})
+            for f in schema_fields
+        ]
+        return _make_df(stripped_fields)
+
+    df.select = mock_select
+    return df
+
+
+def test_strip_char_varchar_constraints_strips_metadata():
+    """Column metadata should be stripped to remove CHAR/VARCHAR constraints."""
+    df = _make_df([
+        StructField("id", IntegerType(), False, metadata={}),
+        StructField("name", StringType(), True, metadata={"__CHAR_VARCHAR_TYPE_STRING": "char(16)"}),
+    ])
+
+    result = ReconIntermediatePersist._strip_char_varchar_constraints(df)
+
+    assert result.schema.fields[1].metadata == {}
+
+
+def test_strip_char_varchar_constraints_preserves_types():
+    """Column types should be preserved — only metadata is stripped."""
+    df = _make_df([
+        StructField("id", IntegerType(), False),
+        StructField("name", StringType(), True),
+    ])
+
+    result = ReconIntermediatePersist._strip_char_varchar_constraints(df)
+
+    assert result.schema.fields[0].dataType == IntegerType()
+    assert result.schema.fields[1].dataType == StringType()
+
+
+


### PR DESCRIPTION
## Changes

### What does this PR do?

Strip CHAR(n)/VARCHAR(n) length constraints from DataFrames before writing intermediate data to Delta during reconciliation. This prevents `DELTA_EXCEED_CHAR_VARCHAR_LIMIT` errors when source data contains space-padded CHAR values.

### Root cause

Some data sources (e.g., Teradata) return CHAR(n) values with space padding via JDBC, resulting in values that exceed the declared column length (e.g., a CHAR(16) column returning 16 digits + 16 spaces = 32 characters). Delta enforces CHAR/VARCHAR length constraints through column metadata (`__CHAR_VARCHAR_TYPE_STRING`), causing writes to fail for these padded values.

This was observed with Teradata via Lakehouse Federation but not with Lakebase (PostgreSQL) via Lakehouse Federation.

### Fix

Strip all column metadata via `col.alias(name, metadata={})` before writing intermediate DataFrames to Delta. This removes the constraint that Delta uses for length enforcement. The intermediate data is temporary and does not need metadata preservation.

### Linked issues

Fixes #2389

### Tests

- [x] manually tested with Teradata via Lakehouse Federation
- [x] added unit tests
- [ ] added integration tests

## Test plan

- [x] `test_strip_char_varchar_constraints_strips_metadata` — verifies CHAR/VARCHAR metadata is stripped
- [x] `test_strip_char_varchar_constraints_preserves_types` — verifies column types are preserved
- [x] All existing reconcile unit tests pass