### PR TITLE
Make serverless compute the default for the deployed recon job

### DIFF
--- a/docs/lakebridge/docs/reconcile/index.mdx
+++ b/docs/lakebridge/docs/reconcile/index.mdx
@@ -83,27 +83,31 @@ See [Configuration Reference](/docs/reconcile/configuration) for the full schema
 
 The User configuring reconcile must have permission to:
 - Create Data Warehouses
-- Create Compute Clusters
 - `USE CONNECTION` on the source connection
 - `USE CATALOG` and `CREATE SCHEMA` on the target catalog
-- `CREATE VOLUME` if using a pre-existing schema on a serverless cluster
+- `CREATE VOLUME` if using a pre-existing schema
 
-### Serverless cluster support
+### Compute selection
 
-Reconcile automatically detects the cluster type and optimizes intermediate data persistence accordingly:
-- **On Serverless clusters**: Reconcile uses Unity Catalog volumes for intermediate data persistence
-- **On Standard clusters**: Reconcile uses DataFrame caching for better performance
+**The deployed reconcile job runs on serverless compute by default.** No cluster is created or managed for you.
+
+To run the job on a classic cluster instead, create the cluster yourself and point
+`job_overrides` at it in the reconcile config (`<USER_WORKSPACE_HOME>/.lakebridge/reconcile.yml`):
+
+```yaml
+job_overrides:
+  existing_cluster_id: "0714-000000-abcdefgh"
+```
 
 :::note
-- On serverless clusters, the configured volume (from `metadata_config.volume`) is automatically used
-- The volume must be created in the metadata catalog and schema specified in your `ReconcileMetadataConfig`
-- Ensure you have the necessary permissions to write to the volume on serverless clusters
+A classic cluster must run **Databricks Runtime 17.3 or above** that supports reading from Unity Catalog connections.
 :::
 
+### Intermediate data persistence
 
-Reconcile automatically adapts to the cluster type:
-- **Serverless clusters:** Uses Unity Catalog volumes for intermediate data persistence (`metadata_config.volume`)
-- **Standard clusters:** Uses DataFrame caching
+Reconcile automatically adapts to the compute type:
+- **Serverless (default):** Uses Unity Catalog volumes for intermediate data persistence — the configured volume (from `metadata_config.volume`) is automatically used. The volume must exist in the metadata catalog and schema specified in your `ReconcileMetadataConfig`, and you need write permission on it.
+- **Classic clusters:** Uses DataFrame caching for better performance
 
 ---
 

--- a/src/databricks/labs/lakebridge/config.py
+++ b/src/databricks/labs/lakebridge/config.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
 from typing import Any, Literal, TypeVar, cast
@@ -285,7 +285,7 @@ class ReconcileMetadataConfig:
 @dataclass
 class ReconcileJobConfig:
     existing_cluster_id: str
-    tags: dict[str, str]
+    tags: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass

--- a/src/databricks/labs/lakebridge/deployment/job.py
+++ b/src/databricks/labs/lakebridge/deployment/job.py
@@ -10,7 +10,7 @@ from databricks.sdk.service import compute
 from databricks.sdk.service.jobs import (
     Task,
     PythonWheelTask,
-    JobCluster,
+    JobEnvironment,
     JobSettings,
     JobParameterDefinition,
 )
@@ -21,7 +21,8 @@ logger = logging.getLogger(__name__)
 
 class JobDeployment:
 
