### PR TITLE
add support for sql server trust server

### DIFF
--- a/docs/lakebridge/docs/assessment/profiler/legacy_synapse.mdx
+++ b/docs/lakebridge/docs/assessment/profiler/legacy_synapse.mdx
@@ -156,6 +156,7 @@ Enter the port details: 1433
 Enter the database name: my_pool
 Enter the SQL username: profiler_user
 Enter the SQL password:
+Trust server certificate (default: no):
 Enter timezone (e.g. America/New_York) (default: UTC):
 Enter the ODBC driver installed locally (default: ODBC Driver 18 for SQL Server):
 ```
@@ -172,6 +173,7 @@ Enter the ODBC driver installed locally (default: ODBC Driver 18 for SQL Server)
 | **Database** | The dedicated SQL pool name to connect to. Dedicated pools do not have a `master` database, so this must be set to the pool you want to profile. | — |
 | **SQL username** | SQL Authentication username | — |
 | **SQL password** | SQL Authentication password (hidden input) | — |
+| **Trust server certificate** | Skip TLS certificate validation when connecting. Leave as `no` for Azure-hosted dedicated SQL pools, which present valid certificates. | `no` |
 | **Timezone** | Timezone for timestamp normalization | `UTC` |
 | **ODBC driver** | Locally installed ODBC driver name | `ODBC Driver 18 for SQL Server` |
 

--- a/docs/lakebridge/docs/assessment/profiler/mssql.mdx
+++ b/docs/lakebridge/docs/assessment/profiler/mssql.mdx
@@ -212,6 +212,7 @@ Enter the port details: 1433
 Enter the database name: MyAppDB
 Enter the SQL username: profiler_user
 Enter the SQL password:
+Trust server certificate (default: no):
 Enter timezone (e.g. America/New_York) (default: UTC):
 Enter the ODBC driver installed locally (default: ODBC Driver 18 for SQL Server):
 Do you want to test the connection to mssql? (yes/no): yes
@@ -229,6 +230,7 @@ Do you want to test the connection to mssql? (yes/no): yes
 | **Database** | Database to connect to. `INFORMATION_SCHEMA` queries are scoped to this database; other databases on the instance are still discovered via `sys.databases`. | — |
 | **SQL username** | SQL Authentication username | — |
 | **SQL password** | SQL Authentication password (hidden input) | — |
+| **Trust server certificate** | Skip TLS certificate validation when connecting. Set to `yes` only when the server uses a self-signed or untrusted certificate (e.g., local/dev SQL Server). Leave as `no` for Azure SQL Database and production servers with valid certificates. | `no` |
 | **Timezone** | Timezone for timestamp normalization | `UTC` |
 | **ODBC driver** | Locally installed ODBC driver name | `ODBC Driver 18 for SQL Server` |
 

--- a/src/databricks/labs/lakebridge/assessments/configure_assessment.py
+++ b/src/databricks/labs/lakebridge/assessments/configure_assessment.py
@@ -133,6 +133,7 @@ class ConfigureSqlServerAssessment(AssessmentConfigurator):
                 "database": self.prompts.question("Enter the database name"),
                 "user": self.prompts.question("Enter the SQL username"),
                 "password": self.prompts.password("Enter the SQL password"),
+                "trust_server_certificate": self.prompts.confirm("Trust server certificate"),
                 "tz_info": self.prompts.question("Enter timezone (e.g. America/New_York)", default="UTC"),
                 "driver": self.prompts.question(
                     "Enter the ODBC driver installed locally", default="ODBC Driver 18 for SQL Server"

--- a/src/databricks/labs/lakebridge/connections/database_manager.py
+++ b/src/databricks/labs/lakebridge/connections/database_manager.py
@@ -132,6 +132,9 @@ class MSSQLConnector(_BaseConnector):
         query_params: dict[str, str] = {
             "driver": str(self.config['driver']),
             "loginTimeout": "30",
+            "TrustServerCertificate": (
+                "no" if str(self.config.get('trust_server_certificate', 'False')) == 'False' else "yes"
+            ),
         }
 
         if auth_type == "ad_passwd_authentication":

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -17,6 +17,7 @@ def test_configure_sqlserver_credentials(tmp_path):
             r"Enter the port details": "1433",
             r"Enter the SQL username": "TEST_TSQL_USER",
             r"Enter the SQL password": "TEST_TSQL_PASS",
+            r"Trust server certificate": "no",
             r"Do you want to test the connection to mssql?.*": "no",
             r"Enter fetch size": "4000",
             r"Enter timezone.*": "UTC",
@@ -43,6 +44,7 @@ def test_configure_sqlserver_credentials(tmp_path):
             'server': 'URL',
             'tz_info': 'UTC',
             'user': 'TEST_TSQL_USER',
+            'trust_server_certificate': False,
         },
     }
 

--- a/tests/unit/connections/test_database_manager.py
+++ b/tests/unit/connections/test_database_manager.py
@@ -9,6 +9,7 @@ sample_config: JsonObject = {
     'server': 'test_server',
     'database': 'test_db',
     'driver': 'ODBC Driver 17 for SQL Server',
+    'trust_server_certificate': False,
 }
 
 


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary, they're helpful to illustrate the before and after state -->
### What does this PR do?
add a new sql server connection property and surface during command `configure-database-profiler`

### Linked issues
Customer Request 

### Functionality

- [X] added relevant user documentation
- [ ] added new CLI command
- [X] modified existing command: `databricks labs lakebridge configure-database-profiler`
