### PR TITLE
Add Snowflake rate_sheet extract for TCO rate/tier

### DIFF
--- a/docs/lakebridge/docs/assessment/profiler/snowflake.mdx
+++ b/docs/lakebridge/docs/assessment/profiler/snowflake.mdx
@@ -9,6 +9,7 @@ import Admonition from '@theme/Admonition';
 ## Prerequisites
 
 - A Snowflake user with permission to create Personal Access Tokens (PATs) and to query the `SNOWFLAKE.ACCOUNT_USAGE` schema (e.g., the `ACCOUNTADMIN` role or a role granted `IMPORTED PRIVILEGES ON DATABASE SNOWFLAKE`).
+- The `rate_sheet` step also reads `SNOWFLAKE.ORGANIZATION_USAGE.RATE_SHEET_DAILY` for the effective credit rate and account tier. This is available to `ACCOUNTADMIN` in an ORGADMIN-enabled account (the first account in an organization is ORGADMIN-enabled by default, so single-account orgs are covered), or to a custom role granted the `ORGANIZATION_BILLING_VIEWER` database role. If the account isn't ORGADMIN-enabled — or the organization is on a reseller contract — the view returns no rows, so `rate_sheet` is skipped and the rest of the profile still completes.
 - Network access from the machine running Lakebridge to your Snowflake account.
 
 ## Authentication

--- a/src/databricks/labs/lakebridge/resources/assessments/snowflake/pipeline_config.yml
+++ b/src/databricks/labs/lakebridge/resources/assessments/snowflake/pipeline_config.yml
@@ -65,3 +65,13 @@ steps:
     mode: overwrite
     frequency: daily
     flag: active
+
+  # Effective rate per credit/unit and the account tier (SERVICE_LEVEL). Requires
+  # SNOWFLAKE.ORGANIZATION_USAGE access (ACCOUNTADMIN in an ORGADMIN-enabled account).
+  # Feeds the downstream TCO model.
+  - name: rate_sheet
+    type: sql
+    extract_source: src/databricks/labs/lakebridge/resources/assessments/snowflake/rate_sheet.sql
+    mode: overwrite
+    frequency: once
+    flag: active

--- a/src/databricks/labs/lakebridge/resources/assessments/snowflake/rate_sheet.sql
+++ b/src/databricks/labs/lakebridge/resources/assessments/snowflake/rate_sheet.sql
@@ -1,0 +1,25 @@
+-- Adjusted Rate (effective $/unit) from the organization rate sheet.
+-- 90-day average effective rate per credit/unit, scoped to the current account and split
+-- by rating type so compute ($/credit) and storage ($/TB) stay separate. EFFECTIVE_RATE
+-- already reflects contract discounts.
+-- Requires SNOWFLAKE.ORGANIZATION_USAGE access (ACCOUNTADMIN in an ORGADMIN-enabled
+-- account, or a role granted the ORGANIZATION_USAGE_VIEWER database role).
+
+SELECT
+    REGION,
+    SERVICE_LEVEL        AS TIER,
+    RATING_TYPE,
+    SERVICE_TYPE,
+    CURRENCY,
+    AVG(EFFECTIVE_RATE)  AS AVG_EFFECTIVE_RATE,
+    COUNT(*)             AS RATE_DAYS,
+    MIN(DATE)            AS PERIOD_START,
+    MAX(DATE)            AS PERIOD_END,
+    CURRENT_TIMESTAMP()  AS EXTRACT_TIMESTAMP
+FROM SNOWFLAKE.ORGANIZATION_USAGE.RATE_SHEET_DAILY
+WHERE ACCOUNT_NAME = CURRENT_ACCOUNT_NAME()
+    AND DATE >= DATEADD('day', -90, CURRENT_DATE())
+    AND IS_ADJUSTMENT = FALSE
+    AND UPPER(BILLING_TYPE) = 'CONSUMPTION'
+    AND RATING_TYPE != 'AI_COMPUTE'
+GROUP BY REGION, SERVICE_LEVEL, RATING_TYPE, SERVICE_TYPE, CURRENCY;


### PR DESCRIPTION
## What
Adds a `rate_sheet` extract to the Snowflake profiler that pulls the effective per-credit/unit rate from `SNOWFLAKE.ORGANIZATION_USAGE.RATE_SHEET_DAILY` — a 90-day average, scoped to the current account and split by rating type. The same rows also carry the account tier (`SERVICE_LEVEL`) and the billing currency.

Also logs the absolute path of the DuckDB extract on successful completion, so users can find the output file (this benefits all profilers, not just Snowflake).

## Why
The downstream TCO / value model needs the customer's effective `$/credit` rate and Snowflake tier to convert consumed credits into dollars and to derive their contract discount. The profiler emitted credits but no rate, so the dollar conversion had to be sourced manually.

## Changes
- New `resources/assessments/snowflake/rate_sheet.sql`
- Register the `rate_sheet` step in the Snowflake `pipeline_config.yml`
- Log the extract output path on successful completion in `pipeline.py`

## Access requirement
`ORGANIZATION_USAGE` lives in the shared `SNOWFLAKE` database. The existing default role `ACCOUNTADMIN` can read it from an ORGADMIN-enabled account (or grant a custom role the `ORGANIZATION_USAGE_VIEWER` database role). When access isn't available the step simply returns 0 rows and is skipped — the run still succeeds.

## Testing
- Ran the Snowflake profiler end-to-end against an ORGADMIN-enabled account; `rate_sheet` populated with tier (Enterprise), region, currency (USD), and effective rate ($3.00/credit).
- `tests/unit/assessment/` unit tests pass (87 passed).

Classifying usage into the value model (BI/ETL split, discount derivation) is downstream work outside this PR.
