### PR TITLE
Pytest: quieter tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ tomli = false
 trove-classifiers = false
 
 [tool.pytest.ini_options]
-addopts = "-s -p no:warnings -vv --cache-clear"
+addopts = "-p no:warnings"
 cache_dir = ".venv/pytest-cache"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope="function"

--- a/src/databricks/labs/lakebridge/transpiler/installers.py
+++ b/src/databricks/labs/lakebridge/transpiler/installers.py
@@ -272,7 +272,7 @@ class WheelInstaller(ArtifactInstaller):
         ]
         if logger.isEnabledFor(logging.DEBUG):
             command.append("--verbose")
-        result = subprocess.run(command, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr, check=False)
+        result = subprocess.run(command, check=False)
         result.check_returncode()
 
     def _copy_lsp_resources(self):


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes

This PR quietens down the output when running pytest: logs and output are only shown for tests that fail.

### Caveats/things to watch out for when reviewing:

The `pip` install logic included a redirection configuration stdin/stdout/stderr that should have had no effect ("pass through") but somehow interfered with the mechanism that pytest uses to capture logs.
