### PR TITLE
Add profiler correctness tests for Redshift and Synapse

### DIFF
--- a/tests/integration/assessments/profiler_extract_helpers.py
+++ b/tests/integration/assessments/profiler_extract_helpers.py
@@ -1,0 +1,61 @@
+"""Shared helpers for the profiler extract correctness tests.
+
+Kept in a non-``test_`` module so pytest does not collect it and so the schema
+parsing / DuckDB inspection helpers live in one place rather than being
+duplicated across the per-profiler test modules.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import duckdb
+
+from tests.integration.debug_envgetter import TestEnvGetter
+
+# Maps the type tokens used in the pinned profiler schemas (e.g. SYNAPSE_SCHEMAS)
+# to the type name DuckDB reports back via information_schema -- a declared STRING
+# column is a DuckDB VARCHAR, etc.
+DECLARED_TO_DUCKDB_TYPE = {
+    "STRING": "VARCHAR",
+    "BIGINT": "BIGINT",
+    "INTEGER": "INTEGER",
+    "DOUBLE": "DOUBLE",
+    "BOOLEAN": "BOOLEAN",
+}
+
+
+def env_available(keys: Sequence[str]) -> bool:
+    """Return True only if every ``key`` resolves via the test env getter.
+
+    Used to skip integration tests when the sandbox credentials are absent
+    (``TestEnvGetter.get`` raises ``KeyError`` for a missing key).
+    """
+    env = TestEnvGetter(True)
+    try:
+        return all(env.get(key) for key in keys)
+    except KeyError:
+        return False
+
+
+def parse_declared_schema(schema: str) -> list[tuple[str, str]]:
+    """Parse a ``"NAME TYPE, NAME TYPE, ..."`` schema string into (name, duckdb_type) pairs.
+
+    Order is preserved so callers can also assert column count / ordering.
+    """
+    columns: list[tuple[str, str]] = []
+    for part in schema.split(","):
+        name, _, type_token = part.strip().partition(" ")
+        columns.append((name.lower(), DECLARED_TO_DUCKDB_TYPE[type_token.strip().upper()]))
+    return columns
+
+
+def actual_schema(db_path: str, table: str) -> list[tuple[str, str]]:
+    """Return the ``(column_name, data_type)`` pairs of ``table`` in declaration order."""
+    with duckdb.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT column_name, data_type FROM information_schema.columns "
+            "WHERE table_name = ? ORDER BY ordinal_position",
+            [table],
+        ).fetchall()
+    return [(name.lower(), data_type) for name, data_type in rows]

--- a/tests/integration/assessments/test_profiler_correctness_redshift.py
+++ b/tests/integration/assessments/test_profiler_correctness_redshift.py
@@ -1,0 +1,119 @@
+"""Correctness integration test for the Redshift (provisioned) profiler.
+
+Where the generic pipeline tests only prove the engine runs, this test runs the
+*real* Redshift provisioned profiler queries
+(``resources/assessments/redshift/provisioned/``) against the live Redshift
+sandbox and validates the shape of the resulting DuckDB extract:
+
+* every profiler query executes without error against the real system tables;
+* the extract contains only expected tables (no stray tables);
+* each produced table has exactly the expected set of columns;
+* the tables backed by unconditional aggregates are always produced (they can
+  never be legitimately empty), which -- because ``_save_to_db`` skips table
+  creation for a zero-row result -- also asserts they were populated.
+
+Column *types* are intentionally not asserted here: they depend on the live
+data returned by the Redshift system tables and cannot be pinned deterministically
+without golden/seeded data. Type-level fidelity is covered separately by the
+unit tests.
+
+Requires Redshift sandbox credentials (``REDSHIFT_*`` in
+``~/.databricks/debug-env.json`` or the environment). The whole module is skipped
+when they are absent, so it only runs in CI where the secrets are configured.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from databricks.labs.lakebridge.assessments.pipeline import (
+    PipelineClass,
+    StepExecutionStatus,
+    make_profiler_db_filename,
+)
+from databricks.labs.lakebridge.assessments.profiler import Profiler
+from databricks.labs.lakebridge.connections.database_manager import DatabaseManager
+
+from tests.integration.assessments.profiler_extract_helpers import env_available
+
+_REDSHIFT_ENV_KEYS = ("REDSHIFT_HOST", "REDSHIFT_USER", "REDSHIFT_PASS", "REDSHIFT_PORT")
+
+_PROVISIONED_CONFIG = Path(
+    "src/databricks/labs/lakebridge/resources/assessments/redshift/provisioned/pipeline_config.yml"
+)
+
+# Expected output columns for each DuckDB table the provisioned profiler produces.
+# Table names are the pipeline step names; columns are the SELECT aliases in the
+# corresponding <step>.sql. Compared case-insensitively (the driver may change
+# identifier casing).
+_EXPECTED_COLUMNS: dict[str, frozenset[str]] = {
+    "rs_spectrum_tb_month": frozenset({"set_name", "s3_scanned_tb_month", "avg_daily_scanned_tb"}),
+    "rs_managed_storage_gb": frozenset({"set_name", "rs_managed_storage_gb"}),
+    "rs_nodes": frozenset({"set_name", "rs_nodes_type", "rs_number_of_nodes"}),
+    "rs_avg_concurrent_users": frozenset({"set_name", "avg_concurrent_users"}),
+    "rs_avg_queries_minute": frozenset({"set_name", "avg_queries_minute"}),
+    "chart_query_type_by_hour": frozenset({"set_name", "query_type", "hour", "count"}),
+    "chart_cpu_consumption_by_query_type": frozenset({"set_name", "query_type", "sum_cpu_time"}),
+    "chart_concurrent_users_by_hour": frozenset({"set_name", "distinct_users", "hour"}),
+    "chart_cpu_consumption_by_hour_and_query_type": frozenset({"set_name", "query_type", "sum_cpu_time", "hour"}),
+}
+
+# Tables whose query is an unconditional aggregate (no outer WHERE / GROUP BY), so
+# it always returns exactly one row and the table is therefore always created.
+# The remaining tables (spectrum + charts) are data-dependent and may be absent
+# when the sandbox has no matching activity.
+_ALWAYS_PRESENT: frozenset[str] = frozenset(
+    {"rs_managed_storage_gb", "rs_avg_concurrent_users", "rs_avg_queries_minute"}
+)
+
+
+pytestmark = pytest.mark.skipif(
+    not env_available(_REDSHIFT_ENV_KEYS),
+    reason="Redshift sandbox credentials not configured (REDSHIFT_* in debug-env)",
+)
+
+
+def _created_tables(db_path: Path) -> set[str]:
+    with duckdb.connect(str(db_path)) as conn:
+        return {row[0] for row in conn.execute("SHOW TABLES").fetchall()}
+
+
+def _column_names(db_path: Path, table: str) -> set[str]:
+    with duckdb.connect(str(db_path)) as conn:
+        rows = conn.execute(
+            "SELECT column_name FROM information_schema.columns WHERE table_name = ?",
+            [table],
+        ).fetchall()
+    return {row[0].lower() for row in rows}
+
+
+def test_redshift_provisioned_profiler_extract_is_correct(
+    sandbox_redshift: DatabaseManager,
+    project_path: Path,
+    tmp_path: Path,
+) -> None:
+    config = Profiler.path_modifier(config_file=project_path / _PROVISIONED_CONFIG, path_prefix=project_path)
+    db_path = tmp_path / make_profiler_db_filename("redshift")
+
+    results = PipelineClass(config, sandbox_redshift, db_path, tmp_path / "credentials.yml").execute()
+
+    # Every real profiler query ran against the live system tables without error.
+    for result in results:
+        assert result.status in (
+            StepExecutionStatus.COMPLETE,
+            StepExecutionStatus.SKIPPED,
+        ), f"Step {result.step_name} failed: {result.error_message}"
+
+    created = _created_tables(db_path)
+
+    # No stray tables, and the always-produced ones are present (hence populated).
+    assert created <= set(_EXPECTED_COLUMNS), f"Unexpected tables in extract: {created - set(_EXPECTED_COLUMNS)}"
+    assert _ALWAYS_PRESENT <= created, f"Expected always-present tables missing: {_ALWAYS_PRESENT - created}"
+
+    # Every produced table has exactly the expected columns.
+    for table in created:
+        expected = {col.lower() for col in _EXPECTED_COLUMNS[table]}
+        assert _column_names(db_path, table) == expected, f"Column mismatch for table '{table}'"

