### PR TITLE
Chore: ignore `.isaac` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ remorph_transpile/
 .databricks-login.json
 .mypy_cache
 .env
+/.isaac/
 /tests/resources/lsp_transpiler/test-lsp-server.log
 .credentials.yml
 .credentials.bak


### PR DESCRIPTION
## Changes

This is a trivial house-keeping PR to ensure that files created by isaac under `.isaac/` are ignored by git.