### PR TITLE
Update expected SQL assertion

### DIFF
--- a/tests/integration/transpile/test_bladebridge.py
+++ b/tests/integration/transpile/test_bladebridge.py
@@ -318,7 +318,7 @@ PRIMARY KEY (col1,col3) )
 TBLPROPERTIES('delta.feature.allowColumnDefaults' = 'supported');"""
     expected_validation_failure_sql = """-------------- Exception Start-------------------
 /*
-[UNRESOLVED_ROUTINE] Cannot resolve routine `cole` on search path [`system`.`builtin`, `system`.`session`, `catalog`.`schema`].
+[UNRESOLVED_ROUTINE] Cannot resolve routine `cole` on search path [`system`.`session`, `system`.`builtin`, `system`.`ai`, `catalog`.`schema`].
 */
 select cole(hello) world from table;
 

--- a/tests/integration/transpile/test_morpheus.py
+++ b/tests/integration/transpile/test_morpheus.py
@@ -81,7 +81,7 @@ async def _transpile_sql_file(
     # The expected SQL Block is custom formatted to match the output of Morpheus exactly.
     expected_failure_sql = """-------------- Exception Start-------------------
 /*
-[UNRESOLVED_ROUTINE] Cannot resolve routine `COLE` on search path [`system`.`builtin`, `system`.`session`, `catalog`.`schema`].
+[UNRESOLVED_ROUTINE] Cannot resolve routine `COLE` on search path [`system`.`session`, `system`.`builtin`, `system`.`ai`, `catalog`.`schema`].
 */
 SELECT COLE(hello) AS world FROM table;
  ---------------Exception End --------------------"""


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary, they're helpful to illustrate the before and after state -->
### What does this PR do?
Fix integration test assertion after databricks workspace behavior change

 - before: `` [`system`.`builtin`, `system`.`session`, `catalog`.`schema`] ``
 - after:  `` [`system`.`session`, `system`.`builtin`, `system`.`ai`, `catalog`.`schema`] ``

### Caveats/things to watch out for when reviewing:
 A more resilient fix (wildcarding the path inside the assertion) was considered and deliberately skipped in favour of the minimal change.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #2515 

### Functionality

- [X] update test code

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [X] added integration tests