--- a/tests/integration/assessments/test_profiler_correctness_synapse.py
+++ b/tests/integration/assessments/test_profiler_correctness_synapse.py
@@ -1,0 +1,80 @@
+"""Correctness integration test for the Synapse profiler metadata extracts.
+
+The Synapse profiler's full run drives Azure Synapse REST APIs (workspace info,
+monitoring metrics, SQL-pool enumeration) that the test sandbox cannot provide,
+so it cannot be executed end to end here. What *can* be exercised against a live
+endpoint is the metadata-extraction subset: the ``INFORMATION_SCHEMA``-based
+queries (tables/columns/views/routines) run on the SQL Server sandbox, which
+stands in for a Synapse SQL pool since they share the T-SQL protocol.
+
+For each of those extracts this test runs the *real* profiler query against the
+live sandbox, ingests the result exactly as the profiler does
+(``save_to_duckdb(..., schema=SYNAPSE_SCHEMAS[table])``), and asserts the
+resulting DuckDB table matches the pinned schema. Because the ingest INSERT is
+positional, this also verifies the query's projected columns line up with the
+declared schema -- a real bug if they ever drift apart.
+
+Not covered here (require Azure APIs / Synapse-only DMVs, no sandbox): workspace
+info, monitoring metrics, SQL-pool enumeration, and the activity extracts backed
+by ``SYS.DM_PDW_*`` views. The declared schemas themselves are validated
+independently in ``test_synapse_schema_contract.py``.
+
+Requires SQL Server sandbox credentials (``TEST_TSQL_*`` in
+``~/.databricks/debug-env.json`` or the environment); skipped when absent, so it
+only runs in CI where the secrets are configured.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from databricks.labs.lakebridge.connections.database_manager import DatabaseManager
+from databricks.labs.lakebridge.resources.assessments.common.duckdb_helpers import save_to_duckdb
+from databricks.labs.lakebridge.resources.assessments.synapse.common.queries import SynapseQueries
+from databricks.labs.lakebridge.resources.assessments.synapse.common.schemas import SYNAPSE_SCHEMAS
+
+from tests.integration.assessments.profiler_extract_helpers import (
+    actual_schema,
+    env_available,
+    parse_declared_schema,
+)
+
+_TSQL_ENV_KEYS = ("TEST_TSQL_JDBC", "TEST_TSQL_USER", "TEST_TSQL_PASS")
+
+# A placeholder SQL-pool name; the sandbox is a single SQL Server database, so the
+# value only ends up as the literal POOL_NAME column in each extract.
+_POOL_NAME = "sandbox_pool"
+
+# The metadata extracts whose queries hit INFORMATION_SCHEMA and therefore run on
+# the SQL Server stand-in. Each maps its DuckDB table to the query that feeds it.
+_METADATA_EXTRACTS: dict[str, Callable[[str], str]] = {
+    "dedicated_tables": SynapseQueries.list_tables,
+    "dedicated_columns": SynapseQueries.list_columns,
+    "dedicated_views": SynapseQueries.list_views,
+    "dedicated_routines": SynapseQueries.list_routines,
+}
+
+pytestmark = pytest.mark.skipif(
+    not env_available(_TSQL_ENV_KEYS),
+    reason="SQL Server sandbox credentials not configured (TEST_TSQL_* in debug-env)",
+)
+
+
+@pytest.mark.parametrize("table_name", sorted(_METADATA_EXTRACTS))
+def test_synapse_metadata_extract_matches_declared_schema(
+    sandbox_synapse: DatabaseManager,
+    tmp_path: Path,
+    table_name: str,
+) -> None:
+    query = _METADATA_EXTRACTS[table_name](_POOL_NAME)
+    db_path = str(tmp_path / "synapse_extract.duckdb")
+
+    # Run the real profiler query against the live endpoint and ingest it exactly
+    # as the Synapse extract does.
+    result = sandbox_synapse.fetch(query)
+    save_to_duckdb(result.to_df(), table_name, db_path, schema=SYNAPSE_SCHEMAS[table_name])
+
+    assert actual_schema(db_path, table_name) == parse_declared_schema(SYNAPSE_SCHEMAS[table_name])

--- a/tests/integration/assessments/test_synapse_schema_contract.py
+++ b/tests/integration/assessments/test_synapse_schema_contract.py
@@ -1,0 +1,65 @@
+"""Schema-contract correctness tests for the Synapse profiler extracts.
+
+Unlike the SQL profilers, the Synapse profiler extracts run as Python steps that
+hit Azure Synapse REST APIs and SQL pools, so a full end-to-end run cannot be
+driven from the test sandbox. What *can* be validated deterministically is the
+ingestion contract every Synapse extract relies on: each table is written with
+``save_to_duckdb(df, table, schema=SYNAPSE_SCHEMAS[table])``.
+
+These tests assert that every declared schema in ``SYNAPSE_SCHEMAS``:
+
+* is valid DuckDB DDL (``save_to_duckdb`` creates the table without error), and
+* produces a table whose columns and types exactly match the declaration.
+
+This catches typos, invalid types, duplicate columns, and drift in the pinned
+schemas -- the failure modes those declarations exist to prevent -- without
+needing a live Synapse workspace.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from databricks.labs.lakebridge.resources.assessments.common.duckdb_helpers import save_to_duckdb
+from databricks.labs.lakebridge.resources.assessments.synapse.common.schemas import SYNAPSE_SCHEMAS
+
+from tests.integration.assessments.profiler_extract_helpers import (
+    DECLARED_TO_DUCKDB_TYPE,
+    actual_schema,
+    parse_declared_schema,
+)
+
+
+def test_synapse_schemas_is_not_empty() -> None:
+    # Guards against the parametrized tests silently passing on an empty mapping.
+    assert SYNAPSE_SCHEMAS
+
+
+@pytest.mark.parametrize("table_name", sorted(SYNAPSE_SCHEMAS))
+def test_synapse_schema_declares_only_known_types(table_name: str) -> None:
+    """Every declared column uses a type token this contract knows how to map."""
+    for part in SYNAPSE_SCHEMAS[table_name].split(","):
+        _, _, type_token = part.strip().partition(" ")
+        assert (
+            type_token.strip().upper() in DECLARED_TO_DUCKDB_TYPE
+        ), f"Table '{table_name}' declares unknown type token '{type_token.strip()}'"
+
+
+@pytest.mark.parametrize("table_name", sorted(SYNAPSE_SCHEMAS))
+def test_synapse_schema_round_trips_through_save_to_duckdb(tmp_path: Path, table_name: str) -> None:
+    """Each declared schema is valid DDL and yields exactly the declared columns and types."""
+    db_path = str(tmp_path / "synapse_extract.duckdb")
+    expected = parse_declared_schema(SYNAPSE_SCHEMAS[table_name])
+
+    # A row-less frame with the declared columns exercises the schema-driven
+    # CREATE TABLE path without needing representative rows: the INSERT is skipped
+    # for an empty frame, so save_to_duckdb owns the column types via the schema.
+    # (An entirely column-less DataFrame cannot be registered with DuckDB.)
+    empty_frame = pd.DataFrame(columns=[name for name, _ in expected])
+    save_to_duckdb(empty_frame, table_name, db_path, schema=SYNAPSE_SCHEMAS[table_name])
+
+    actual = actual_schema(db_path, table_name)
+    assert actual == expected, f"Schema mismatch for Synapse table '{table_name}'"


