### PR TITLE
Select Scala 2.13 LTS runtime for the deployed recon job

### DIFF
--- a/src/databricks/labs/lakebridge/deployment/job.py
+++ b/src/databricks/labs/lakebridge/deployment/job.py
@@ -136,7 +136,12 @@ class JobDeployment:
         return task
 
     def _default_job_cluster(self) -> JobCluster:
-        latest_lts_spark = self._ws.clusters.select_spark_version(latest=True, long_term_support=True)
+        # Reconcile reads every non-Databricks source through the remote_query() table-valued
+        # function, which classic clusters only support on DBR 17.3+. DBR 17.x ships with
+        # Scala 2.13 only, while select_spark_version defaults to scala="2.12" and would cap
+        # the selection at DBR 16.4 LTS, where recon jobs fail with
+        # UNRESOLVABLE_TABLE_VALUED_FUNCTION.
+        latest_lts_spark = self._ws.clusters.select_spark_version(latest=True, long_term_support=True, scala="2.13")
         return JobCluster(
             job_cluster_key=self.DEFAULT_CLUSTER_NAME,
             new_cluster=compute.ClusterSpec(

--- a/tests/unit/deployment/test_job.py
+++ b/tests/unit/deployment/test_job.py
@@ -101,6 +101,11 @@ def test_deploy_new_job(oracle_recon_config):
     job_deployer.deploy_recon_job(name, oracle_recon_config, "lakebridge-x.y.z-py3-none-any.whl")
     workspace_client.jobs.create.assert_called_once()
     assert install_state.jobs[name] == str(job.job_id)
+    # The default job cluster must select a Scala 2.13 runtime (DBR 17.3+): remote_query(),
+    # used for all uc_connection sources, is unavailable on 16.4 LTS and below.
+    workspace_client.clusters.select_spark_version.assert_called_once_with(
+        latest=True, long_term_support=True, scala="2.13"
+    )
 
 
 def test_parse_package_name() -> None:


### PR DESCRIPTION
## Changes
This PR fixes the default job-cluster runtime selection for the reconcile job so the documented CLI flow (`configure-reconcile` → `reconcile`) works out of the box for UC-connection sources.

### What does this PR do?
- Passes `scala="2.13"` when selecting the default runtime for the deployed `Reconciliation Runner` job, so the latest Scala 2.13 LTS (currently DBR 17.3) is selected instead of DBR 16.4 LTS.
- Files changed
  - src/databricks/labs/lakebridge/deployment/job.py
  - tests/unit/deployment/test_job.py

### Relevant implementation details
`JobDeployment._default_job_cluster()` used `select_spark_version(latest=True, long_term_support=True)`. The SDK helper defaults to `scala="2.12"`, and DBR 17.x ships with Scala 2.13 only, so the newest runtime this call can ever return is DBR 16.4 LTS (the last Scala 2.12 line). Reconcile reads every non-Databricks source (Snowflake / Oracle / TSQL / Redshift / Teradata via `uc_connection_name`) through the `remote_query()` table-valued function, which classic clusters support only on DBR 17.3+ — so the deployed job failed on 16.4 with `[UNRESOLVABLE_TABLE_VALUED_FUNCTION] Could not resolve remote_query to a table-valued function. SQLSTATE: 42883`.

### Caveats/things to watch out for when reviewing:
- The lakebridge wheel is pure Python, so the Scala 2.13 bump does not affect the job's library. Future LTS lines (18.x+) are Scala 2.13 as well, so the selection keeps advancing automatically.
- Only the recon job's default cluster changes; `job_overrides.existing_cluster_id` behavior and the profiler ingestion job are untouched.

### Linked issues

Resolves #2561

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [x] modified existing command: `databricks labs lakebridge configure-reconcile` (runtime of the deployed recon job)

### Tests
1. Manually tested on an AWS workspace with a Snowflake UC connection: on v0.14.0 the deployed job (DBR 16.4) fails with `UNRESOLVABLE_TABLE_VALUED_FUNCTION` for every table; after switching the job cluster to `17.3.x-scala2.13`, the same `databricks labs lakebridge reconcile` run succeeds and correctly detects seeded mismatches (results identical to notebook execution of the same recon).

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
