### PR TITLE
use correct exit code on profiler error

### DIFF
--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -1140,7 +1140,7 @@ def execute_database_profiler(
     try:
         profiler = Profiler.create(source_tech, variant, creds_path)
         profiler.profile(output_folder=Path(output_folder), cred_file_path=creds_path)
-    except (RuntimeError, FileNotFoundError, ValueError) as e:
+    except Exception as e:  # noqa: BLE001
         raise SystemExit(f"Profiler execution failed: {e}") from e
 
 

--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -1137,8 +1137,8 @@ def execute_database_profiler(
             default=str(default_output_folder(source_tech)),
         ).strip()
 
-    profiler = Profiler.create(source_tech, variant, creds_path)
     try:
+        profiler = Profiler.create(source_tech, variant, creds_path)
         profiler.profile(output_folder=Path(output_folder), cred_file_path=creds_path)
     except (RuntimeError, FileNotFoundError, ValueError) as e:
         raise SystemExit(f"Profiler execution failed: {e}") from e

--- a/src/databricks/labs/lakebridge/cli.py
+++ b/src/databricks/labs/lakebridge/cli.py
@@ -1138,8 +1138,10 @@ def execute_database_profiler(
         ).strip()
 
     profiler = Profiler.create(source_tech, variant, creds_path)
-    # TODO: Add extractor logic to ApplicationContext instead of creating inside the Profiler class
-    profiler.profile(output_folder=Path(output_folder), cred_file_path=creds_path)
+    try:
+        profiler.profile(output_folder=Path(output_folder), cred_file_path=creds_path)
+    except (RuntimeError, FileNotFoundError, ValueError) as e:
+        raise SystemExit(f"Profiler execution failed: {e}") from e
 
 
 def parse_profiler_variant(prompts: Prompts, source_tech: str, variant: str | None) -> str | None:


### PR DESCRIPTION
<!-- REMOVE IRRELEVANT COMMENTS BEFORE CREATING A PULL REQUEST -->
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary, they're helpful to illustrate the before and after state -->
### What does this PR do?

`Profiler._execute` (profiler.py:93-95) and `PipelineClass.execute()` (pipeline.py:67,76) both correctly raise RuntimeError on step failures. The exception gets swallowed one level up, in blueprint's `App._route`:
  ```
  # databricks/labs/blueprint/cli.py:119-126
  try:
      cmd.fn(**kwargs)
  except Exception as err:
      logger.error(f"{err.__class__.__name__}: {err}")
```
  The error is logged and the process falls off the end of main — so the Python entrypoint exits 0 on any profiler failure, and the databricks CLI in turn reports success. This affects every lakebridge command that signals failure with a plain exception, not just the profiler.

  There is an escape hatch already used: SystemExit derives from BaseException, so it sails through blueprint's except Exception and terminates the process with exit code 1. That's exactly why `test-profiler-connection` raises SystemExit at cli.py:1206-1217.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Functionality

- [ ] added relevant user documentation
- [ ] added new CLI command
- [X] modified existing command: `databricks labs lakebridge execute-database-profiler`

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