### PR DESCRIPTION
## What

Adds the first profiler-correctness tests, following review feedback that the
suite should validate profiler *correctness*, not just that the pipeline engine
runs. Test-only, no production changes.

- **`test_profiler_correctness_redshift.py`** (integration) - runs the real
  Redshift provisioned profiler queries against the live Redshift sandbox and
  asserts the DuckDB extract has no stray tables, the always-produced tables are
  present, and each produced table has exactly the expected column set. Skips
  when `REDSHIFT_*` creds are absent (runs in CI).
- **`test_profiler_correctness_synapse.py`** (integration) - runs the real
  Synapse metadata extract queries (`INFORMATION_SCHEMA`: tables/columns/views/
  routines) against the SQL Server sandbox stand-in and asserts each result
  ingests into its pinned `SYNAPSE_SCHEMAS` shape. Skips when `TEST_TSQL_*` creds
  are absent (runs in CI).
- **`test_synapse_schema_contract.py`** - validates every `SYNAPSE_SCHEMAS`
  declaration is valid DuckDB DDL producing exactly the declared columns and
  types. Needs no creds.
- **`profiler_extract_helpers.py`** - shared, non-test helpers (schema parsing,
  DuckDB inspection, env gating) used by the above.

## Testing

- `test_synapse_schema_contract.py`: 41 cases, all passing locally.
- The two integration tests were verified to lint clean and skip gracefully
  without creds, they exercise their live sandboxes in CI, where their exact
  column/schema expectations get their first live validation.

## Known gaps (follow-ups)

- Synapse coverage is the metadata subset only, the Azure-API steps (workspace
  info, monitoring metrics, SQL-pool enumeration) and `SYS.DM_PDW_*` activity
  extracts require a real Synapse workspace and are not covered.
- No Oracle integration test yet - blocked on provisioning an Oracle sandbox and
  credentials.
- Tests assert schema/column correctness, not value-level correctness.
