### PR TITLE
Handle database errors fully

### DIFF
--- a/src/databricks/labs/lakebridge/assessments/configure_assessment.py
+++ b/src/databricks/labs/lakebridge/assessments/configure_assessment.py
@@ -13,7 +13,7 @@ from databricks.labs.lakebridge.connections.credential_manager import (
     cred_file as creds,
     create_credential_manager,
 )
-from databricks.labs.lakebridge.connections.database_manager import DatabaseManager
+from databricks.labs.lakebridge.connections.database_manager import create_connector
 from databricks.labs.lakebridge.connections.mssql_auth import AUTH_CHOICES
 from databricks.labs.lakebridge.connections.env_getter import EnvGetter
 from databricks.labs.lakebridge.connections.synapse_connection_helpers import validate_synapse_pools
@@ -76,9 +76,9 @@ class AssessmentConfigurator(ABC):
         logger.info("Connection to the source system successful")
 
     def _check_connection(self, raw_config: dict) -> None:
-        """Default check: open a ``DatabaseManager`` connection and run a health check."""
-        with DatabaseManager(self._source_name, raw_config) as db_manager:
-            if not db_manager.check_connection():
+        """Default check: open a connection and run a health check."""
+        with create_connector(self._source_name, raw_config) as connector:
+            if not connector.health_check():
                 raise ConnectionError(f"Connection to {self._source_name} failed")
 
     def run(self):

--- a/src/databricks/labs/lakebridge/assessments/pipeline.py
+++ b/src/databricks/labs/lakebridge/assessments/pipeline.py
@@ -13,7 +13,7 @@ import yaml
 from databricks.labs.blueprint.paths import read_text
 from databricks.labs.lakebridge import __version__ as lakebridge_version
 from databricks.labs.lakebridge.assessments.profiler_config import PipelineConfig, Step
-from databricks.labs.lakebridge.connections.database_manager import DatabaseManager, FetchResult
+from databricks.labs.lakebridge.connections.database_manager import DatabaseConnector, FetchResult
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ class PipelineClass:
     def __init__(
         self,
         config: PipelineConfig,
-        executor: DatabaseManager | None,
+        executor: DatabaseConnector | None,
         db_path: Path,
         cred_file_path: Path,
     ):
@@ -116,8 +116,8 @@ class PipelineClass:
         query = read_text(Path(step.extract_source))
 
         if self.executor is None:
-            logging.error("DatabaseManager executor is not set.")
-            raise RuntimeError("DatabaseManager executor is not set.")
+            logging.error("Database executor is not set.")
+            raise RuntimeError("Database executor is not set.")
 
         # Execute the query using the database manager
         logging.info(f"Executing query: {query}")
@@ -134,7 +134,7 @@ class PipelineClass:
         """Run a no-result DDL statement against the *source* database (one statement per file).
 
         Distinct from ``ddl`` (which targets the local DuckDB extract) and from ``sql``
-        (which expects a result set: ``DatabaseManager.fetch`` calls ``fetchall()`` and
+        (which expects a result set: ``DatabaseConnector.fetch`` calls ``fetchall()`` and
         raises on statements that return no rows). Used to create/drop source-side
         views or objects that subsequent ``sql`` steps depend on.
         """
@@ -142,8 +142,8 @@ class PipelineClass:
         content = read_text(Path(step.extract_source)).strip()
 
         if self.executor is None:
-            logging.error("DatabaseManager executor is not set.")
-            raise RuntimeError("DatabaseManager executor is not set.")
+            logging.error("Database executor is not set.")
+            raise RuntimeError("Database executor is not set.")
 
         if not content or all(line.strip().startswith("--") for line in content.split("\n")):
             logging.warning(f"source_ddl step '{step.name}' has no statement in {step.extract_source}")

--- a/src/databricks/labs/lakebridge/assessments/pipeline.py
+++ b/src/databricks/labs/lakebridge/assessments/pipeline.py
@@ -119,12 +119,9 @@ class PipelineClass:
             logging.error("Database executor is not set.")
             raise RuntimeError("Database executor is not set.")
 
-        # Execute the query using the database manager
         logging.info(f"Executing query: {query}")
         try:
             result = self.executor.fetch(query)
-
-            # Save the result to duckdb
             self._save_to_db(result, step.name, str(step.mode))
         except Exception as e:
             logging.error(f"SQL execution failed: {str(e)}")

--- a/src/databricks/labs/lakebridge/assessments/profiler.py
+++ b/src/databricks/labs/lakebridge/assessments/profiler.py
@@ -5,7 +5,7 @@ from databricks.labs.lakebridge.assessments import PRODUCT_PATH_PREFIX
 from databricks.labs.lakebridge.assessments.pipeline import PipelineClass, make_profiler_db_filename
 from databricks.labs.lakebridge.assessments.profiler_config import PipelineConfig
 from databricks.labs.lakebridge.assessments.variants import resolve_variant