-    DEFAULT_CLUSTER_NAME = "Remorph_Reconciliation_Cluster"
+    SERVERLESS_ENVIRONMENT_KEY = "reconcile_serverless"
+    SERVERLESS_ENVIRONMENT_VERSION = "3"
 
     def __init__(
         self,
@@ -79,10 +80,9 @@ class JobDeployment:
             logger.debug(f"Applying deployment overrides: {recon_config.job_overrides}")
             tags.update(recon_config.job_overrides.tags)
 
-        return {
+        job_settings = {
             "name": self._name_with_prefix(job_name),
             "tags": tags,
-            "job_clusters": [] if recon_config.job_overrides else [self._default_job_cluster()],
             "tasks": [
                 self._job_recon_task(
                     task_key,
@@ -97,21 +97,33 @@ class JobDeployment:
                 JobParameterDefinition(name="install_folder", default=self._installation.install_folder()),
             ],
         }
+        if not self._existing_cluster_id(recon_config):
+            job_settings["environments"] = [
+                JobEnvironment(
+                    environment_key=self.SERVERLESS_ENVIRONMENT_KEY,
+                    spec=compute.Environment(
+                        environment_version=self.SERVERLESS_ENVIRONMENT_VERSION,
+                        dependencies=[lakebridge_wheel_path],
+                    ),
+                )
+            ]
+        return job_settings
 
     def _job_recon_task(
         self, task_key: str, description: str, recon_config: ReconcileConfig, lakebridge_wheel_path: str
     ) -> Task:
-        libraries = [
-            compute.Library(whl=lakebridge_wheel_path),
-        ]
+        existing_cluster_id = self._existing_cluster_id(recon_config)
+        # The job runs on serverless compute unless job_overrides points at a classic
+        # cluster. Serverless tasks must not set libraries or cluster references; the
+        # wheel is supplied through the job-level environment instead
+        # (see _recon_job_settings). Classic clusters get the wheel as a library.
+        libraries = [compute.Library(whl=lakebridge_wheel_path)] if existing_cluster_id else None
 
         task = Task(
             task_key=task_key,
             description=description,
-            job_cluster_key=None if recon_config.job_overrides else self.DEFAULT_CLUSTER_NAME,
-            existing_cluster_id=(
-                recon_config.job_overrides.existing_cluster_id if recon_config.job_overrides else None
-            ),
+            existing_cluster_id=existing_cluster_id,
+            environment_key=None if existing_cluster_id else self.SERVERLESS_ENVIRONMENT_KEY,
             libraries=libraries,
             python_wheel_task=PythonWheelTask(
                 package_name=self.parse_package_name(lakebridge_wheel_path),
@@ -120,25 +132,16 @@ class JobDeployment:
             ),
         )
         logger.debug(
-            f"Reconciliation job task cluster: existing: {task.existing_cluster_id} or name: {task.job_cluster_key}"
+            f"Reconciliation job task cluster: existing: {task.existing_cluster_id} "
+            f"or environment: {task.environment_key}"
         )
         return task
 
-    def _default_job_cluster(self) -> JobCluster:
-        latest_lts_spark = self._ws.clusters.select_spark_version(latest=True, long_term_support=True)
-        return JobCluster(
-            job_cluster_key=self.DEFAULT_CLUSTER_NAME,
-            new_cluster=compute.ClusterSpec(
-                data_security_mode=compute.DataSecurityMode.USER_ISOLATION,
-                spark_conf={},
-                node_type_id=self._get_default_node_type_id(),
-                autoscale=compute.AutoScale(min_workers=2, max_workers=10),
-                spark_version=latest_lts_spark,
-            ),
-        )
-
-    def _get_default_node_type_id(self) -> str:
-        return self._ws.clusters.select_node_type(local_disk=True, min_memory_gb=16)
+    @staticmethod
+    def _existing_cluster_id(recon_config: ReconcileConfig) -> str | None:
+        if recon_config.job_overrides:
+            return recon_config.job_overrides.existing_cluster_id or None
+        return None
 
     def _name_with_prefix(self, name: str) -> str:
         prefix = self._installation.product()

--- a/tests/unit/deployment/test_job.py
+++ b/tests/unit/deployment/test_job.py
@@ -1,3 +1,4 @@
+import dataclasses
 from unittest.mock import create_autospec
 
 from databricks.labs.blueprint.installation import MockInstallation
@@ -7,7 +8,7 @@ from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import InvalidParameterValue
 from databricks.sdk.service.jobs import Job
 
-from databricks.labs.lakebridge.config import LakebridgeConfiguration
+from databricks.labs.lakebridge.config import LakebridgeConfiguration, ReconcileJobConfig
 from databricks.labs.lakebridge.deployment.job import JobDeployment
 
 
@@ -42,7 +43,7 @@ def test_deploy_missing_job(snowflake_recon_config):
     assert install_state.jobs[name] == str(job.job_id)
 
 
-def test_deploy_new_job(oracle_recon_config):
+def test_deploy_new_job_defaults_to_serverless(oracle_recon_config):
     workspace_client = create_autospec(WorkspaceClient)
     job = Job(job_id=1234)
     workspace_client.jobs.create.return_value = job
@@ -50,10 +51,76 @@ def test_deploy_new_job(oracle_recon_config):
     install_state = InstallState.from_installation(installation)
     product_info = ProductInfo.from_class(LakebridgeConfiguration)
     name = "Recon Job"
+    wheel_path = "/Workspace/user/.lakebridge/wheels/databricks_labs_lakebridge-x.y.z-py3-none-any.whl"
     job_deployer = JobDeployment(workspace_client, installation, install_state, product_info)
-    job_deployer.deploy_recon_job(name, oracle_recon_config, "lakebridge-x.y.z-py3-none-any.whl")
+    job_deployer.deploy_recon_job(name, oracle_recon_config, wheel_path)
     workspace_client.jobs.create.assert_called_once()
     assert install_state.jobs[name] == str(job.job_id)
+    job_settings = workspace_client.jobs.create.call_args.kwargs
+    assert "job_clusters" not in job_settings
+    environments = job_settings["environments"]
+    assert len(environments) == 1
+    assert environments[0].environment_key == JobDeployment.SERVERLESS_ENVIRONMENT_KEY
+    assert environments[0].spec.dependencies == [wheel_path]
+    task = job_settings["tasks"][0]
+    assert task.environment_key == JobDeployment.SERVERLESS_ENVIRONMENT_KEY
+    assert task.libraries is None
+    assert task.existing_cluster_id is None
+    # No classic cluster APIs should be touched on the serverless path
+    workspace_client.clusters.select_spark_version.assert_not_called()
+    workspace_client.clusters.select_node_type.assert_not_called()
+
+
+def test_deploy_new_job_with_existing_cluster(oracle_recon_config):
+    workspace_client = create_autospec(WorkspaceClient)
+    job = Job(job_id=1234)
+    workspace_client.jobs.create.return_value = job
+    installation = MockInstallation(is_global=False)
+    install_state = InstallState.from_installation(installation)
+    product_info = ProductInfo.from_class(LakebridgeConfiguration)
+    name = "Recon Job"
+    wheel_path = "/Workspace/user/.lakebridge/wheels/databricks_labs_lakebridge-x.y.z-py3-none-any.whl"
+    cluster_id = "0714-000000-abcdefgh"
+    recon_config = dataclasses.replace(
+        oracle_recon_config, job_overrides=ReconcileJobConfig(existing_cluster_id=cluster_id, tags={})
+    )
+    job_deployer = JobDeployment(workspace_client, installation, install_state, product_info)
+    job_deployer.deploy_recon_job(name, recon_config, wheel_path)
+    workspace_client.jobs.create.assert_called_once()
+    job_settings = workspace_client.jobs.create.call_args.kwargs
+    assert "environments" not in job_settings
+    task = job_settings["tasks"][0]
+    assert task.existing_cluster_id == cluster_id
+    assert task.environment_key is None
+    assert [library.whl for library in task.libraries] == [wheel_path]
+
+
+def test_deploy_new_job_with_blank_existing_cluster_falls_back_to_serverless(oracle_recon_config):
+    workspace_client = create_autospec(WorkspaceClient)
+    job = Job(job_id=1234)
+    workspace_client.jobs.create.return_value = job
+    installation = MockInstallation(is_global=False)
+    install_state = InstallState.from_installation(installation)
+    product_info = ProductInfo.from_class(LakebridgeConfiguration)
+    name = "Recon Job"
+    wheel_path = "/Workspace/user/.lakebridge/wheels/databricks_labs_lakebridge-x.y.z-py3-none-any.whl"
+    # A blank existing_cluster_id must not leak an empty cluster reference into the spec: the Jobs API
+    # rejects a task that carries both environment_key and existing_cluster_id="".
+    recon_config = dataclasses.replace(
+        oracle_recon_config, job_overrides=ReconcileJobConfig(existing_cluster_id="", tags={})
+    )
+    job_deployer = JobDeployment(workspace_client, installation, install_state, product_info)
+    job_deployer.deploy_recon_job(name, recon_config, wheel_path)
+    workspace_client.jobs.create.assert_called_once()
+    job_settings = workspace_client.jobs.create.call_args.kwargs
+    environments = job_settings["environments"]
+    assert len(environments) == 1
+    task = job_settings["tasks"][0]
+    assert task.environment_key == JobDeployment.SERVERLESS_ENVIRONMENT_KEY
+    assert task.existing_cluster_id is None
+    assert task.libraries is None
+    # The serialized spec must not carry an empty existing_cluster_id key alongside the environment.
+    assert task.as_dict().get("existing_cluster_id") is None
 
 
 def test_parse_package_name() -> None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,6 +2,7 @@ from databricks.labs.blueprint.installation import MockInstallation
 
 from databricks.labs.lakebridge.config import (
     ReconcileConfig,
+    ReconcileJobConfig,
     ReconcileMetadataConfig,
     SourceConnectionConfig,
     TableRecon,
@@ -243,3 +244,28 @@ def test_reconcile_v1_migrate_drops_orphan_fields() -> None:
     loaded = installation.load(ReconcileConfig)
     assert loaded.source.dialect == "snowflake"
     assert loaded.target.catalog == "tgt"
+
+
+def test_reconcile_job_overrides_without_tags_keeps_existing_cluster_id() -> None:
+    """A job_overrides block that pins a cluster but omits tags must not silently drop the cluster."""
+    installation = MockInstallation(
+        {
+            "reconcile.yml": {
+                "report_type": "all",
+                "source": {
+                    "dialect": "snowflake",
+                    "catalog": "src_cat",
+                    "schema": "src_sch",
+                    "uc_connection_name": "c",
+                },
+                "target": {"catalog": "tgt_cat", "schema": "tgt_sch"},
+                "metadata_config": {"catalog": "remorph", "schema": "reconcile", "volume": "reconcile_volume"},
+                "job_overrides": {"existing_cluster_id": "0714-000000-abcdefgh"},
+                "version": 2,
+            }
+        }
+    )
+
+    loaded = installation.load(ReconcileConfig)
+
+    assert loaded.job_overrides == ReconcileJobConfig(existing_cluster_id="0714-000000-abcdefgh", tags={})


### PR DESCRIPTION
### What does this PR do?
- The deployed `Reconciliation Runner` job now runs on serverless by default: a job-level environment carries the lakebridge wheel and the task is bound via `environment_key`. No job cluster is created by the installer anymore.
- To use a classic cluster: set `job_overrides.existing_cluster_id` in `reconcile.yml` — the task then uses that cluster with the wheel as a task library.
- Removes `_default_job_cluster()` / `_get_default_node_type_id()` (classic job-cluster creation) entirely — this also eliminates the DBR 16.4 runtime-selection bug (#2561), since no runtime is ever selected by the installer.
- Documents compute selection (new "Compute selection" section) and updates Required permissions ("Create Compute Clusters" now needed only for the classic path; classic clusters must be DBR 17.3+ for `remote_query`).
- Files changed
  - src/databricks/labs/lakebridge/config.py
  - src/databricks/labs/lakebridge/deployment/job.py
  - docs/lakebridge/docs/reconcile/index.mdx
  - tests/unit/deployment/test_job.py

### Relevant implementation details
- `ReconcileJobConfig` simplifies to `existing_cluster_id: str | None` + `tags` (the interim `serverless` flag from the previous revision of this PR is gone — serverless needs no opt-in now). `job_overrides` with only `tags` stays on serverless; tags are orthogonal to compute.
- The recon runtime needs no changes — it already detects serverless and persists intermediate data via the UC volume from `metadata_config`.

### Caveats/things to watch out for when reviewing:
- Behavior change for existing installations: on the next `configure-reconcile`, the redeployed job switches from a classic job cluster to serverless. Prerequisites are unchanged (`remote_query` preview, volume for intermediate persistence).
- Existing `reconcile.yml` files with `job_overrides.existing_cluster_id` keep working unchanged.

### Linked issues

Resolves #2564
Resolves #2561

### Functionality

- [x] added relevant user documentation
- [ ] added new CLI command
- [x] modified existing command: `databricks labs lakebridge configure-reconcile` (deployed job defaults to serverless)

### Tests
1. Manually tested on an AWS workspace: deployed the job with this branch **without any overrides** — job spec has the serverless environment (no job_clusters/libraries) and the run completed a full `all`-report reconciliation against a Snowflake UC-connection source in ~4 minutes with correct results.

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
