### PR TITLE
create dedicated test cluster for recon e2e tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ tomli = false
 trove-classifiers = false
 
 [tool.pytest.ini_options]
-addopts = "-p no:warnings"
+addopts = "-s -p no:warnings"
 cache_dir = ".venv/pytest-cache"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope="function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ tomli = false
 trove-classifiers = false
 
 [tool.pytest.ini_options]
-addopts = "-s -p no:warnings -vv --cache-clear"
+addopts = "-p no:warnings"
 cache_dir = ".venv/pytest-cache"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope="function"

--- a/tests/integration/reconcile/conftest.py
+++ b/tests/integration/reconcile/conftest.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import json
 import logging
 import tempfile
@@ -204,7 +205,7 @@ def recon_cluster(make_cluster, test_env) -> str:
         kind=Kind.CLASSIC_PREVIEW,
         instance_pool_id=pool_id,
         spark_version="17.3.x-scala2.13",
-    ).result()
+    ).result(timeout=dt.timedelta(minutes=10))
     assert cluster.cluster_id
     return cluster.cluster_id
 

--- a/tests/integration/reconcile/conftest.py
+++ b/tests/integration/reconcile/conftest.py
@@ -14,6 +14,7 @@ from databricks.labs.blueprint.paths import WorkspacePath
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors.platform import PermissionDenied
 from databricks.sdk.service.catalog import TableInfo, SchemaInfo
+from databricks.sdk.service.compute import DataSecurityMode, Kind
 
 from databricks.labs.lakebridge.config import (
     LakebridgeConfiguration,
@@ -195,8 +196,17 @@ def oracle_recon_table_config(recon_schema: SchemaInfo, recon_tables: tuple[Tabl
 
 
 @pytest.fixture
-def recon_cluster(test_env) -> str:
-    return test_env.get("DATABRICKS_DQX_CLUSTER_ID")
+def recon_cluster(make_cluster, test_env) -> str:
+    pool_id = test_env.get("TEST_INSTANCE_POOL_ID")
+    cluster = make_cluster(
+        single_node=True,
+        data_security_mode=DataSecurityMode.DATA_SECURITY_MODE_AUTO,
+        kind=Kind.CLASSIC_PREVIEW,
+        instance_pool_id=pool_id,
+        spark_version="17.3.x-scala2.13",
+    ).result()
+    assert cluster.cluster_id
+    return cluster.cluster_id
 
 
 @pytest.fixture

--- a/tests/integration/reconcile/test_recon_e2e.py
+++ b/tests/integration/reconcile/test_recon_e2e.py
@@ -13,8 +13,6 @@ from tests.integration.reconcile.conftest import generate_recon_application_cont
 
 logger = logging.getLogger(__name__)
 
-pytestmark = pytest.mark.timeout(1800)
-
 
 def _debug_run_output(ctx: ApplicationContext, run_id: int) -> None:
     _ansi_escape = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
@@ -61,6 +59,7 @@ def _run_recon_e2e_spec(app_ctx: ApplicationContext):
     assert result.status.termination_details.type.value == TerminationTypeType.SUCCESS.value
 
 
+@pytest.mark.timeout(func_only=True)
 def test_recon_databricks_job_succeeds(
     application_ctx: ApplicationContext,
     databricks_recon_config: ReconcileConfig,
@@ -72,6 +71,7 @@ def test_recon_databricks_job_succeeds(
         _run_recon_e2e_spec(app_ctx)
 
 
+@pytest.mark.timeout(func_only=True)
 def test_recon_sql_server_job_succeeds(
     application_ctx: ApplicationContext, tsql_recon_config: ReconcileConfig, tsql_recon_table_config: TableRecon
 ) -> None:
@@ -79,6 +79,7 @@ def test_recon_sql_server_job_succeeds(
         _run_recon_e2e_spec(app_ctx)
 
 
+@pytest.mark.timeout(func_only=True)
 def test_recon_snowflake_job_succeeds(
     application_ctx: ApplicationContext,
     snowflake_recon_config: ReconcileConfig,
@@ -90,6 +91,7 @@ def test_recon_snowflake_job_succeeds(
         _run_recon_e2e_spec(app_ctx)
 
 
+@pytest.mark.timeout(func_only=True)
 def test_recon_redshift_job_succeeds(
     application_ctx: ApplicationContext,
     redshift_recon_config: ReconcileConfig,
@@ -101,6 +103,7 @@ def test_recon_redshift_job_succeeds(
         _run_recon_e2e_spec(app_ctx)
 
 
+@pytest.mark.timeout(func_only=True)
 def test_recon_oracle_job_succeeds(
     application_ctx: ApplicationContext,
     oracle_recon_config: ReconcileConfig,


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary, they're helpful to illustrate the before and after state -->
### What does this PR do?
creates a test cluster to run recon e2e tests
### Relevant implementation details
use pytester and pin spark version

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [X] manually tested
- [ ] added unit tests
- [ ] added integration tests
