### PR TITLE
Fix case sensitivity in reconcile information_schema query

### DIFF
--- a/src/databricks/labs/lakebridge/reconcile/connectors/databricks.py
+++ b/src/databricks/labs/lakebridge/reconcile/connectors/databricks.py
@@ -22,13 +22,20 @@ def _get_describe_query(catalog: str, schema: str, table: str):
 
 
 def _get_information_schema_query(catalog: str, schema: str, table: str):
+    # information_schema stores identifiers in lowercase, so the RHS literals
+    # must be lowercased to match the lowercased LHS expressions. Otherwise
+    # any mixed-case input (e.g. `MySchema`) produces zero rows and the recon
+    # downstream sees an empty schema.
+    catalog_lc = catalog.lower()
+    schema_lc = schema.lower()
+    table_lc = table.lower()
     query = f"""select
                             lower(column_name) as col_name,
                              full_data_type as data_type
-                       from {catalog}.information_schema.columns
-                       where lower(table_catalog)='{catalog}'
-                                    and lower(table_schema)='{schema}'
-                                     and lower(table_name) ='{table}'
+                       from {catalog_lc}.information_schema.columns
+                       where lower(table_catalog)='{catalog_lc}'
+                                    and lower(table_schema)='{schema_lc}'
+                                     and lower(table_name) ='{table_lc}'
                        order by col_name"""
     return re.sub(r'\s+', ' ', query)
 

--- a/tests/unit/reconcile/connectors/test_databricks.py
+++ b/tests/unit/reconcile/connectors/test_databricks.py
@@ -40,6 +40,29 @@ def test_get_schema_uses_information_schema():
     spark.sql().selectExpr().where.assert_called_with("column_name not like '#%'")
 
 
+def test_get_schema_lowercases_mixed_case_identifiers():
+    """Information-schema query must lowercase RHS literals.
+
+    The query is `... where lower(table_schema) = '{schema}' ...`. If the
+    literal is not also lowercased, mixed-case identifiers never match because
+    information_schema stores them in lowercase. The schema fetch then returns
+    zero rows and the recon downstream sees an empty schema.
+    """
+    engine, spark = initial_setup()
+    ddds = DatabricksDataSource(engine, spark)
+
+    ddds.get_schema("MyCatalog", "MySchema", "MyTable")
+    expected = re.sub(
+        r'\s+',
+        ' ',
+        """select lower(column_name) as col_name, full_data_type as data_type from
+                mycatalog.information_schema.columns where lower(table_catalog)='mycatalog'
+                and lower(table_schema)='myschema' and lower(table_name) ='mytable' order by
+                col_name""",
+    )
+    spark.sql.assert_called_with(expected)
+
+
 def test_get_schema_non_uc_uses_describe_table():
     """DatabricksNonUnityCatalogDataSource always uses DESCRIBE TABLE for hive, global_temp, and Foreign Catalogs."""
     engine, spark = initial_setup()


### PR DESCRIPTION
## Changes
### What does this PR do?
Fixes the schema-fetch query in `DatabricksDataSource` so it works with mixed-case catalog/schema/table names. Today the query returns zero rows for any non-lowercase input, which surfaces downstream as an empty schema and confusing `UNRESOLVED_COLUMN` / "no matches" errors.

### Relevant implementation details
`_get_information_schema_query` in `src/databricks/labs/lakebridge/reconcile/connectors/databricks.py` builds:

```sql
where lower(table_catalog)='{catalog}'
  and lower(table_schema)='{schema}'
  and lower(table_name)  ='{table}'
```

The LHS is wrapped in `lower(...)` but the RHS literal is interpolated verbatim. Since `information_schema` stores identifiers in lowercase, any mixed-case input (e.g. `MySchema`) compares `lower(table_schema)` (always lowercase) against `'MySchema'` and never matches.

Upstream normalization only covers `Table.source_name` / `Table.target_name` (auto-lowercased in `recon_config.Table.__post_init__`). `SourceConnectionConfig.catalog/schema` and `TargetConnectionConfig.catalog/schema` are passed through unchanged, so the bug is reachable from real user configs — particularly when a schema is created with mixed case.

### Fix
Lowercase the RHS literals (and the catalog identifier in the `FROM` clause, for consistency) inside `_get_information_schema_query`. Single-file change.

### Caveats/things to watch out for when reviewing:
- `DatabricksNonUnityCatalogDataSource` uses `DESCRIBE TABLE` (not `information_schema`) and is unaffected — its identifiers are unquoted and resolved case-insensitively by the engine.
- `read_data` uses unquoted identifiers in the FROM clause (`{catalog}.{schema}.{table}`), which Spark/Databricks normalizes case-insensitively, so it is unaffected.

### Linked issues
None (reported via Slack).

### Functionality
- [ ] added relevant user documentation
- [ ] added new CLI command
- [x] modified existing command: reconcile schema fetch on Databricks
- [ ] ... +add your own

### Tests
- [x] manually tested
- [x] added unit tests
- [ ] added integration tests

Manual: `_get_information_schema_query("MyCatalog", "MySchema", "MyTable")` previously returned `... where lower(table_schema)='MySchema' ...` (never matches). After the fix it returns `... where lower(table_schema)='myschema' ...`, and a recon run against a mixed-case schema returns the expected columns.

New unit test in `tests/unit/reconcile/connectors/test_databricks.py`:
- `test_get_schema_lowercases_mixed_case_identifiers` — passes `MyCatalog` / `MySchema` / `MyTable` and asserts the emitted query uses all-lowercase literals on the RHS and in the `FROM` clause. Fails on unfixed code, passes on the fix.