### PR TITLE
Fix: use metadata_config.schema as fallback in aggregate final output

### DIFF
--- a/src/databricks/labs/lakebridge/reconcile/recon_capture.py
+++ b/src/databricks/labs/lakebridge/reconcile/recon_capture.py
@@ -198,7 +198,7 @@ def generate_final_reconcile_aggregate_output(
     metadata_config: ReconcileMetadataConfig = ReconcileMetadataConfig(),
     local_test_run: bool = False,
 ) -> ReconcileOutput:
-    _db_prefix = "default" if local_test_run else f"{metadata_config.catalog}.{metadata_config.schema}"
+    _db_prefix = metadata_config.schema if local_test_run else f"{metadata_config.catalog}.{metadata_config.schema}"
     recon_df = spark.sql(
         f"""
         SELECT source_table,

--- a/tests/unit/reconcile/test_recon_capture.py
+++ b/tests/unit/reconcile/test_recon_capture.py
@@ -1,0 +1,58 @@
+from unittest.mock import MagicMock
+
+from databricks.labs.lakebridge.config import ReconcileMetadataConfig
+from databricks.labs.lakebridge.reconcile.recon_capture import (
+    generate_final_reconcile_aggregate_output,
+)
+
+
+def _mock_spark() -> MagicMock:
+    spark = MagicMock()
+    df = MagicMock()
+    df.collect.return_value = []
+    spark.sql.return_value = df
+    return spark
+
+
+def test_generate_final_reconcile_aggregate_output_uses_metadata_schema_in_local_test_run() -> None:
+    """local_test_run=True must read from metadata_config.schema, not the literal 'default'.
+
+    Other places in recon_capture (generate_final_reconcile_output, ReconCapture.__init__)
+    already use metadata_config.schema as the test-run prefix; the aggregate variant
+    diverged and hard-coded 'default', which fails when callers pass a populated
+    ReconcileMetadataConfig together with local_test_run=True.
+    """
+    spark = _mock_spark()
+    metadata_config = ReconcileMetadataConfig(catalog="my_cat", schema="my_recon", volume="my_vol")
+
+    generate_final_reconcile_aggregate_output(
+        recon_id="r-1",
+        spark=spark,
+        metadata_config=metadata_config,
+        local_test_run=True,
+    )
+
+    spark.sql.assert_called_once()
+    sql = spark.sql.call_args.args[0]
+    assert "my_recon.main" in sql
+    assert "my_recon.aggregate_metrics" in sql
+    # Regression: must not fall back to the hardcoded 'default' database
+    assert "default.main" not in sql
+    assert "default.aggregate_metrics" not in sql
+
+
+def test_generate_final_reconcile_aggregate_output_uses_full_path_outside_local_test_run() -> None:
+    """local_test_run=False keeps the catalog.schema prefix (production CLI path)."""
+    spark = _mock_spark()
+    metadata_config = ReconcileMetadataConfig(catalog="my_cat", schema="my_recon", volume="my_vol")
+
+    generate_final_reconcile_aggregate_output(
+        recon_id="r-2",
+        spark=spark,
+        metadata_config=metadata_config,
+        local_test_run=False,
+    )
+
+    sql = spark.sql.call_args.args[0]
+    assert "my_cat.my_recon.main" in sql
+    assert "my_cat.my_recon.aggregate_metrics" in sql


### PR DESCRIPTION
## Changes
### What does this PR do?
Replaces the hardcoded ``"default"`` ``_db_prefix`` in ``generate_final_reconcile_aggregate_output`` with ``metadata_config.schema``, matching every other ``local_test_run=True`` branch in ``recon_capture.py``.

### Relevant implementation details
``recon_capture.py`` has three places that pick a DB prefix based on ``local_test_run``:
- ``generate_final_reconcile_output`` (line 131): ``metadata_config.schema if local_test_run else f"{catalog}.{schema}"``
- ``generate_final_reconcile_aggregate_output`` (line 201): ``"default" if local_test_run else f"{catalog}.{schema}"`` ← outlier
- ``ReconCapture.__init__`` (line 273): same as the data path

When a programmatic caller passes ``local_test_run=True`` together with a populated ``ReconcileMetadataConfig`` (realistic for notebooks running aggregate recon), the final output query hits ``default.main`` / ``default.aggregate_metrics``, fails with ``TABLE_OR_VIEW_NOT_FOUND``, and the recon run blows up after the per-table comparisons have already written rows to the configured metadata schema.

This PR aligns line 201 with the existing convention. One-line change.

### Caveats/things to watch out for when reviewing:
- No behavior change for ``local_test_run=False`` (production CLI path)
- Brings the aggregate path in line with the data path that has shipped this convention for a long time

### Linked issues
None

### Functionality
- [ ] added relevant user documentation
- [ ] added new CLI command
- [x] modified existing command: programmatic API of aggregate reconcile final output

### Tests
- [x] manually tested
- [x] added unit tests
- [ ] added integration tests

Manual end-to-end on Databricks: aggregate reconcile with ``local_test_run=True`` and a real metadata schema now returns the aggregated ``ReconcileOutput`` instead of failing on ``default.main``.

Unit tests added in ``tests/unit/reconcile/test_recon_capture.py``:
- ``test_generate_final_reconcile_aggregate_output_uses_metadata_schema_in_local_test_run``: the test-run prefix is the metadata schema, not the literal ``default``
- ``test_generate_final_reconcile_aggregate_output_uses_full_path_outside_local_test_run``: the production path keeps the ``catalog.schema`` prefix