### PR TITLE
Update java requirement: we now need Java 21

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -47,6 +47,12 @@ jobs:
           version: "0.11.2"
           checksum: "7ac2ca0449c8d68dae9b99e635cd3bc9b22a4cb1de64b7c43716398447d42981"
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: corretto
+          java-version: 21
+
       - name: Setup for JFrog
         uses: ./.github/actions/jfrog-auth
 

--- a/docs/lakebridge/docs/installation.mdx
+++ b/docs/lakebridge/docs/installation.mdx
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
 | **Databricks workspace** | Any workspace (production, development, or [free trial](https://www.databricks.com/try-databricks))                   |
 | **Databricks CLI**       | [Install here](https://docs.databricks.com/en/dev-tools/cli/install.html) and configure with PAT or Service Principal |
 | **Python**               | 3.10.1–3.14.x                                                                                                         |
-| **Java**                 | Java 11 or above (required for the Morpheus transpiler)                                                               |
+| **Java**                 | Java 21 or above (required for the Morpheus transpiler)                                                               |
 | **Network access**       | GitHub, Maven Central, PyPI                                                                                           |
 
 ### Python and Java

--- a/src/databricks/labs/lakebridge/transpiler/installers.py
+++ b/src/databricks/labs/lakebridge/transpiler/installers.py
@@ -526,7 +526,7 @@ class MorpheusInstaller(TranspilerInstaller):
     def install(self, artifact: Path | None = None) -> bool:
         if not self.is_java_version_okay():
             logger.error(
-                "The morpheus transpiler requires Java 11 or above. Please install Java and re-run 'install-transpile'."
+                "The morpheus transpiler requires Java 21 or above. Please install Java and re-run 'install-transpile'."
             )
             return False
         artifact_id = "databricks-morph-plugin"
@@ -549,7 +549,7 @@ class MorpheusInstaller(TranspilerInstaller):
                 display_version = repr(raw_version)[2:-1]  # Strip b'' from the repr.
                 logger.warning(f"Java found ({java_executable}), but could not parse the version:\n{display_version}")
                 return False
-            case (java_executable, tuple() as old_version) if old_version < (11, 0, 0, 0):
+            case (java_executable, tuple() as old_version) if old_version < (21, 0, 0, 0):
                 version_str = ".".join(str(v) for v in old_version)
                 logger.warning(f"Java found ({java_executable}), but version {version_str} is too old.")
                 return False

--- a/tests/integration/transpile/test_installers.py
+++ b/tests/integration/transpile/test_installers.py
@@ -45,6 +45,6 @@ def test_java_version() -> None:
             # Fine, no Java available.
             pass
         case (java_home, tuple() as version):
-            assert java_home.exists() and version >= (11, 0, 0, 0)
+            assert java_home.exists() and version >= (21, 0, 0, 0)
         case _:
             pytest.fail(f"Unexpected result from WorkspaceInstaller.find_java(): {result!r}")


### PR DESCRIPTION
## Changes

This PR updates the Java requirements for the CLI from 11 to 21. The most recent builds of Morpheus switched from Java 11 to 21, so this is now a requirement.

### Linked issues

Context: databrickslabs/morpheus#952 (private)

### Functionality

- updated relevant user documentation
- modified existing command: `databricks labs lakebridge install-transpile`

### Tests

- updated integration tests