-from databricks.labs.lakebridge.connections.database_manager import DatabaseManager
+from databricks.labs.lakebridge.connections.database_manager import DatabaseConnector, create_connector
 from databricks.labs.lakebridge.connections.credential_manager import (
     create_credential_manager,
     cred_file,
@@ -95,7 +95,7 @@ class Profiler:
             raise RuntimeError(f"Pipeline execution failed for source {source_system} : {e}") from e
 
     @staticmethod
-    def _setup_extractor(source_system: str, cred_file_path: Path | None = None) -> DatabaseManager | None:
+    def _setup_extractor(source_system: str, cred_file_path: Path | None = None) -> DatabaseConnector | None:
         cred_manager = create_credential_manager(source_system, EnvGetter(), creds_path=cred_file_path)
         connect_config = cred_manager.get_credentials(source_system)
-        return DatabaseManager(source_system, connect_config)
+        return create_connector(source_system, connect_config)

--- a/src/databricks/labs/lakebridge/assessments/variants.py
+++ b/src/databricks/labs/lakebridge/assessments/variants.py
@@ -10,7 +10,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from databricks.labs.lakebridge.assessments import SOURCE_SYSTEM_VARIANTS, AUTO
-from databricks.labs.lakebridge.connections.database_manager import DatabaseManager, ALL_DATABASES
+from databricks.labs.lakebridge.connections.database_manager import create_connector, ALL_DATABASES
 from databricks.labs.lakebridge.connections.credential_manager import create_credential_manager
 from databricks.labs.lakebridge.connections.env_getter import EnvGetter
 
@@ -37,9 +37,9 @@ def resolve_mssql_variant(cred_file_path: Path | None) -> str:
     if database and database != ALL_DATABASES:
         # The user picked a specific database -> profile only that one, regardless of edition.
         return "single_db"
-    with DatabaseManager("mssql", connect_config) as db_manager:
+    with create_connector("mssql", connect_config) as connector:
         # SERVERPROPERTY returns sql_variant, which pyodbc cannot fetch (ODBC type -16); CAST to int.
-        result = db_manager.fetch("SELECT CAST(SERVERPROPERTY('EngineEdition') AS INT) AS engine_edition")
+        result = connector.fetch("SELECT CAST(SERVERPROPERTY('EngineEdition') AS INT) AS engine_edition")
     engine_edition = int(result.rows[0][0])
     if engine_edition == SQLSERVER_AZURE_SQL_DB_ENGINE_EDITION:
         raise ValueError(

--- a/src/databricks/labs/lakebridge/connections/database_manager.py
+++ b/src/databricks/labs/lakebridge/connections/database_manager.py
@@ -12,7 +12,7 @@ import pandas as pd
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine, URL
 from sqlalchemy import text
-from sqlalchemy.exc import DatabaseError
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm.session import Session
 import mssql_python
 import redshift_connector  # type: ignore[import-untyped]
@@ -81,7 +81,7 @@ class _BaseConnector(DatabaseConnector):
             try:
                 result = session.execute(text(query))
                 return FetchResult(list(result.keys()), result.fetchall())
-            except DatabaseError as e:
+            except DBAPIError as e:
                 logger.debug("Database query failed", exc_info=True)
                 reason = str(getattr(e, "orig", e)).split("\n", 1)[0].strip()
                 raise ConnectionError(f"Database query failed: {reason}") from e

--- a/src/databricks/labs/lakebridge/connections/database_manager.py
+++ b/src/databricks/labs/lakebridge/connections/database_manager.py
@@ -12,7 +12,7 @@ import pandas as pd
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine, URL
 from sqlalchemy import text
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DatabaseError
 from sqlalchemy.orm.session import Session
 import mssql_python
 import redshift_connector  # type: ignore[import-untyped]
@@ -43,8 +43,7 @@ class FetchResult:
 
 class DatabaseConnector(contextlib.AbstractContextManager):
     @abstractmethod
-    def fetch(self, query: str) -> FetchResult:
-        pass
+    def fetch(self, query: str) -> FetchResult: ...
 
     @abstractmethod
     def close(self) -> None:
@@ -79,8 +78,13 @@ class _BaseConnector(DatabaseConnector):
             raise ConnectionError("Not connected to the database.")
 
         with Session(self.engine) as session, session.begin():
-            result = session.execute(text(query))
-            return FetchResult(list(result.keys()), result.fetchall())
+            try:
+                result = session.execute(text(query))
+                return FetchResult(list(result.keys()), result.fetchall())
+            except DatabaseError as e:
+                logger.debug("Database query failed", exc_info=True)
+                reason = str(getattr(e, "orig", e)).split("\n", 1)[0].strip()
+                raise ConnectionError(f"Database query failed: {reason}") from e
 
     def health_check(self) -> bool:
         query = "SELECT 101 AS test_column"
@@ -170,6 +174,10 @@ class MSSQLConnector(DatabaseConnector):
             names = [desc[0] for desc in cursor.description]
             rows = [tuple(row) for row in cursor.fetchall()]
             return FetchResult(names, rows)
+        except mssql_python.Error as e:
+            logger.debug("Database query failed", exc_info=True)
+            reason = str(e).split("\n", 1)[0].strip()
+            raise ConnectionError(f"Database query failed: {reason}") from e
         finally:
             cursor.close()
 
@@ -264,6 +272,10 @@ class RedshiftConnector(DatabaseConnector):
             rows = cursor.fetchall()
             columns = [desc[0] for desc in cursor.description]
             return FetchResult(columns, rows)
+        except redshift_connector.Error as e:
+            logger.debug("Database query failed", exc_info=True)
+            reason = str(e).split("\n", 1)[0].strip()
+            raise ConnectionError(f"Database query failed: {reason}") from e
         finally:
             cursor.close()
 
@@ -276,7 +288,7 @@ class RedshiftConnector(DatabaseConnector):
         return result.rows[0][0] == 101
 
 
-def _create_connector(db_type: str, config: JsonObject) -> DatabaseConnector:
+def create_connector(db_type: str, config: JsonObject) -> DatabaseConnector:
     connectors: dict[str, Callable[[JsonObject], DatabaseConnector]] = {
         "snowflake": SnowflakeConnector,
         "mssql": MSSQLConnector,
@@ -293,35 +305,3 @@ def _create_connector(db_type: str, config: JsonObject) -> DatabaseConnector:
         raise ValueError(f"Unsupported database type: {db_type}")
 
     return connector_class(config)
-
-
-# TODO remove this class, connectors are managed using ContextManager
-class DatabaseManager:
-    def __init__(self, db_type: str, config: JsonObject):
-        self.connector: DatabaseConnector = _create_connector(db_type, config)
-
-    def __enter__(self) -> "DatabaseManager":
-        """Support context manager protocol for resource management."""
-        return self
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        """Clean up connector resources when exiting context."""
-        self.connector.__exit__(exc_type, exc_val, exc_tb)
-
-    def fetch(self, query: str) -> FetchResult:
-        try:
-            return self.connector.fetch(query)
-        except OperationalError as e:
-            # Drivers (notably teradatasql) embed a full stack trace and the offending SQL in the error
-            # message; keep that detail at debug level and surface only the concise first line.
-            logger.debug("Database query failed", exc_info=True)
-            reason = str(getattr(e, "orig", e)).split("\n", 1)[0].strip()
-            raise ConnectionError(f"Database query failed: {reason}") from e
-
-    def check_connection(self) -> bool:
-        return self.connector.health_check()

--- a/src/databricks/labs/lakebridge/connections/synapse_connection_helpers.py
+++ b/src/databricks/labs/lakebridge/connections/synapse_connection_helpers.py
@@ -1,5 +1,5 @@
 import logging
-from databricks.labs.lakebridge.connections.database_manager import DatabaseManager
+from databricks.labs.lakebridge.connections.database_manager import DatabaseConnector, create_connector
 
 logger = logging.getLogger(__name__)
 
@@ -9,15 +9,15 @@ def create_synapse_connection(
     database: str,
     endpoint_key: str = 'dedicated_sql_endpoint',
     auth_type: str = 'SqlPassword',
-) -> DatabaseManager:
-    """Create a DatabaseManager connection to a Synapse SQL pool.
+) -> DatabaseConnector:
+    """Create a connection to a Synapse SQL pool.
 
     Selects the requested endpoint and forwards the workspace's credential fields to
     `MSSQLConnector` unchanged; the configured `MSSQLAuth` strategy decides whether
     to use them at connect time.
 
     Returns:
-        DatabaseManager configured for the specified Synapse SQL pool
+        DatabaseConnector configured for the specified Synapse SQL pool
     """
     server = workspace_config.get(endpoint_key)
     if not server:
@@ -31,7 +31,7 @@ def create_synapse_connection(
         "password": workspace_config.get('password'),
         "auth_type": auth_type,
     }
-    return DatabaseManager(db_type="synapse", config=config)
+    return create_connector(db_type="synapse", config=config)
 
 
 def _test_pool_connection(
@@ -56,8 +56,8 @@ def _test_pool_connection(
     logger.info(f"Testing connection to {pool_name} SQL pool...")
 
     try:
-        with create_synapse_connection(workspace_config, database, endpoint_key, auth_type) as db_manager:
-            if db_manager.check_connection():
+        with create_synapse_connection(workspace_config, database, endpoint_key, auth_type) as connector:
+            if connector.health_check():
                 logger.info(f"✓ {pool_name.capitalize()} SQL pool connection successful")
                 return True, None
             logger.error(f"✗ {pool_name.capitalize()} SQL pool connection failed")

--- a/tests/integration/assessments/test_pipeline.py
+++ b/tests/integration/assessments/test_pipeline.py
@@ -12,7 +12,7 @@ from databricks.labs.lakebridge.assessments.pipeline import (
 )
 from databricks.labs.lakebridge.assessments.profiler import Profiler
 from databricks.labs.lakebridge.assessments.profiler_config import Step, PipelineConfig
-from databricks.labs.lakebridge.connections.database_manager import DatabaseManager
+from databricks.labs.lakebridge.connections.database_manager import DatabaseConnector
 
 _Loader: TypeAlias = Callable[[Path], PipelineConfig]
 
@@ -65,7 +65,7 @@ def empty_result_config() -> PipelineConfig:
 
 
 def test_run_pipeline(
-    sandbox_sqlserver: DatabaseManager,
+    sandbox_sqlserver: DatabaseConnector,
     pipeline_config: PipelineConfig,
     get_logger: Logger,
     tmp_path: Path,
@@ -89,7 +89,7 @@ def test_run_pipeline(
 
 
 def test_run_sql_failure_pipeline(
-    sandbox_sqlserver: DatabaseManager,
+    sandbox_sqlserver: DatabaseConnector,
     sql_failure_config: PipelineConfig,
     get_logger: Logger,
     tmp_path: Path,
@@ -108,7 +108,7 @@ def test_run_sql_failure_pipeline(
 
 
 def test_run_python_failure_pipeline(
-    sandbox_sqlserver: DatabaseManager,
+    sandbox_sqlserver: DatabaseConnector,
     python_failure_config: PipelineConfig,
     get_logger: Logger,
     tmp_path: Path,
@@ -127,7 +127,7 @@ def test_run_python_failure_pipeline(
 
 
 def test_skipped_steps(
-    sandbox_sqlserver: DatabaseManager,
+    sandbox_sqlserver: DatabaseConnector,
     pipeline_config: PipelineConfig,
     tmp_path: Path,
 ) -> None:
@@ -224,7 +224,7 @@ def test_pipeline_step_comments() -> None:
 
 
 def test_run_empty_result_pipeline(
-    sandbox_sqlserver: DatabaseManager,
+    sandbox_sqlserver: DatabaseConnector,
     empty_result_config: PipelineConfig,
     get_logger: Logger,
     tmp_path: Path,
@@ -253,7 +253,7 @@ def test_run_empty_result_pipeline(
 
 
 def test_run_pipeline_with_ddl(
-    sandbox_sqlserver: DatabaseManager,
+    sandbox_sqlserver: DatabaseConnector,
     pipeline_config_with_ddl: PipelineConfig,
     get_logger: Logger,
     tmp_path: Path,
@@ -301,7 +301,7 @@ def test_run_pipeline_with_ddl(
 
 
 def test_run_pipeline_with_combined_ddl(
-    sandbox_sqlserver: DatabaseManager,
+    sandbox_sqlserver: DatabaseConnector,
     pipeline_config_combined_ddl: PipelineConfig,
     get_logger: Logger,
     tmp_path: Path,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,7 +10,7 @@ from databricks.labs.blueprint.paths import WorkspacePath
 from databricks.labs.blueprint.wheels import ProductInfo
 from databricks.labs.blueprint.installation import JsonObject
 from databricks.labs.lakebridge.__about__ import __version__
-from databricks.labs.lakebridge.connections.database_manager import DatabaseManager
+from databricks.labs.lakebridge.connections.database_manager import DatabaseConnector, create_connector
 from databricks.labs.lakebridge.contexts.application import ApplicationContext
 from databricks.sdk import WorkspaceClient
 
@@ -94,13 +94,13 @@ def sandbox_sqlserver_config() -> JsonObject:
 
 
 @pytest.fixture()
-def sandbox_sqlserver(sandbox_sqlserver_config) -> DatabaseManager:
-    return DatabaseManager("mssql", sandbox_sqlserver_config)
+def sandbox_sqlserver(sandbox_sqlserver_config) -> DatabaseConnector:
+    return create_connector("mssql", sandbox_sqlserver_config)
 
 
 @pytest.fixture()
 def sandbox_synapse_config(sandbox_sqlserver_config: JsonObject) -> JsonObject:
-    """Convert SQL Server config to Synapse config format for direct DatabaseManager usage."""
+    """Convert SQL Server config to Synapse config format for direct connector usage."""
     # Transform MSSQL config to Synapse format
     # In testing, we use SQL Server as a stand-in for Synapse since they use the same protocol
     return {
@@ -163,9 +163,9 @@ def sandbox_spn_sqlserver_config(sandbox_sqlserver_config: JsonObject, monkeypat
 
 
 @pytest.fixture()
-def sandbox_synapse(sandbox_synapse_config: JsonObject) -> DatabaseManager:
-    """Create a DatabaseManager for Synapse (uses MSSQLConnector via factory method)."""
-    return DatabaseManager("synapse", sandbox_synapse_config)
+def sandbox_synapse(sandbox_synapse_config: JsonObject) -> DatabaseConnector:
+    """Create a connector for Synapse (uses MSSQLConnector via factory method)."""
+    return create_connector("synapse", sandbox_synapse_config)
 
 
 @pytest.fixture()
@@ -184,8 +184,8 @@ def sandbox_redshift_config() -> JsonObject:
 
 
 @pytest.fixture()
-def sandbox_redshift(sandbox_redshift_config: JsonObject) -> DatabaseManager:
-    return DatabaseManager("redshift", sandbox_redshift_config)
+def sandbox_redshift(sandbox_redshift_config: JsonObject) -> DatabaseConnector:
+    return create_connector("redshift", sandbox_redshift_config)
 
 
 @pytest.fixture()

--- a/tests/integration/connections/test_mssql_connector.py
+++ b/tests/integration/connections/test_mssql_connector.py
@@ -1,9 +1,9 @@
 from databricks.labs.blueprint.installation import JsonObject
-from databricks.labs.lakebridge.connections.database_manager import DatabaseManager, MSSQLConnector
+from databricks.labs.lakebridge.connections.database_manager import create_connector, MSSQLConnector
 
 
 def test_mssql_connector_connection(sandbox_sqlserver):
-    assert isinstance(sandbox_sqlserver.connector, MSSQLConnector)
+    assert isinstance(sandbox_sqlserver, MSSQLConnector)
 
 
 def test_mssql_connector_execute_query(sandbox_sqlserver):
@@ -14,9 +14,9 @@ def test_mssql_connector_execute_query(sandbox_sqlserver):
 
 
 def test_connection_test(sandbox_sqlserver):
-    assert sandbox_sqlserver.check_connection()
+    assert sandbox_sqlserver.health_check()
 
 
 def test_spn_authentication_connection(sandbox_spn_sqlserver_config: JsonObject) -> None:
-    dbm = DatabaseManager("mssql", sandbox_spn_sqlserver_config)
-    assert dbm.check_connection()
+    connector = create_connector("mssql", sandbox_spn_sqlserver_config)
+    assert connector.health_check()

--- a/tests/integration/connections/test_redshift_connector.py
+++ b/tests/integration/connections/test_redshift_connector.py
@@ -1,18 +1,18 @@
-from databricks.labs.lakebridge.connections.database_manager import DatabaseManager, RedshiftConnector
+from databricks.labs.lakebridge.connections.database_manager import DatabaseConnector, RedshiftConnector
 
 
-def test_redshift_connector_connection(sandbox_redshift: DatabaseManager) -> None:
-    """Test that Redshift DatabaseManager uses RedshiftConnector."""
-    assert isinstance(sandbox_redshift.connector, RedshiftConnector)
+def test_redshift_connector_connection(sandbox_redshift: DatabaseConnector) -> None:
+    """Test that the Redshift factory returns a RedshiftConnector."""
+    assert isinstance(sandbox_redshift, RedshiftConnector)
 
 
-def test_redshift_connector_execute_query(sandbox_redshift: DatabaseManager) -> None:
-    """Test executing a query through Redshift DatabaseManager."""
+def test_redshift_connector_execute_query(sandbox_redshift: DatabaseConnector) -> None:
+    """Test executing a query through the Redshift connector."""
     query = "SELECT 101 AS test_column"
     result = sandbox_redshift.fetch(query).rows
     assert result[0][0] == 101
 
 
-def test_redshift_connection_check(sandbox_redshift: DatabaseManager) -> None:
+def test_redshift_connection_check(sandbox_redshift: DatabaseConnector) -> None:
     """Test connection check for Redshift."""
-    assert sandbox_redshift.check_connection()
+    assert sandbox_redshift.health_check()

--- a/tests/integration/connections/test_synapse_connector.py
+++ b/tests/integration/connections/test_synapse_connector.py
@@ -1,6 +1,6 @@
 import pytest
 from databricks.labs.blueprint.installation import JsonObject
-from databricks.labs.lakebridge.connections.database_manager import DatabaseManager, MSSQLConnector
+from databricks.labs.lakebridge.connections.database_manager import DatabaseConnector, MSSQLConnector, create_connector
 from databricks.labs.lakebridge.connections.synapse_connection_helpers import create_synapse_connection
 from tests.integration.debug_envgetter import TestEnvGetter
 
@@ -13,25 +13,25 @@ def _get_synapse_workspace(cred_config: JsonObject) -> dict:
     return workspace_config
 
 
-def test_synapse_connector_connection(sandbox_synapse: DatabaseManager) -> None:
-    """Test that Synapse DatabaseManager uses MSSQLConnector."""
-    assert isinstance(sandbox_synapse.connector, MSSQLConnector)
+def test_synapse_connector_connection(sandbox_synapse: DatabaseConnector) -> None:
+    """Test that the Synapse factory returns an MSSQLConnector."""
+    assert isinstance(sandbox_synapse, MSSQLConnector)
 
 
-def test_synapse_connector_execute_query(sandbox_synapse: DatabaseManager) -> None:
-    """Test executing a query through Synapse DatabaseManager."""
+def test_synapse_connector_execute_query(sandbox_synapse: DatabaseConnector) -> None:
+    """Test executing a query through the Synapse connector."""
     query = "SELECT 101 AS test_column"
     result = sandbox_synapse.fetch(query).rows
     assert result[0][0] == 101
 
 
-def test_synapse_connection_check(sandbox_synapse: DatabaseManager) -> None:
+def test_synapse_connection_check(sandbox_synapse: DatabaseConnector) -> None:
     """Test connection check for Synapse."""
-    assert sandbox_synapse.check_connection()
+    assert sandbox_synapse.health_check()
 
 
 def test_synapse_with_credential_format(sandbox_synapse_cred_config: JsonObject) -> None:
-    """Test DatabaseManager with credential format."""
+    """Test the connector with credential format."""
     synapse = sandbox_synapse_cred_config["synapse"]
     assert isinstance(synapse, dict)
     workspace_config = synapse["workspace"]
@@ -41,7 +41,7 @@ def test_synapse_with_credential_format(sandbox_synapse_cred_config: JsonObject)
     db_name = profiler["databases"]
 
     # Simulate what the assessment code does: transform credential format to connection config
-    manager = DatabaseManager(
+    connector = create_connector(
         "synapse",
         {
             "server": workspace_config['dedicated_sql_endpoint'],
@@ -53,20 +53,19 @@ def test_synapse_with_credential_format(sandbox_synapse_cred_config: JsonObject)
         },
     )
 
-    assert isinstance(manager, DatabaseManager)
-    assert isinstance(manager.connector, MSSQLConnector)
-    assert manager.check_connection()
+    assert isinstance(connector, MSSQLConnector)
+    assert connector.health_check()
 
 
 def test_create_synapse_connection_sql_auth(sandbox_synapse_cred_config: JsonObject) -> None:
     """create_synapse_connection forwards workspace user/password to the connector unchanged."""
     workspace_config = _get_synapse_workspace(sandbox_synapse_cred_config)
 
-    database_manager = create_synapse_connection(workspace_config, "master", auth_type="SqlPassword")
+    connector = create_synapse_connection(workspace_config, "master", auth_type="SqlPassword")
 
-    assert isinstance(database_manager.connector, MSSQLConnector)
-    assert database_manager.connector.config["user"] == workspace_config["user"]
-    assert database_manager.check_connection()
+    assert isinstance(connector, MSSQLConnector)
+    assert connector.config["user"] == workspace_config["user"]
+    assert connector.health_check()
 
 
 def test_create_synapse_connection_spn(
@@ -81,13 +80,11 @@ def test_create_synapse_connection_spn(
         k: v for k, v in _get_synapse_workspace(sandbox_synapse_cred_config).items() if k not in {"user", "password"}
     }
 
-    database_manager = create_synapse_connection(
-        workspace_config, "master", auth_type="ActiveDirectoryServicePrincipal"
-    )
+    connector = create_synapse_connection(workspace_config, "master", auth_type="ActiveDirectoryServicePrincipal")
 
-    assert isinstance(database_manager.connector, MSSQLConnector)
-    assert database_manager.connector.config["auth_type"] == "ActiveDirectoryServicePrincipal"
-    assert database_manager.check_connection()
+    assert isinstance(connector, MSSQLConnector)
+    assert connector.config["auth_type"] == "ActiveDirectoryServicePrincipal"
+    assert connector.health_check()
 
 
 def test_create_synapse_connection_endpoint_key(sandbox_synapse_cred_config: JsonObject) -> None:
@@ -96,15 +93,15 @@ def test_create_synapse_connection_endpoint_key(sandbox_synapse_cred_config: Jso
     # Sandbox has one server; point serverless to the same endpoint to exercise the routing
     workspace_config["serverless_sql_endpoint"] = workspace_config["dedicated_sql_endpoint"]
 
-    database_manager = create_synapse_connection(workspace_config, "master", endpoint_key="serverless_sql_endpoint")
+    connector = create_synapse_connection(workspace_config, "master", endpoint_key="serverless_sql_endpoint")
 
-    assert isinstance(database_manager.connector, MSSQLConnector)
-    assert database_manager.connector.config["server"] == workspace_config["serverless_sql_endpoint"]
-    assert database_manager.check_connection()
+    assert isinstance(connector, MSSQLConnector)
+    assert connector.config["server"] == workspace_config["serverless_sql_endpoint"]
+    assert connector.health_check()
 
 
 def test_synapse_query_execution(sandbox_synapse_cred_config: JsonObject) -> None:
-    """Test DatabaseManager can execute queries with credential format."""
+    """Test the connector can execute queries with credential format."""
     synapse = sandbox_synapse_cred_config["synapse"]
     assert isinstance(synapse, dict)
     workspace_config = synapse["workspace"]
@@ -113,7 +110,7 @@ def test_synapse_query_execution(sandbox_synapse_cred_config: JsonObject) -> Non
     assert isinstance(profiler, dict)
     db_name = profiler["databases"]
 
-    manager = DatabaseManager(
+    connector = create_connector(
         "synapse",
         {
             "server": workspace_config['dedicated_sql_endpoint'],
@@ -126,5 +123,5 @@ def test_synapse_query_execution(sandbox_synapse_cred_config: JsonObject) -> Non
     )
 
     query = "SELECT 202 AS test_column"
-    result = manager.fetch(query).rows
+    result = connector.fetch(query).rows
     assert result[0][0] == 202

--- a/tests/unit/assessment/test_assessment.py
+++ b/tests/unit/assessment/test_assessment.py
@@ -504,19 +504,19 @@ def test_redshift_configurator_writes_only_connector_supported_auth_types():
 
 
 def test_test_connection_default_uses_database_manager():
-    """Sources without an override go through DatabaseManager (the JDBC connector)."""
+    """Sources without an override go through create_connector (the JDBC connector)."""
     configurator = ConfigureRedshiftAssessment(
         product_name="lakebridge", source_name="redshift", prompts=MockPrompts({})
     )
     raw_config = {"host": "redshift.example.com", "database": "dev"}
     with (
         patch("databricks.labs.lakebridge.assessments.configure_assessment.create_credential_manager") as cred_manager,
-        patch("databricks.labs.lakebridge.assessments.configure_assessment.DatabaseManager") as database_manager,
+        patch("databricks.labs.lakebridge.assessments.configure_assessment.create_connector") as create_connector,
     ):
         cred_manager.return_value.get_credentials.return_value = raw_config
-        database_manager.return_value.__enter__.return_value.check_connection.return_value = True
+        create_connector.return_value.__enter__.return_value.health_check.return_value = True
         configurator.test_connection()
-    database_manager.assert_called_once_with("redshift", raw_config)
+    create_connector.assert_called_once_with("redshift", raw_config)
 
 
 def test_synapse_test_connection_delegates_to_pools():

--- a/tests/unit/assessment/test_mssql_variants.py
+++ b/tests/unit/assessment/test_mssql_variants.py
@@ -42,25 +42,25 @@ def test_mssql_variant_config_references_existing_files(variant: str) -> None:
     ],
 )
 def test_resolve_mssql_variant(engine_edition: int, expected: str) -> None:
-    db_manager = MagicMock()
-    db_manager.__enter__.return_value = db_manager
-    db_manager.fetch.return_value = MagicMock(rows=[[engine_edition]])
+    connector = MagicMock()
+    connector.__enter__.return_value = connector
+    connector.fetch.return_value = MagicMock(rows=[[engine_edition]])
     with (
-        patch("databricks.labs.lakebridge.assessments.variants.DatabaseManager", return_value=db_manager),
+        patch("databricks.labs.lakebridge.assessments.variants.create_connector", return_value=connector),
         patch("databricks.labs.lakebridge.assessments.variants.create_credential_manager") as cred_manager,
     ):
         cred_manager.return_value.get_credentials.return_value = {}
         assert resolve_mssql_variant(Path("creds.yml")) == expected
-    db_manager.fetch.assert_called_once_with("SELECT CAST(SERVERPROPERTY('EngineEdition') AS INT) AS engine_edition")
+    connector.fetch.assert_called_once_with("SELECT CAST(SERVERPROPERTY('EngineEdition') AS INT) AS engine_edition")
 
 
 def test_resolve_mssql_variant_azure_sql_db_without_database_raises() -> None:
     """Azure SQL Database (edition 5) with no concrete database must not silently profile master."""
-    db_manager = MagicMock()
-    db_manager.__enter__.return_value = db_manager
-    db_manager.fetch.return_value = MagicMock(rows=[[5]])  # Azure SQL Database
+    connector = MagicMock()
+    connector.__enter__.return_value = connector
+    connector.fetch.return_value = MagicMock(rows=[[5]])  # Azure SQL Database
     with (
-        patch("databricks.labs.lakebridge.assessments.variants.DatabaseManager", return_value=db_manager),
+        patch("databricks.labs.lakebridge.assessments.variants.create_connector", return_value=connector),
         patch("databricks.labs.lakebridge.assessments.variants.create_credential_manager") as cred_manager,
     ):
         cred_manager.return_value.get_credentials.return_value = {"database": "*"}
@@ -70,26 +70,26 @@ def test_resolve_mssql_variant_azure_sql_db_without_database_raises() -> None:
 
 def test_resolve_mssql_variant_with_configured_database_skips_probe() -> None:
     """A configured database scopes profiling to that database (single_db) without probing the edition."""
-    db_manager = MagicMock()
-    db_manager.__enter__.return_value = db_manager
+    connector = MagicMock()
+    connector.__enter__.return_value = connector
     with (
-        patch("databricks.labs.lakebridge.assessments.variants.DatabaseManager", return_value=db_manager),
+        patch("databricks.labs.lakebridge.assessments.variants.create_connector", return_value=connector),
         patch("databricks.labs.lakebridge.assessments.variants.create_credential_manager") as cred_manager,
     ):
         cred_manager.return_value.get_credentials.return_value = {"database": "AdventureWorks"}
         assert resolve_mssql_variant(Path("creds.yml")) == "single_db"
-    db_manager.fetch.assert_not_called()
+    connector.fetch.assert_not_called()
 
 
 @pytest.mark.parametrize("database", ["*", "  ", "", None])
 def test_resolve_mssql_variant_all_databases_probes(database) -> None:
     """The '*' sentinel and blank/whitespace all mean 'all databases' -> probe the edition, not single_db."""
-    db_manager = MagicMock()
-    db_manager.__enter__.return_value = db_manager
-    db_manager.fetch.return_value = MagicMock(rows=[[3]])  # on-prem Enterprise -> multi_db
+    connector = MagicMock()
+    connector.__enter__.return_value = connector
+    connector.fetch.return_value = MagicMock(rows=[[3]])  # on-prem Enterprise -> multi_db
     config = {} if database is None else {"database": database}
     with (
-        patch("databricks.labs.lakebridge.assessments.variants.DatabaseManager", return_value=db_manager),
+        patch("databricks.labs.lakebridge.assessments.variants.create_connector", return_value=connector),
         patch("databricks.labs.lakebridge.assessments.variants.create_credential_manager") as cred_manager,
     ):
         cred_manager.return_value.get_credentials.return_value = config

--- a/tests/unit/connections/test_database_manager.py
+++ b/tests/unit/connections/test_database_manager.py
@@ -2,7 +2,7 @@ import mssql_python
 import pytest
 from unittest.mock import MagicMock, patch
 from databricks.labs.blueprint.installation import JsonObject
-from databricks.labs.lakebridge.connections.database_manager import DatabaseManager, MSSQLConnector
+from databricks.labs.lakebridge.connections.database_manager import create_connector, MSSQLConnector
 
 sample_config: JsonObject = {
     'user': 'test_user',
@@ -15,7 +15,7 @@ sample_config: JsonObject = {
 
 def test_create_connector_unsupported_db_type() -> None:
     with pytest.raises(ValueError, match="Unsupported database type: unsupported_db"):
-        DatabaseManager("unsupported_db", sample_config)
+        create_connector("unsupported_db", sample_config)
 
 
 # Test case for MSSQLConnector
@@ -24,9 +24,9 @@ def test_mssql_connector(mock_mssql_connector) -> None:
     mock_connector_instance = MagicMock()
     mock_mssql_connector.return_value = mock_connector_instance
 
-    db_manager = DatabaseManager("mssql", sample_config)
+    connector = create_connector("mssql", sample_config)
 
-    assert db_manager.connector == mock_connector_instance
+    assert connector == mock_connector_instance
     mock_mssql_connector.assert_called_once_with(sample_config)
 
 
@@ -36,9 +36,9 @@ def test_legacy_synapse_connector(mock_mssql_connector) -> None:
     mock_connector_instance = MagicMock()
     mock_mssql_connector.return_value = mock_connector_instance
 
-    db_manager = DatabaseManager("legacy_synapse", sample_config)
+    connector = create_connector("legacy_synapse", sample_config)
 
-    assert db_manager.connector == mock_connector_instance
+    assert connector == mock_connector_instance
     mock_mssql_connector.assert_called_once_with(sample_config)
 
 
@@ -47,13 +47,13 @@ def test_fetch(mock_mssql_connector) -> None:
     mock_connector_instance = MagicMock()
     mock_mssql_connector.return_value = mock_connector_instance
 
-    db_manager = DatabaseManager("mssql", sample_config)
+    connector = create_connector("mssql", sample_config)
 
     query = "SELECT * FROM users"
     mock_result = MagicMock()
     mock_connector_instance.fetch.return_value = mock_result
 
-    result = db_manager.fetch(query)
+    result = connector.fetch(query)
 
     assert result == mock_result
     mock_connector_instance.fetch.assert_called_once_with(query)
@@ -64,13 +64,13 @@ def test_fetch_commit(mock_mssql_connector) -> None:
     mock_connector_instance = MagicMock()
     mock_mssql_connector.return_value = mock_connector_instance
 
-    db_manager = DatabaseManager("mssql", sample_config)
+    connector = create_connector("mssql", sample_config)
 
     mutate_query = "TRUNCATE users"
     mock_result = MagicMock()
     mock_connector_instance.fetch.return_value = mock_result
 
-    mutate_result = db_manager.fetch(mutate_query)
+    mutate_result = connector.fetch(mutate_query)
 
     assert mutate_result == mock_result
     mock_connector_instance.fetch.assert_called_once_with(mutate_query)
@@ -81,9 +81,9 @@ def test_teradata_connector(mock_teradata_connector) -> None:
     mock_connector_instance = MagicMock()
     mock_teradata_connector.return_value = mock_connector_instance
 
-    db_manager = DatabaseManager("teradata", sample_config)
+    connector = create_connector("teradata", sample_config)
 
-    assert db_manager.connector == mock_connector_instance
+    assert connector == mock_connector_instance
     mock_teradata_connector.assert_called_once_with(sample_config)
 
 
@@ -93,3 +93,25 @@ def test_mssql_connect_failure_raises_connection_error(mock_connect) -> None:
 
     with pytest.raises(ConnectionError, match="test_server"):
         MSSQLConnector(sample_config)
+
+
+@patch('databricks.labs.lakebridge.connections.database_manager.mssql_python.connect')
+def test_mssql_fetch_error_is_cleaned_to_connection_error(mock_connect) -> None:
+    """A raw driver query error surfaces as a ConnectionError whose message keeps the
+    concise first line of the driver error (not an empty string)."""
+    cursor = MagicMock()
+    cursor.execute.side_effect = mssql_python.ProgrammingError(
+        "Invalid column name 'foo'", "DDBC detail\nstack line 2\nstack line 3"
+    )
+    mock_connect.return_value.cursor.return_value = cursor
+
+    connector = MSSQLConnector(sample_config)
+    with pytest.raises(ConnectionError) as exc:
+        connector.fetch("SELECT foo FROM bar")
+
+    message = str(exc.value)
+    assert message.startswith("Database query failed: ")
+    # non-empty reason, and the multi-line stack is stripped to the first line
+    assert message != "Database query failed: "
+    assert "\n" not in message
+    assert "stack line 2" not in message


### PR DESCRIPTION
## Changes                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                          
### What does this PR do?                                                                                                                                                                                                                                                                                                 
Removes the vestigial `DatabaseManager` wrapper. Its only real behavior — cleaning raw driver query errors into a concise `ConnectionError` — moves into each connector's `fetch`, and callers use the connectors directly.                                                                                               
                                                                                                                                                                                                                                                                                                                          
### Relevant implementation details                                                                                                                                                                                                                                                                                       
* `DatabaseConnector.fetch` is now abstract; `_create_connector` → public `create_connector`; `DatabaseManager` deleted.                                                                                                                                                                                                  
* Each connector cleans its own query errors inline.                                                                                                                
* `mssql_python.Error` / `redshift_connector.Error` previously bypassed the SQLAlchemy-only handler and bubbled up uncleaned.                                                                                                                                                    
* Callers migrated: `DatabaseManager(...)` → `create_connector(...)`, `.check_connection()` → `.health_check()` (pipeline, profiler, variants, configurator, synapse helper).                                                                                                                                             
                                                                                                                                                                                                                                                                                                                          
### Caveats/things to watch out for when reviewing:                                                                                                                                                                                                                                                                       
Pure refactor — no behavior change beyond the broadened error cleaning. Stacked on the mssql-python driver PRs.                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                          
### Linked issues                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                          
Resolves #..                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                          
### Functionality                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                          
- [ ] added relevant user documentation                                                                                                                                                                                                                                                                                   
- [ ] added new CLI command                                                                                                                                                                                                                                                                                               
- [ ] modified existing command                                                                                                                                                                                                                                                                                           
- [X] internal refactor (no user-facing change)                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                          
### Tests                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                          
- [ ] manually tested                                                                                                                                                                                                                                                                                                     
- [X] added unit tests                                                                                                                                                                                                                                                                                                    
- [ ] added integration tests 