### PR TITLE
Mark non-deployment environments in GHA as such

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -18,7 +18,9 @@ concurrency:
 
 jobs:
   integration:
-    environment: tool
+    environment:
+      name: tool
+      deployment: false
     permissions:
       # Access to JFrog and the integration testing infrastructure.
       id-token: write

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
-    environment: release
+    environment:
+      name: release
+      deployment: false
     permissions:
       # JFrog OIDC authentication.
       id-token: write


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes

Traditionally GitHub Actions associate the use of an `environment` as deploying in some way. These days we can mark environment usage as unrelated to deployments, which reduces a bunch of clutter in PRs and various places in the UI.
