### PR TITLE
Fix project packaging for source and wheel distributions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,20 @@ requires = [
 ]
 build-backend = "hatchling.build"
 
-[tool.hatch.build]
-sources = ["src"]
-include = ["src"]
+[tool.hatch.build.targets.sdist]
+only-include = [
+    "/.build-constraints.txt",
+    "/README.*",
+    "/LICEN[CS]E",
+    "/NOTICE",
+    "/pyproject.toml",
+    "/src",
+    "/tests",
+    "/uv.lock",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/databricks"]
 
 [tool.hatch.version]
 path = "src/databricks/labs/lakebridge/__about__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,8 @@ only-include = [
     "/LICEN[CS]E",
     "/NOTICE",
     "/pyproject.toml",
-    "/src",
-    "/tests",
+    "/src/",
+    "/tests/",
     "/uv.lock",
 ]
 


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes

This PR updates the configuration used to build the source and wheel distributions from this repository. With these changes:

 - The source distribution is correct;
 - The wheel can be built from either the source distribution (or directly from the project repository).

As a bonus a lot of unintended resources (documentation) are no longer included in the wheel that we build.

### Relevant implementation details

The build configuration was previously incorrect, and worked coincidentally when building a wheel directly from this repository but not when building from the source distribution. A quick summary of the gory details:

 - A source distribution is intended to facilitate, in a reproducible manner: a) testing the package; b) building a binary wheel distribution.
 - Wheels can be built _either_ from a source distribution _or_ from the project repository.
 - Previously, using hatch, the wheel was produced directly from the project repository. A source distribution was produced, but its layout was different: a wheel built from this was bogus and didn't contain the intended package sources.
 - Now, using uv, the wheel is produced in a 2-step process:
   1. Build the source distribution;
   2. Build the wheel from the source distribution.

   This exposed the problem with the source distribution.

With these changes building the wheel directly from the project repo or the source distribution yield the same results. This also provided an opportunity to ensure that both the source distribution and wheel only include the intended files from the repository.

### Tests

- manually tested